### PR TITLE
Improve zooming performance

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ install_requires =
     PyQt6-WebEngine-Qt6==6.6.0
     python-dotenv>=1.0.1
     pypdf~=4.2.0
+    pytube~=15.0.0
 python_requires = >=3.10
 zip_safe = no
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,23 +132,23 @@ def tilia_errors(qtui):
 
 
 @pytest.fixture(scope="session")
-def qtui():
+def qtui(tilia):
     qtui_ = QtUI()
     stop_listening(qtui_, Post.DISPLAY_ERROR)
+
+    # finish tilia setup
+    # all this depends on a player
+    tilia.player = qtui_.player
+    tilia.set_media_duration(100)
+    tilia.reset_undo_manager()
+
     yield qtui_
-    # stop_listening_to_all(qtui_.timeline_uis)
-    # stop_serving_all(qtui_.timeline_uis)
-    # stop_listening_to_all(qtui_)
-    # stop_serving_all(qtui_)
 
 
 # noinspection PyProtectedMember
 @pytest.fixture(scope="session")
-def tilia(qtui):
+def tilia():
     tilia_ = setup_logic(autosaver=False)
-    tilia_.player = qtui.player
-    tilia_.set_media_duration(100)
-    tilia_.reset_undo_manager()
     yield tilia_
 
 

--- a/tests/timelines/hierarchy/test_hierarchy_timeline.py
+++ b/tests/timelines/hierarchy/test_hierarchy_timeline.py
@@ -12,19 +12,6 @@ from tilia.timelines.timeline_kinds import TimelineKind
 from tilia.ui.timelines.hierarchy import HierarchyTimelineUI
 
 
-class HierarchyUIDummy:
-    def __init__(self, component, **kwargs):
-        self.tl_component = component
-        for attr, value in kwargs.items():
-            setattr(self, attr, value)
-
-    def update_position(self):
-        return
-
-    def process_color_before_level_change(self, *args, **kwargs):
-        return
-
-
 class DummyTimelines:
     ID_ITER = itertools.count()
 

--- a/tests/ui/timelines/beat/interact.py
+++ b/tests/ui/timelines/beat/interact.py
@@ -1,12 +1,12 @@
 from tests.ui.timelines.interact import click_timeline_ui_view
-from tilia.ui.coords import get_x_by_time
+from tilia.ui.coords import time_x_converter
 
 
 def click_beat_ui(beat_ui, button="left", modifier=None, double=False):
     click_timeline_ui_view(
         beat_ui.timeline_ui.view,
         button,
-        get_x_by_time(beat_ui.time),
+        time_x_converter.get_x_by_time(beat_ui.time),
         beat_ui.height / 2,
         beat_ui.body,
         modifier,

--- a/tests/ui/timelines/beat/test_beat_ui.py
+++ b/tests/ui/timelines/beat/test_beat_ui.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from tests.ui.timelines.beat.interact import click_beat_ui
 from tests.ui.timelines.interact import drag_mouse_in_timeline_view
 from tilia.requests import get, Get
-from tilia.ui.coords import get_x_by_time
+from tilia.ui.coords import time_x_converter
 
 
 class TestRightClick:
@@ -26,5 +26,5 @@ class TestDoubleClick:
     def test_does_not_trigger_drag(self, beat_tlui):
         _, bui = beat_tlui.create_beat(0)
         click_beat_ui(bui, double=True)
-        drag_mouse_in_timeline_view(get_x_by_time(50), bui.height / 2)
+        drag_mouse_in_timeline_view(time_x_converter.get_x_by_time(50), bui.height / 2)
         assert bui.get_data("time") == 0

--- a/tests/ui/timelines/harmony/interact.py
+++ b/tests/ui/timelines/harmony/interact.py
@@ -20,4 +20,3 @@ def click_harmony_ui(harmony_ui, button="left", modifier=None, double=False):
 
 def click_mode_ui(mode_ui, button="left", modifier=None, double=False):
     _click_element_ui(mode_ui, button, modifier, double)
-

--- a/tests/ui/timelines/harmony/interact.py
+++ b/tests/ui/timelines/harmony/interact.py
@@ -1,12 +1,12 @@
 from tests.ui.timelines.interact import click_timeline_ui_view
-from tilia.ui.coords import get_x_by_time
+from tilia.ui.coords import time_x_converter
 
 
 def _click_element_ui(element, button, modifier, double):
     click_timeline_ui_view(
         element.timeline_ui.view,
         button,
-        get_x_by_time(element.get_data("time")),
+        time_x_converter.get_x_by_time(element.get_data("time")),
         element.timeline_ui.get_data("height") / 2,
         element.body,
         modifier,

--- a/tests/ui/timelines/harmony/test_harmony_ui.py
+++ b/tests/ui/timelines/harmony/test_harmony_ui.py
@@ -4,7 +4,6 @@ from tests.ui.timelines.harmony.interact import click_harmony_ui
 from tests.ui.timelines.interact import click_timeline_ui
 from tilia.ui import actions
 from tilia.ui.actions import TiliaAction
-from tilia.ui.coords import get_x_by_time
 
 
 class TestRightClick:

--- a/tests/ui/timelines/interact.py
+++ b/tests/ui/timelines/interact.py
@@ -1,7 +1,7 @@
 from PyQt6.QtCore import Qt
 
 from tilia.requests import Post, post
-from tilia.ui.coords import get_time_by_x, get_x_by_time
+from tilia.ui.coords import time_x_converter
 
 
 def click_timeline_ui_view(view, button, x, y, item, modifier, double):
@@ -29,7 +29,7 @@ def click_timeline_ui_view(view, button, x, y, item, modifier, double):
 def click_timeline_ui(
     timeline_ui, time, y=None, button="left", modifier=None, double=False
 ):
-    x = int(get_x_by_time(time))
+    x = int(time_x_converter.get_x_by_time(time))
     y = int(y or timeline_ui.get_data("height") / 2)
     item = timeline_ui.view.itemAt(x, y)
     click_timeline_ui_view(timeline_ui.view, button, x, y, item, modifier, double)

--- a/tests/ui/timelines/marker/interact.py
+++ b/tests/ui/timelines/marker/interact.py
@@ -2,7 +2,7 @@ from tests.ui.timelines.interact import click_timeline_ui_view
 from tilia.ui.coords import get_x_by_time
 
 
-def click_marker_ui(element, button='left', modifier=None, double=False):
+def click_marker_ui(element, button="left", modifier=None, double=False):
     click_timeline_ui_view(
         element.timeline_ui.view,
         button,

--- a/tests/ui/timelines/marker/interact.py
+++ b/tests/ui/timelines/marker/interact.py
@@ -1,12 +1,12 @@
 from tests.ui.timelines.interact import click_timeline_ui_view
-from tilia.ui.coords import get_x_by_time
+from tilia.ui.coords import time_x_converter
 
 
 def click_marker_ui(element, button="left", modifier=None, double=False):
     click_timeline_ui_view(
         element.timeline_ui.view,
         button,
-        get_x_by_time(element.get_data("time")),
+        time_x_converter.get_x_by_time(element.get_data("time")),
         element.timeline_ui.get_data("height") / 2,
         element.body,
         modifier,

--- a/tests/ui/timelines/marker/test_marker_ui.py
+++ b/tests/ui/timelines/marker/test_marker_ui.py
@@ -5,7 +5,7 @@ from PyQt6.QtGui import QColor
 
 from tests.mock import PatchPost
 from tilia.requests import Post
-from tilia.ui.coords import get_time_by_x, get_x_by_time
+from tilia.ui.coords import time_x_converter
 
 MODULE = "tilia.ui.timelines.marker.element"
 
@@ -28,7 +28,7 @@ class TestMarker:
 
     def test_update_time(self, mrkui):
         mrkui.set_data("time", 100)
-        assert mrkui.x == get_x_by_time(100)
+        assert mrkui.x == time_x_converter.get_x_by_time(100)
 
     def test_update_color(self, mrkui):
         mrkui.set_data("color", "#010101")
@@ -58,7 +58,7 @@ class TestMarkerDrag:
 
     def test_after_each_drag(self, mrkui):
         mrkui.after_each_drag(202)
-        assert mrkui.get_data("time") == get_time_by_x(202)
+        assert mrkui.get_data("time") == time_x_converter.get_time_by_x(202)
 
     def test_on_drag_end_when_dragged(self, mrkui):
         mrkui.dragged = True

--- a/tests/ui/timelines/test_element_manager.py
+++ b/tests/ui/timelines/test_element_manager.py
@@ -8,10 +8,8 @@ class TestElementOrder:
         for i in range(0, 100, 10):
             marker_tlui.create_marker(i)
 
-        for i in range(10):
-            marker_tlui.timeline.set_component_data(
-                marker_tlui[i].id, "time", random.randrange(0, 99)
-            )
+        for marker_ui in marker_tlui:
+            marker_ui.set_data("time", random.randrange(0, 99))
 
         elms = marker_tlui.elements
 

--- a/tests/ui/timelines/test_timelineui_collection.py
+++ b/tests/ui/timelines/test_timelineui_collection.py
@@ -13,7 +13,7 @@ from tilia.timelines.timeline_kinds import (
 )
 from tilia.ui import actions
 from tilia.ui.actions import TiliaAction
-from tilia.ui.coords import get_x_by_time
+from tilia.ui.coords import time_x_converter
 
 
 ADD_TIMELINE_ACTIONS = [
@@ -172,7 +172,7 @@ class TestAutoScroll:
         post(Post.PLAYER_SEEK, 50)
         post(Post.VIEW_ZOOM_IN)
         assert tluis[0].scene.playback_line.line().x1() == pytest.approx(
-            get_x_by_time(50)
+            time_x_converter.get_x_by_time(50)
         )
 
 
@@ -182,7 +182,7 @@ class TestSeek:
     ):
         y = slider_tlui.trough.pos().y()
         click_timeline_ui(slider_tlui, 0, y=y)
-        target_x = get_x_by_time(50)
+        target_x = time_x_converter.get_x_by_time(50)
         drag_mouse_in_timeline_view(target_x, y)
         assert marker_tlui.playback_line.line().x1() == pytest.approx(target_x)
 
@@ -191,7 +191,7 @@ class TestSeek:
     ):
         y = slider_tlui.trough.pos().y()
         click_timeline_ui(slider_tlui, 0, y=y)
-        target_x = get_x_by_time(60)
+        target_x = time_x_converter.get_x_by_time(60)
         drag_mouse_in_timeline_view(target_x, y)
         tilia_state.current_time = 75
         assert marker_tlui.playback_line.line().x1() == target_x
@@ -225,7 +225,7 @@ class TestSeek:
     ):
         y = slider_tlui.trough.pos().y()
         click_timeline_ui(slider_tlui, 0, y=y)
-        drag_mouse_in_timeline_view(get_x_by_time(50), y)
+        drag_mouse_in_timeline_view(time_x_converter.get_x_by_time(50), y)
         tilia_state.current_time = 75
         if request_to_serve:
             with Serve(*request_to_serve):

--- a/tests/ui/timelines/test_timelineui_collection.py
+++ b/tests/ui/timelines/test_timelineui_collection.py
@@ -7,7 +7,6 @@ from tilia import errors as tilia_errors
 from tests.mock import PatchGet, PatchPost, Serve
 from tilia.media.player.base import MediaTimeChangeReason
 from tilia.requests import Post, post, get, Get
-from tilia.timelines.component_kinds import ComponentKind
 from tilia.timelines.timeline_kinds import (
     TimelineKind as TlKind,
     TimelineKind,

--- a/tilia/file/file_manager.py
+++ b/tilia/file/file_manager.py
@@ -11,7 +11,7 @@ from tilia.file.common import are_tilia_data_equal, write_tilia_file_to_disk
 from tilia.requests import listen, Post, Get, serve, get, post
 from tilia.file.tilia_file import TiliaFile
 from tilia.file.media_metadata import MediaMetadata
-from tilia.settings import settings
+from tilia.settings import settings_manager
 import tilia.errors
 
 
@@ -177,11 +177,11 @@ class FileManager:
         data["file_path"] = path
         self.file = TiliaFile(**data)
         try:
-            settings.update_recent_files(
+            settings_manager.update_recent_files(
                 path, get(Get.WINDOW_GEOMETRY), get(Get.WINDOW_STATE)
             )
         except tilia.exceptions.NoReplyToRequest:
-            settings.update_recent_files(path, None, None)
+            settings_manager.update_recent_files(path, None, None)
 
     def open(self, file_path: str | Path):
         with open(file_path, "r", encoding="utf-8") as f:

--- a/tilia/settings.py
+++ b/tilia/settings.py
@@ -181,4 +181,26 @@ class SettingsManager(QObject):
         return editable_settings
 
 
-settings = SettingsManager()
+class SettingsCache():
+    def __init__(self):
+        self.values = {}
+
+        for group in settings_manager.DEFAULT_SETTINGS.keys():
+            for setting, value in settings_manager.DEFAULT_SETTINGS[group].items():
+                if group not in self.values:
+                   self.values[group] = {}
+                self.values[group][setting] = settings_manager.get(group, setting)
+
+    def get(self, group, setting):
+        return self.values[group][setting]
+
+    def set(self, group, setting, value):
+        try:
+            settings_manager.set(group, setting, value)
+            self.values[group][setting] = value
+        except AttributeError:
+            raise AttributeError(f"{group}.{setting} not found in cache.")
+
+
+settings_manager = SettingsManager()
+settings = SettingsCache()

--- a/tilia/timelines/base/component.py
+++ b/tilia/timelines/base/component.py
@@ -54,13 +54,10 @@ class TimelineComponent(ABC):
             self.timeline.update_component_order(self)
         return value, True
 
-    def validate_get_data(self, attr):
-        if not hasattr(self, attr):
+    def get_data(self, attr: str):
+        try:
+            return getattr(self, attr)
+        except AttributeError:
             raise GetComponentDataError(
                 f"Component '{self}' has no attribute named '{attr}'"
             )
-        return True
-
-    def get_data(self, attr: str):
-        if self.validate_get_data(attr):
-            return getattr(self, attr)

--- a/tilia/timelines/base/timeline.py
+++ b/tilia/timelines/base/timeline.py
@@ -27,7 +27,6 @@ if TYPE_CHECKING:
     # noinspection PyUnresolvedReferences
     from .component import TimelineComponent
 
-
 TC = TypeVar("TC", bound="TimelineComponent")
 T = TypeVar("T", bound="Timeline")
 
@@ -45,12 +44,12 @@ class Timeline(ABC, Generic[TC]):
     }
 
     def __init__(
-        self,
-        component_manager: TimelineComponentManager | None = None,
-        name: str = "",
-        height: int = 0,
-        is_visible: bool = True,
-        ordinal: int = None,
+            self,
+            component_manager: TimelineComponentManager | None = None,
+            name: str = "",
+            height: int = 0,
+            is_visible: bool = True,
+            ordinal: int = None,
     ):
         self.id = get(Get.ID)
 
@@ -99,7 +98,7 @@ class Timeline(ABC, Generic[TC]):
     @property
     def components(self):
         return self.component_manager.get_components()
-    
+
     @property
     def default_height(self):
         return None
@@ -134,7 +133,7 @@ class Timeline(ABC, Generic[TC]):
             return getattr(self, attr)
 
     def create_timeline_component(
-        self, kind: ComponentKind, *args, **kwargs
+            self, kind: ComponentKind, *args, **kwargs
     ) -> tuple[TC | None, str | None]:
         component_id = get(Get.ID)
         success, component, reason = self.component_manager.create_component(
@@ -143,7 +142,8 @@ class Timeline(ABC, Generic[TC]):
 
         if success:
             post(
-                Post.TIMELINE_COMPONENT_CREATED, self.KIND, self.id, kind, component.id
+                Post.TIMELINE_COMPONENT_CREATED, self.KIND, self.id, kind, component.id, component.get_data,
+                functools.partial(self.set_component_data, component.id)
             )
             return component, None
         else:
@@ -213,8 +213,8 @@ class Timeline(ABC, Generic[TC]):
 
 class TimelineComponentManager(Generic[T, TC]):
     def __init__(
-        self,
-        component_kinds: list[ComponentKind],
+            self,
+            component_kinds: list[ComponentKind],
     ):
         self._components: list[TC] = []
         self.component_kinds = component_kinds
@@ -236,7 +236,7 @@ class TimelineComponentManager(Generic[T, TC]):
         return True, ""
 
     def create_component(
-        self, kind: ComponentKind, timeline, id, *args, **kwargs
+            self, kind: ComponentKind, timeline, id, *args, **kwargs
     ) -> tuple[bool, TC | None, str]:
         self._validate_component_kind(kind)
         valid, reason = self._validate_component_creation(kind, *args, **kwargs)
@@ -269,19 +269,19 @@ class TimelineComponentManager(Generic[T, TC]):
         return self.get_component(id).get_data(attr)
 
     def get_component_by_attribute(
-        self, attr_name: str, value: Any, kind: ComponentKind
+            self, attr_name: str, value: Any, kind: ComponentKind
     ):
         cmp_set = self._get_component_set_by_kind(kind)
         return self._get_component_from_set_by_attribute(cmp_set, attr_name, value)
 
     def get_components_by_attribute(
-        self, attr_name: str, value: Any, kind: ComponentKind
+            self, attr_name: str, value: Any, kind: ComponentKind
     ) -> list:
         cmp_set = self._get_component_set_by_kind(kind)
         return self._get_components_from_set_by_attribute(cmp_set, attr_name, value)
 
     def get_components_by_condition(
-        self, condition: Callable[[TC], bool], kind: ComponentKind
+            self, condition: Callable[[TC], bool], kind: ComponentKind
     ) -> list:
         cmp_set = self._get_component_set_by_kind(kind)
         return [c for c in cmp_set if condition(c)]
@@ -334,7 +334,7 @@ class TimelineComponentManager(Generic[T, TC]):
         return {cmp for cmp in self._components if isinstance(cmp, cmp_class)}
 
     def _get_component_class_by_kind(
-        self, kind: ComponentKind
+            self, kind: ComponentKind
     ) -> type[TimelineComponent]:
         self._validate_component_kind(kind)
         return get_component_class_by_kind(kind)
@@ -345,13 +345,13 @@ class TimelineComponentManager(Generic[T, TC]):
 
     @staticmethod
     def _get_component_from_set_by_attribute(
-        cmp_list: set, attr_name: str, value: Any
+            cmp_list: set, attr_name: str, value: Any
     ) -> Any | None:
         return next((c for c in cmp_list if getattr(c, attr_name) == value), None)
 
     @staticmethod
     def _get_components_from_set_by_attribute(
-        cmp_list: set, attr_name: str, value: Any
+            cmp_list: set, attr_name: str, value: Any
     ) -> list:
         return [c for c in cmp_list if getattr(c, attr_name) == value]
 

--- a/tilia/ui/coords.py
+++ b/tilia/ui/coords.py
@@ -1,4 +1,3 @@
-import tilia.exceptions
 from tilia.requests import get, Get, listen, Post
 
 
@@ -22,13 +21,19 @@ class TimeXConverter:
 
     def get_time_by_x(self, x):
         try:
-            return (x - self.left_margin_x) * self.media_duration / self.playback_area_width
+            return (
+                (x - self.left_margin_x)
+                * self.media_duration
+                / self.playback_area_width
+            )
         except ZeroDivisionError:
             return 0.0
 
     def get_x_by_time(self, time: float) -> int:
         try:
-            return ((time / self.media_duration) * self.playback_area_width) + self.left_margin_x
+            return (
+                (time / self.media_duration) * self.playback_area_width
+            ) + self.left_margin_x
         except ZeroDivisionError:
             return self.left_margin_x
 
@@ -45,9 +50,9 @@ def get_x_by_time(time: float) -> int:
 def get_time_by_x(x: float) -> float:
     try:
         return (
-                (x - get(Get.LEFT_MARGIN_X))
-                * get(Get.MEDIA_DURATION)
-                / get(Get.PLAYBACK_AREA_WIDTH)
+            (x - get(Get.LEFT_MARGIN_X))
+            * get(Get.MEDIA_DURATION)
+            / get(Get.PLAYBACK_AREA_WIDTH)
         )
     except ZeroDivisionError:
         return 0.0

--- a/tilia/ui/coords.py
+++ b/tilia/ui/coords.py
@@ -1,4 +1,36 @@
-from tilia.requests import get, Get
+import tilia.exceptions
+from tilia.requests import get, Get, listen, Post
+
+
+class TimeXConverter:
+    def __init__(self):
+        self.media_duration = get(Get.MEDIA_DURATION)
+        self.playback_area_width = get(Get.PLAYBACK_AREA_WIDTH)
+        self.left_margin_x = get(Get.LEFT_MARGIN_X)
+
+        listen(self, Post.FILE_MEDIA_DURATION_CHANGED, self.on_media_duration_changed)
+        listen(self, Post.PLAYBACK_AREA_SET_WIDTH, self.on_playback_area_set_width)
+
+    def on_media_duration_changed(self, duration):
+        self.media_duration = duration
+
+    def on_playback_area_set_width(self, width):
+        if width < 0:
+            return
+
+        self.playback_area_width = width
+
+    def get_time_by_x(self, x):
+        try:
+            return (x - self.left_margin_x) * self.media_duration / self.playback_area_width
+        except ZeroDivisionError:
+            return 0.0
+
+    def get_x_by_time(self, time: float) -> int:
+        try:
+            return ((time / self.media_duration) * self.playback_area_width) + self.left_margin_x
+        except ZeroDivisionError:
+            return self.left_margin_x
 
 
 def get_x_by_time(time: float) -> int:
@@ -13,9 +45,9 @@ def get_x_by_time(time: float) -> int:
 def get_time_by_x(x: float) -> float:
     try:
         return (
-            (x - get(Get.LEFT_MARGIN_X))
-            * get(Get.MEDIA_DURATION)
-            / get(Get.PLAYBACK_AREA_WIDTH)
+                (x - get(Get.LEFT_MARGIN_X))
+                * get(Get.MEDIA_DURATION)
+                / get(Get.PLAYBACK_AREA_WIDTH)
         )
     except ZeroDivisionError:
         return 0.0

--- a/tilia/ui/coords.py
+++ b/tilia/ui/coords.py
@@ -3,12 +3,13 @@ from tilia.requests import get, Get, listen, Post
 
 class TimeXConverter:
     def __init__(self):
+        listen(self, Post.FILE_MEDIA_DURATION_CHANGED, self.on_media_duration_changed)
+        listen(self, Post.PLAYBACK_AREA_SET_WIDTH, self.on_playback_area_set_width)
+
+    def setup(self):
         self.media_duration = get(Get.MEDIA_DURATION)
         self.playback_area_width = get(Get.PLAYBACK_AREA_WIDTH)
         self.left_margin_x = get(Get.LEFT_MARGIN_X)
-
-        listen(self, Post.FILE_MEDIA_DURATION_CHANGED, self.on_media_duration_changed)
-        listen(self, Post.PLAYBACK_AREA_SET_WIDTH, self.on_playback_area_set_width)
 
     def on_media_duration_changed(self, duration):
         self.media_duration = duration
@@ -26,6 +27,16 @@ class TimeXConverter:
                 * self.media_duration
                 / self.playback_area_width
             )
+        except AttributeError:
+            self.setup()
+            try:
+                return (
+                    (x - self.left_margin_x)
+                    * self.media_duration
+                    / self.playback_area_width
+                )
+            except ZeroDivisionError:
+                return 0.0
         except ZeroDivisionError:
             return 0.0
 
@@ -34,25 +45,16 @@ class TimeXConverter:
             return (
                 (time / self.media_duration) * self.playback_area_width
             ) + self.left_margin_x
+        except AttributeError:
+            self.setup()
+            try:
+                return (
+                    (time / self.media_duration) * self.playback_area_width
+                ) + self.left_margin_x
+            except ZeroDivisionError:
+                return self.left_margin_x
         except ZeroDivisionError:
             return self.left_margin_x
 
 
-def get_x_by_time(time: float) -> int:
-    try:
-        return ((time / get(Get.MEDIA_DURATION)) * get(Get.PLAYBACK_AREA_WIDTH)) + get(
-            Get.LEFT_MARGIN_X
-        )
-    except ZeroDivisionError:
-        return get(Get.LEFT_MARGIN_X)
-
-
-def get_time_by_x(x: float) -> float:
-    try:
-        return (
-            (x - get(Get.LEFT_MARGIN_X))
-            * get(Get.MEDIA_DURATION)
-            / get(Get.PLAYBACK_AREA_WIDTH)
-        )
-    except ZeroDivisionError:
-        return 0.0
+time_x_converter = TimeXConverter()

--- a/tilia/ui/menus.py
+++ b/tilia/ui/menus.py
@@ -6,7 +6,7 @@ from PyQt6.QtWidgets import QMenu
 from PyQt6.QtGui import QAction
 
 from tilia.ui.actions import TiliaAction, get_qaction
-from tilia.settings import settings
+from tilia.settings import settings_manager
 from tilia.requests.post import post, Post, listen
 from tilia.ui.enums import WindowState
 
@@ -70,10 +70,10 @@ class RecentFilesMenu(QMenu):
         super().__init__()
         self.setTitle("Open Recent File...")
         self.add_items()
-        settings.link_file_update(self.update_items)
+        settings_manager.link_file_update(self.update_items)
 
     def add_items(self):
-        recent_files = settings.get_recent_files()
+        recent_files = settings_manager.get_recent_files()
         qactions = [self._get_action(file) for file in recent_files]
         self.addActions(qactions)
 

--- a/tilia/ui/qtui.py
+++ b/tilia/ui/qtui.py
@@ -42,7 +42,7 @@ from .windows.kinds import WindowKind
 from ..media.player import QtAudioPlayer, QtVideoPlayer, YouTubePlayer
 from ..parsers.csv.beat import beats_from_csv
 from tilia import constants
-from tilia.settings import settings
+from tilia.settings import settings_manager, settings
 from tilia.utils import get_tilia_class_string
 from tilia.timelines.timeline_kinds import TimelineKind as TlKind
 from tilia.requests import Post, listen, post, serve, Get, get
@@ -270,7 +270,7 @@ class QtUI:
         return self.main_window.saveState()
     
     def on_file_load(self, file: TiliaFile) -> None:
-        geometry, state = settings.get_geometry_and_state_from_path(file.file_path)
+        geometry, state = settings_manager.get_geometry_and_state_from_path(file.file_path)
         if geometry and state:
             self.main_window.restoreGeometry(geometry)
             self.main_window.restoreState(state)

--- a/tilia/ui/timelines/audiowave/element.py
+++ b/tilia/ui/timelines/audiowave/element.py
@@ -8,7 +8,7 @@ from PyQt6.QtWidgets import QGraphicsLineItem
 from tilia.requests import Post, post, get, Get
 from ..cursors import CursorMixIn
 from ..drag import DragManager
-from ...coords import get_x_by_time
+from ...coords import time_x_converter
 from ...color import get_tinted_color
 from ...consts import TINT_FACTOR_ON_SELECTION
 from tilia.settings import settings
@@ -33,7 +33,9 @@ class AmplitudeBarUI(TimelineUIElement):
 
     @property
     def width(self):
-        return get_x_by_time(self.get_data("end") - self.get_data("start"))
+        return time_x_converter.get_x_by_time(
+            self.get_data("end") - self.get_data("start")
+        )
 
     @property
     def amplitude(self):

--- a/tilia/ui/timelines/audiowave/element.py
+++ b/tilia/ui/timelines/audiowave/element.py
@@ -18,28 +18,19 @@ from ...windows.inspect import InspectRowKind
 if TYPE_CHECKING:
     from .timeline import AudioWaveTimelineUI
 
+
 class AmplitudeBarUI(TimelineUIElement):
     INSPECTOR_FIELDS = [
         ("Start / End", InspectRowKind.LABEL, None),
         ("Amplitude", InspectRowKind.LABEL, None)
     ]
 
-    def __init__(
-            self,
-            id: int,
-            timeline_ui: AudioWaveTimelineUI,
-            scene: QGraphicsScene,
-            **_,
-    ):
-        super().__init__(id=id, timeline_ui=timeline_ui, scene=scene)
-        self.timeline_ui = timeline_ui
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
         self._setup_body()
         self.dragged = False
 
-    @property
-    def start_x(self):
-        return get_x_by_time(self.get_data("start"))
-    
     @property
     def width(self):
         return get_x_by_time(self.get_data("end") - self.get_data("start"))
@@ -56,10 +47,6 @@ class AmplitudeBarUI(TimelineUIElement):
     def seek_time(self):
         return self.get_data("start")
 
-    @property
-    def x(self):
-        return get_x_by_time(self.seek_time)
-    
     def _setup_body(self):
         self.body = AmplitudeBarUIBody(
             self.start_x,

--- a/tilia/ui/timelines/audiowave/element.py
+++ b/tilia/ui/timelines/audiowave/element.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from PyQt6.QtCore import Qt, QPointF, QLineF
 from PyQt6.QtGui import QPen, QColor
-from PyQt6.QtWidgets import QGraphicsScene, QGraphicsLineItem
+from PyQt6.QtWidgets import QGraphicsLineItem
 
 from tilia.requests import Post, post, get, Get
 from ..cursors import CursorMixIn
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 class AmplitudeBarUI(TimelineUIElement):
     INSPECTOR_FIELDS = [
         ("Start / End", InspectRowKind.LABEL, None),
-        ("Amplitude", InspectRowKind.LABEL, None)
+        ("Amplitude", InspectRowKind.LABEL, None),
     ]
 
     def __init__(self, *args, **kwargs):
@@ -34,25 +34,22 @@ class AmplitudeBarUI(TimelineUIElement):
     @property
     def width(self):
         return get_x_by_time(self.get_data("end") - self.get_data("start"))
-    
+
     @property
     def amplitude(self):
         return self.get_data("amplitude")
-    
+
     @property
     def height(self):
         return self.timeline_ui.get_data("height")
-        
+
     @property
     def seek_time(self):
         return self.get_data("start")
 
     def _setup_body(self):
         self.body = AmplitudeBarUIBody(
-            self.start_x,
-            self.width,
-            self.amplitude,
-            self.height
+            self.start_x, self.width, self.amplitude, self.height
         )
         self.scene.addItem(self.body)
 
@@ -60,25 +57,20 @@ class AmplitudeBarUI(TimelineUIElement):
         self.update_time()
 
     def update_time(self):
-        self.body.set_position(
-            self.start_x,
-            self.width,
-            self.amplitude, 
-            self.height
-        )
+        self.body.set_position(self.start_x, self.width, self.amplitude, self.height)
 
     def child_items(self):
         return [self.body]
-        
+
     def left_click_triggers(self):
         return [self.body]
-    
+
     def on_left_click(self, _) -> None:
         self.setup_drag()
 
     def double_left_click_triggers(self):
         return [self.body]
-    
+
     def on_double_left_click(self, _):
         post(Post.PLAYER_SEEK, self.seek_time)
 
@@ -88,9 +80,9 @@ class AmplitudeBarUI(TimelineUIElement):
             get_max_x=lambda: get(Get.RIGHT_MARGIN_X),
             before_each=self.before_each_drag,
             after_each=self.after_each_drag,
-            on_release=self.on_drag_end
+            on_release=self.on_drag_end,
         )
-        
+
     def before_each_drag(self):
         if not self.dragged:
             post(Post.ELEMENT_DRAG_START)
@@ -114,6 +106,7 @@ class AmplitudeBarUI(TimelineUIElement):
     def get_inspector_dict(self) -> dict:
         return self.timeline_ui.get_inspector_dict()
 
+
 class AmplitudeBarUIBody(CursorMixIn, QGraphicsLineItem):
     def __init__(self, start_x: float, width: float, amplitude: float, height: float):
         super().__init__(cursor_shape=Qt.CursorShape.PointingHandCursor)
@@ -134,8 +127,14 @@ class AmplitudeBarUIBody(CursorMixIn, QGraphicsLineItem):
         return QLineF(QPointF(x, offset), QPointF(x, offset + height))
 
     def update_pen_style(self):
-        color = get_tinted_color(settings.get("audiowave_timeline", "default_color"), TINT_FACTOR_ON_SELECTION) if self.selected \
+        color = (
+            get_tinted_color(
+                settings.get("audiowave_timeline", "default_color"),
+                TINT_FACTOR_ON_SELECTION,
+            )
+            if self.selected
             else settings.get("audiowave_timeline", "default_color")
+        )
         pen = QPen(QColor(color))
         pen.setStyle(Qt.PenStyle.SolidLine)
         pen.setWidthF(self.width)

--- a/tilia/ui/timelines/base/element.py
+++ b/tilia/ui/timelines/base/element.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import functools
 from abc import ABC, abstractmethod
 
 from typing import Optional, Any, Callable
@@ -12,7 +11,7 @@ from tilia.utils import get_tilia_class_string
 
 from PyQt6.QtWidgets import QGraphicsScene
 
-from tilia.requests import stop_listening_to_all, get, Get
+from tilia.requests import stop_listening_to_all
 
 
 class TimelineUIElement(ABC):
@@ -51,7 +50,7 @@ class TimelineUIElement(ABC):
 
     @property
     def kind(self):
-        return self.tl_component.get_data('KIND')
+        return self.tl_component.get_data("KIND")
 
     def update(self, attr: str, value: Any):
         if attr not in self.UPDATE_TRIGGERS:
@@ -67,7 +66,8 @@ class TimelineUIElement(ABC):
         return self in self.timeline_ui.selected_elements
 
     @abstractmethod
-    def child_items(self): ...
+    def child_items(self):
+        ...
 
     def selection_triggers(self):
         return self.child_items()
@@ -88,9 +88,11 @@ class TimelineUIElement(ABC):
         menu = self.CONTEXT_MENU_CLASS(self)
         menu.exec(QPoint(x, y))
 
-    def on_select(self): ...
+    def on_select(self):
+        ...
 
-    def on_deselect(self): ...
+    def on_deselect(self):
+        ...
 
     def delete(self):
         for item in self.child_items():

--- a/tilia/ui/timelines/base/element.py
+++ b/tilia/ui/timelines/base/element.py
@@ -7,6 +7,7 @@ from typing import Optional, Any, Callable
 from PyQt6.QtCore import QPoint
 
 from tilia.ui.timelines.base.context_menus import TimelineUIElementContextMenu
+from tilia.ui.coords import time_x_converter
 from tilia.utils import get_tilia_class_string
 
 from PyQt6.QtWidgets import QGraphicsScene
@@ -33,8 +34,6 @@ class TimelineUIElement(ABC):
         self.timeline_ui = timeline_ui
         self.id = id
         self.scene = scene
-        self.get_x_by_time = self.timeline_ui.time_x_converter.get_x_by_time
-        self.get_time_by_x = self.timeline_ui.time_x_converter.get_time_by_x
         self.get_data = get_data
         self.set_data = set_data
 
@@ -104,12 +103,12 @@ class TimelineUIElement(ABC):
 
     @property
     def start_x(self):
-        return self.get_x_by_time(self.get_data("start"))
+        return time_x_converter.get_x_by_time(self.get_data("start"))
 
     @property
     def end_x(self):
-        return self.get_x_by_time(self.get_data("end"))
+        return time_x_converter.get_x_by_time(self.get_data("end"))
 
     @property
     def x(self):
-        return self.get_x_by_time(self.get_data("time"))
+        return time_x_converter.get_x_by_time(self.get_data("time"))

--- a/tilia/ui/timelines/base/element_manager.py
+++ b/tilia/ui/timelines/base/element_manager.py
@@ -48,11 +48,13 @@ class ElementManager(Generic[TE]):
         id: int,
         timeline_ui: TimelineUI,
         scene: TimelineScene,
+        get_data: Callable[[str], Any],
+        set_data: Callable[[str, Any], None],
     ):
         if self.is_single_element:
-            element = self.element_classes[0](id, timeline_ui, scene)
+            element = self.element_classes[0](id, timeline_ui, scene, get_data, set_data)
         else:
-            element = get_element_class_by_kind(kind)(id, timeline_ui, scene)
+            element = get_element_class_by_kind(kind)(id, timeline_ui, scene, get_data, set_data)
 
         self._add_to_elements_set(element)
 

--- a/tilia/ui/timelines/base/timeline.py
+++ b/tilia/ui/timelines/base/timeline.py
@@ -200,8 +200,12 @@ class TimelineUI(ABC):
     def on_timeline_request(self, request, *args, **kwargs):
         return TimelineRequestHandler(self, {}).on_request(request, *args, **kwargs)
 
-    def on_timeline_component_created(self, kind: ComponentKind, id: int, get_data, set_data):
-        return self.element_manager.create_element(kind, id, self, self.scene, get_data, set_data)
+    def on_timeline_component_created(
+        self, kind: ComponentKind, id: int, get_data, set_data
+    ):
+        return self.element_manager.create_element(
+            kind, id, self, self.scene, get_data, set_data
+        )
 
     def on_timeline_component_deleted(self, id: int):
         self.delete_element(self.id_to_element[id])

--- a/tilia/ui/timelines/base/timeline.py
+++ b/tilia/ui/timelines/base/timeline.py
@@ -28,7 +28,7 @@ from tilia.ui.timelines.copy_paste import (
 from .request_handlers import TimelineRequestHandler
 from ..collection.requests.enums import ElementSelector
 from ..view import TimelineView
-from ...coords import get_x_by_time, TimeXConverter
+from ...coords import time_x_converter
 
 if TYPE_CHECKING:
     from tilia.ui.timelines.collection.collection import TimelineUIs
@@ -54,12 +54,10 @@ class TimelineUI(ABC):
         element_manager: ElementManager,
         scene: TimelineScene,
         view: TimelineView,
-        time_x_converter: TimeXConverter | None = None,
     ):
         super().__init__()
         self.id = id
         self.collection = collection
-        self.time_x_converter = time_x_converter
         self.scene = scene
         self.view = view
 
@@ -159,10 +157,13 @@ class TimelineUI(ABC):
         self.scene.set_width(int(width))
         self.view.setFixedWidth(int(width))
         self.element_manager.update_time_on_elements()
-        self.scene.set_playback_line_pos(get_x_by_time(get(Get.SELECTED_TIME)))
+        self.scene.set_playback_line_pos(
+            time_x_converter.get_x_by_time(get(Get.SELECTED_TIME))
+        )
         (loop_start, loop_end) = get(Get.LOOP_TIME)
         self.scene.set_loop_box_position(
-            get_x_by_time(loop_start), get_x_by_time(loop_end)
+            time_x_converter.get_x_by_time(loop_start),
+            time_x_converter.get_x_by_time(loop_end),
         )
 
     def update_ordinal(self):

--- a/tilia/ui/timelines/beat/element.py
+++ b/tilia/ui/timelines/beat/element.py
@@ -3,7 +3,7 @@ Defines the ui corresponding to a Beat object.
 """
 
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Any
 
 from PyQt6.QtCore import Qt, QLineF, QPointF
 from PyQt6.QtGui import QPen, QColor, QFont
@@ -63,9 +63,11 @@ class BeatUI(TimelineUIElement):
         id: int,
         timeline_ui: BeatTimelineUI,
         scene: QGraphicsScene,
+        get_data: Callable[[str], Any],
+        set_data: Callable[[str, Any], None],
         **_,
     ):
-        super().__init__(id=id, timeline_ui=timeline_ui, scene=scene)
+        super().__init__(id=id, timeline_ui=timeline_ui, scene=scene, get_data=get_data, set_data=set_data)
 
         self._setup_body()
         self._setup_label()
@@ -84,10 +86,6 @@ class BeatUI(TimelineUIElement):
     @property
     def time(self):
         return self.tl_component.time
-
-    @property
-    def x(self):
-        return get_x_by_time(self.time)
 
     @property
     def label_y(self):

--- a/tilia/ui/timelines/beat/element.py
+++ b/tilia/ui/timelines/beat/element.py
@@ -15,7 +15,7 @@ from ..copy_paste import CopyAttributes
 from ..cursors import CursorMixIn
 from ..drag import DragManager
 from ...format import format_media_time
-from ...coords import get_x_by_time, get_time_by_x
+from ...coords import time_x_converter
 from tilia.ui.timelines.base.element import TimelineUIElement
 from ...windows.inspect import InspectRowKind
 
@@ -171,13 +171,18 @@ class BeatUI(TimelineUIElement):
         previous_beat = self.timeline_ui.get_previous_element(self)
         if not previous_beat:
             return get(Get.LEFT_MARGIN_X)
-        return get_x_by_time(previous_beat.time) + self.DRAG_PROXIMITY_LIMIT
+        return (
+            time_x_converter.get_x_by_time(previous_beat.time)
+            + self.DRAG_PROXIMITY_LIMIT
+        )
 
     def get_drag_right_limit(self):
         next_beat = self.timeline_ui.get_next_element(self)
         if not next_beat:
             return get(Get.RIGHT_MARGIN_X)
-        return get_x_by_time(next_beat.time) - self.DRAG_PROXIMITY_LIMIT
+        return (
+            time_x_converter.get_x_by_time(next_beat.time) - self.DRAG_PROXIMITY_LIMIT
+        )
 
     def before_each_drag(self):
         if not self.dragged:
@@ -185,7 +190,7 @@ class BeatUI(TimelineUIElement):
             self.dragged = True
 
     def after_each_drag(self, drag_x: int):
-        self.tl_component.time = get_time_by_x(drag_x)
+        self.tl_component.time = time_x_converter.get_time_by_x(drag_x)
         self.update_position()
 
     def on_drag_end(self):

--- a/tilia/ui/timelines/beat/element.py
+++ b/tilia/ui/timelines/beat/element.py
@@ -45,9 +45,9 @@ class BeatUI(TimelineUIElement):
         ("Beat", InspectRowKind.LABEL, None),
     ]
 
-    FIELD_NAMES_TO_ATTRIBUTES: dict[str, str] = (
-        {}
-    )  # only needed if attrs will be set by Inspect
+    FIELD_NAMES_TO_ATTRIBUTES: dict[
+        str, str
+    ] = {}  # only needed if attrs will be set by Inspect
 
     DEFAULT_COPY_ATTRIBUTES = CopyAttributes(
         by_element_value=[],
@@ -67,7 +67,13 @@ class BeatUI(TimelineUIElement):
         set_data: Callable[[str, Any], None],
         **_,
     ):
-        super().__init__(id=id, timeline_ui=timeline_ui, scene=scene, get_data=get_data, set_data=set_data)
+        super().__init__(
+            id=id,
+            timeline_ui=timeline_ui,
+            scene=scene,
+            get_data=get_data,
+            set_data=set_data,
+        )
 
         self._setup_body()
         self._setup_label()

--- a/tilia/ui/timelines/collection/collection.py
+++ b/tilia/ui/timelines/collection/collection.py
@@ -63,8 +63,8 @@ class TimelineUIs:
     UPDATE_TRIGGERS = ["height", "level_count"]
 
     def __init__(
-            self,
-            main_window: QMainWindow,
+        self,
+        main_window: QMainWindow,
     ):
 
         self.main_window = main_window
@@ -215,8 +215,8 @@ class TimelineUIs:
             )
 
         for (
-                request,
-                selector,
+            request,
+            selector,
         ) in tilia.ui.timelines.collection.requests.element.request_to_scope.items():
             listen(
                 self,
@@ -225,8 +225,8 @@ class TimelineUIs:
             )
 
         for (
-                request,
-                selector,
+            request,
+            selector,
         ) in tilia.ui.timelines.collection.requests.timeline.request_to_scope.items():
             listen(
                 self,
@@ -249,7 +249,7 @@ class TimelineUIs:
             element_manager=element_manager,
             scene=scene,
             view=view,
-            time_x_converter=self.time_x_converter
+            time_x_converter=self.time_x_converter,
         )
 
         self._add_to_timeline_uis_set(tl_ui)
@@ -261,9 +261,13 @@ class TimelineUIs:
         return tl_ui
 
     def on_timeline_component_created(
-            self, _: TlKind, tl_id: int, component_kind: ComponentKind, component_id: int,
-            get_data: Callable[[str, Any], None],
-            set_data: Callable[[str], Any],
+        self,
+        _: TlKind,
+        tl_id: int,
+        component_kind: ComponentKind,
+        component_id: int,
+        get_data: Callable[[str, Any], None],
+        set_data: Callable[[str], Any],
     ):
         self.get_timeline_ui(tl_id).on_timeline_component_created(
             component_kind, component_id, get_data, set_data
@@ -278,7 +282,7 @@ class TimelineUIs:
         self.get_timeline_ui(tl_id).on_timeline_component_deleted(component_id)
 
     def on_timeline_component_set_data_done(
-            self, timeline_id: int, component_id: int, attr: str, value: Any
+        self, timeline_id: int, component_id: int, attr: str, value: Any
     ):
         timeline_ui = self.get_timeline_ui(timeline_id)
         element = timeline_ui.get_element(component_id)
@@ -368,12 +372,12 @@ class TimelineUIs:
 
     def get_scene_height(self):
         return (
-                sum(
-                    tlui.get_data("height")
-                    for tlui in sorted(self)
-                    if tlui.get_data("is_visible")
-                )
-                + 20
+            sum(
+                tlui.get_data("height")
+                for tlui in sorted(self)
+                if tlui.get_data("is_visible")
+            )
+            + 20
         )
 
     def on_timeline_width_set_done(self, width):
@@ -460,13 +464,13 @@ class TimelineUIs:
         return next((tlui for tlui in self if tlui.view == view), None)
 
     def _on_timeline_ui_right_click(
-            self,
-            view: QGraphicsView,
-            x: int,
-            y: int,
-            item: Optional[QGraphicsItem],
-            modifier: ModifierEnum,
-            **_,  # ignores the double argument
+        self,
+        view: QGraphicsView,
+        x: int,
+        y: int,
+        item: Optional[QGraphicsItem],
+        modifier: ModifierEnum,
+        **_,  # ignores the double argument
     ) -> None:
         timeline_ui = self._get_timeline_ui_by_view(view)
 
@@ -477,8 +481,8 @@ class TimelineUIs:
             )
 
         if (
-                modifier == Qt.KeyboardModifier.NoModifier
-                and not timeline_ui.belongs_to_selection(item)
+            modifier == Qt.KeyboardModifier.NoModifier
+            and not timeline_ui.belongs_to_selection(item)
         ):
             self.deselect_all_elements_in_timeline_uis(excluding=timeline_ui)
 
@@ -486,13 +490,13 @@ class TimelineUIs:
         timeline_ui.on_right_click(x, y, item, modifier=modifier)
 
     def _on_timeline_ui_left_click(
-            self,
-            view: QGraphicsView,
-            x: int,
-            y: int,
-            item: Optional[QGraphicsItem],
-            modifier: Qt.KeyboardModifier,
-            double: bool,
+        self,
+        view: QGraphicsView,
+        x: int,
+        y: int,
+        item: Optional[QGraphicsItem],
+        modifier: Qt.KeyboardModifier,
+        double: bool,
     ) -> None:
         timeline_ui = self._get_timeline_ui_by_view(view)
 
@@ -591,7 +595,7 @@ class TimelineUIs:
                 self.next_sbx_boundary_below = self.selection_boxes[0].scene().height()
 
             self.next_sbx_boundary_above = (
-                    sum([sbx.scene().height() for sbx in self.selection_boxes]) * -1
+                sum([sbx.scene().height() for sbx in self.selection_boxes]) * -1
             )
             self.selection_boxes_above = True
 
@@ -606,7 +610,7 @@ class TimelineUIs:
             self.selection_boxes.remove(sb)
 
     def on_selection_box_select_item(
-            self, scene: QGraphicsScene, item: QGraphicsItem
+        self, scene: QGraphicsScene, item: QGraphicsItem
     ) -> None:
         timeline_ui = self._get_timeline_ui_by_scene(scene)
 
@@ -672,8 +676,8 @@ class TimelineUIs:
 
     def on_hierarchy_merge_split(self, new_units: list, old_units: list):
         if (
-                self.loop_delete_ignore.issuperset(set(old_units))
-                and self.loop_time[0] != self.loop_time[1]
+            self.loop_delete_ignore.issuperset(set(old_units))
+            and self.loop_time[0] != self.loop_time[1]
         ):
             self.loop_elements.update(new_units)
             self.loop_elements.difference_update(old_units)
@@ -778,19 +782,19 @@ class TimelineUIs:
 
         for i in connections:
             if (
-                    connector[0] < connections[i][0]
-                    and connector[1] > connections[i][0]
-                    and connector[1] < connections[i][1]
+                connector[0] < connections[i][0]
+                and connector[1] > connections[i][0]
+                and connector[1] < connections[i][1]
             ):
                 connector[1] = connections[i][1]
             elif (
-                    connector[0] > connections[i][0]
-                    and connector[0] < connections[i][1]
-                    and connector[1] > connections[i][1]
+                connector[0] > connections[i][0]
+                and connector[0] < connections[i][1]
+                and connector[1] > connections[i][1]
             ):
                 connector[0] = connections[i][0]
             elif (
-                    connector[0] <= connections[i][0] and connector[1] >= connections[i][1]
+                connector[0] <= connections[i][0] and connector[1] >= connections[i][1]
             ):
                 pass
             elif connector[0] > connections[i][0] and connector[1] < connections[i][1]:
@@ -824,10 +828,10 @@ class TimelineUIs:
             self.loop_elements.clear()
 
     def pre_process_timeline_request(
-            self,
-            request: Post,
-            kinds: list[TlKind],
-            selector: tilia.ui.timelines.collection.requests.timeline.TimelineSelector,
+        self,
+        request: Post,
+        kinds: list[TlKind],
+        selector: tilia.ui.timelines.collection.requests.timeline.TimelineSelector,
     ):
         timeline_uis = self.get_timelines_uis_for_request(kinds, selector)
 
@@ -855,9 +859,9 @@ class TimelineUIs:
         return args, kwargs, True
 
     def on_timeline_element_request(
-            self,
-            request: Post,
-            selector: TlElmRequestSelector,
+        self,
+        request: Post,
+        selector: TlElmRequestSelector,
     ) -> None:
         timeline_uis, args, kwargs, success = self.pre_process_timeline_request(
             request, selector.tl_kind, selector.timeline
@@ -916,18 +920,18 @@ class TimelineUIs:
             post(Post.APP_RECORD_STATE, f"timeline request: {request.name}")
 
     def get_timelines_uis_for_request(
-            self, kinds: list[TlKind], selector: TimelineSelector
+        self, kinds: list[TlKind], selector: TimelineSelector
     ) -> list[TimelineUI]:
         def get_by_kinds(_kinds: list[TlKind]) -> list[TimelineUI]:
             return [tlui for tlui in self if tlui.TIMELINE_KIND in _kinds]
 
         def filter_if_has_selected_elements(
-                timeline_uis: list[TimelineUI],
+            timeline_uis: list[TimelineUI],
         ) -> list[TimelineUI]:
             return [tlui for tlui in timeline_uis if tlui.has_selected_elements]
 
         def filter_if_first_on_select_order(
-                timeline_uis: list[TimelineUI],
+            timeline_uis: list[TimelineUI],
         ) -> list[TimelineUI]:
             for tl_ui in self._select_order:
                 if tl_ui in timeline_uis:
@@ -1023,7 +1027,7 @@ class TimelineUIs:
         if timeline_ui.timeline.KIND == TlKind.SLIDER_TIMELINE:
             return
 
-        timeline_ui.scene.set_playback_line_pos(get_x_by_time(time))
+        timeline_ui.scene.set_playback_line_pos(time_x_converter.get_x_by_time(time))
 
     def on_timelines_crop_done(self):
         for tlui in self:
@@ -1083,10 +1087,10 @@ class TimelineUIs:
         )
 
     def _get_choose_timeline_dialog(
-            self,
-            title: str,
-            prompt: str,
-            kind: TlKind | list[TlKind] | None = None,
+        self,
+        title: str,
+        prompt: str,
+        kind: TlKind | list[TlKind] | None = None,
     ) -> ChooseDialog:
         if kind and not isinstance(kind, list):
             kind = [kind]
@@ -1100,10 +1104,10 @@ class TimelineUIs:
         return ChooseDialog(self.main_window, title, prompt, options)
 
     def ask_choose_timeline(
-            self,
-            title: str,
-            prompt: str,
-            kind: TlKind | list[TlKind] | None = None,
+        self,
+        title: str,
+        prompt: str,
+        kind: TlKind | list[TlKind] | None = None,
     ) -> Optional[Timeline] | None:
         """
         Opens a dialog where the user may choose an existing timeline.
@@ -1123,13 +1127,13 @@ class TimelineUIs:
         return [tlui for tlui in self if tlui.has_selected_elements]
 
     def on_component_event(
-            self,
-            event: Post,
-            _: TlKind,
-            tl_id: int,
-            component_id: int,
-            *args,
-            **kwargs,
+        self,
+        event: Post,
+        _: TlKind,
+        tl_id: int,
+        component_id: int,
+        *args,
+        **kwargs,
     ):
         event_to_callback = {}
 

--- a/tilia/ui/timelines/collection/collection.py
+++ b/tilia/ui/timelines/collection/collection.py
@@ -30,7 +30,7 @@ from tilia.requests import get, Get, serve
 from tilia.requests import listen, Post, post
 from tilia.timelines.base.timeline import Timeline
 from tilia.timelines.timeline_kinds import TimelineKind as TlKind, TimelineKind
-from tilia.ui.coords import get_x_by_time, get_time_by_x, TimeXConverter
+from tilia.ui.coords import time_x_converter
 from tilia.ui.dialogs.choose import ChooseDialog
 from tilia.ui.modifier_enum import ModifierEnum
 from tilia.ui.player import PlayerToolbarElement
@@ -78,7 +78,6 @@ class TimelineUIs:
         self._setup_widgets(main_window)
         self._setup_requests()
 
-        self.time_x_converter = TimeXConverter()
         self._setup_selection_box()
         self._setup_drag_tracking_vars()
         self._setup_auto_scroll()
@@ -249,7 +248,6 @@ class TimelineUIs:
             element_manager=element_manager,
             scene=scene,
             view=view,
-            time_x_converter=self.time_x_converter,
         )
 
         self._add_to_timeline_uis_set(tl_ui)
@@ -814,7 +812,8 @@ class TimelineUIs:
         start_time, end_time = self.loop_time
         for tl_ui in self:
             tl_ui.scene.set_loop_box_position(
-                get_x_by_time(start_time), get_x_by_time(end_time)
+                time_x_converter.get_x_by_time(start_time),
+                time_x_converter.get_x_by_time(end_time),
             )
 
     def update_loop_elements_ui(self, is_looping: bool) -> None:
@@ -1010,7 +1009,7 @@ class TimelineUIs:
             self.clear_selection_boxes()
 
     def on_slider_drag(self, x: float):
-        time = get_time_by_x(x)
+        time = time_x_converter.get_time_by_x(x)
         self.selected_time = time
         self.set_playback_lines_position(time)
 
@@ -1020,7 +1019,7 @@ class TimelineUIs:
         self.auto_scroll_is_enabled = value
 
     def center_on_time(self, time: float):
-        self.view.move_to_x(get_x_by_time(time))
+        self.view.move_to_x(time_x_converter.get_x_by_time(time))
 
     @staticmethod
     def change_playback_line_position(timeline_ui: TimelineUI, time: float):

--- a/tilia/ui/timelines/harmony/elements/harmony.py
+++ b/tilia/ui/timelines/harmony/elements/harmony.py
@@ -5,7 +5,7 @@ import typing
 import music21
 from PyQt6.QtCore import QPointF
 from PyQt6.QtGui import QFont, QColor
-from PyQt6.QtWidgets import QGraphicsScene, QGraphicsItem, QGraphicsTextItem
+from PyQt6.QtWidgets import QGraphicsItem, QGraphicsTextItem
 from music21.roman import RomanNumeral
 
 from . import harmony_attrs
@@ -46,10 +46,8 @@ class HarmonyUI(TimelineUIElement):
 
     CONTEXT_MENU_CLASS = HarmonyContextMenu
 
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
 
         self._setup_body()
 
@@ -208,7 +206,6 @@ class HarmonyUI(TimelineUIElement):
 
     def update_label(self):
         self.body.set_text(self.label)
-        # self.body.set_alternate_text(self.alternate_lable)
         self.body.set_position(self.x, self.y)
 
     def update_position(self):

--- a/tilia/ui/timelines/harmony/elements/harmony.py
+++ b/tilia/ui/timelines/harmony/elements/harmony.py
@@ -10,7 +10,7 @@ from music21.roman import RomanNumeral
 
 from . import harmony_attrs
 from tilia.requests import get, Get, post, Post
-from tilia.ui.coords import get_x_by_time, get_time_by_x
+from tilia.ui.coords import time_x_converter
 from tilia.ui.timelines.base.element import TimelineUIElement
 from tilia.ui.timelines.drag import DragManager
 from tilia.ui.timelines.harmony.constants import (
@@ -247,7 +247,7 @@ class HarmonyUI(TimelineUIElement):
             self.dragged = True
 
     def after_each_drag(self, drag_x: int):
-        self.set_data("time", get_time_by_x(drag_x))
+        self.set_data("time", time_x_converter.get_time_by_x(drag_x))
         self.update_label()
 
     def on_drag_end(self):

--- a/tilia/ui/timelines/harmony/elements/harmony.py
+++ b/tilia/ui/timelines/harmony/elements/harmony.py
@@ -46,14 +46,10 @@ class HarmonyUI(TimelineUIElement):
 
     CONTEXT_MENU_CLASS = HarmonyContextMenu
 
-    def __init__(
-        self,
-        id: int,
-        timeline_ui: HarmonyTimelineUI,
-        scene: QGraphicsScene,
-        **_,
-    ):
-        super().__init__(id=id, timeline_ui=timeline_ui, scene=scene)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
 
         self._setup_body()
 
@@ -63,10 +59,6 @@ class HarmonyUI(TimelineUIElement):
     def _setup_body(self):
         self.body = HarmonyBody(self.x, self.y, self.label, self.font_type)
         self.scene.addItem(self.body)
-
-    @property
-    def x(self):
-        return get_x_by_time(self.get_data("time"))
 
     @property
     def y(self):

--- a/tilia/ui/timelines/harmony/elements/mode.py
+++ b/tilia/ui/timelines/harmony/elements/mode.py
@@ -5,7 +5,7 @@ import typing
 import music21
 from PyQt6.QtCore import QPointF
 from PyQt6.QtGui import QFont, QColor
-from PyQt6.QtWidgets import QGraphicsScene, QGraphicsItem, QGraphicsTextItem
+from PyQt6.QtWidgets import QGraphicsItem, QGraphicsTextItem
 
 from tilia.requests import get, Get, post, Post
 from tilia.ui.coords import get_x_by_time, get_time_by_x
@@ -40,10 +40,6 @@ class ModeUI(TimelineUIElement):
     def _setup_body(self):
         self.body = ModeBody(self.x, self.y, self.label)
         self.scene.addItem(self.body)
-
-    @property
-    def x(self):
-        return get_x_by_time(self.get_data("time"))
 
     @property
     def y(self):
@@ -151,10 +147,10 @@ class ModeUI(TimelineUIElement):
 
 class ModeBody(QGraphicsTextItem):
     def __init__(
-            self,
-            x: float,
-            y: float,
-            text: str,
+        self,
+        x: float,
+        y: float,
+        text: str,
     ):
         super().__init__()
         self._setup_font()

--- a/tilia/ui/timelines/harmony/elements/mode.py
+++ b/tilia/ui/timelines/harmony/elements/mode.py
@@ -29,14 +29,8 @@ class ModeUI(TimelineUIElement):
     UPDATE_TRIGGERS = ["time", "step", "accidental", "type", "level"]
     CONTEXT_MENU_CLASS = ModeContextMenu
 
-    def __init__(
-        self,
-        id: int,
-        timeline_ui: HarmonyTimelineUI,
-        scene: QGraphicsScene,
-        **_,
-    ):
-        super().__init__(id=id, timeline_ui=timeline_ui, scene=scene)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self._setup_body()
 
@@ -157,10 +151,10 @@ class ModeUI(TimelineUIElement):
 
 class ModeBody(QGraphicsTextItem):
     def __init__(
-        self,
-        x: float,
-        y: float,
-        text: str,
+            self,
+            x: float,
+            y: float,
+            text: str,
     ):
         super().__init__()
         self._setup_font()

--- a/tilia/ui/timelines/harmony/elements/mode.py
+++ b/tilia/ui/timelines/harmony/elements/mode.py
@@ -8,7 +8,7 @@ from PyQt6.QtGui import QFont, QColor
 from PyQt6.QtWidgets import QGraphicsItem, QGraphicsTextItem
 
 from tilia.requests import get, Get, post, Post
-from tilia.ui.coords import get_x_by_time, get_time_by_x
+from tilia.ui.coords import time_x_converter
 from tilia.ui.timelines.base.element import TimelineUIElement
 from tilia.ui.timelines.drag import DragManager
 from tilia.ui.timelines.harmony.constants import (
@@ -125,7 +125,7 @@ class ModeUI(TimelineUIElement):
             self.dragged = True
 
     def after_each_drag(self, drag_x: int):
-        self.set_data("time", get_time_by_x(drag_x))
+        self.set_data("time", time_x_converter.get_time_by_x(drag_x))
 
     def on_drag_end(self):
         if self.dragged:

--- a/tilia/ui/timelines/hierarchy/drag.py
+++ b/tilia/ui/timelines/hierarchy/drag.py
@@ -2,7 +2,7 @@ import functools
 import math
 
 from tilia.requests import get, Get, post, Post
-from tilia.ui import coords
+from tilia.ui.coords import time_x_converter
 from tilia.ui.timelines.drag import DragManager
 from tilia.ui.timelines.hierarchy.handles import (
     HierarchyBodyHandle,
@@ -93,7 +93,7 @@ def before_each_drag(hierarchy_ui):
 
 
 def after_each_body_handle_drag(hierarchy_ui, extremity, x: int) -> None:
-    hierarchy_ui.set_data(extremity.value, coords.get_time_by_x(x))
+    hierarchy_ui.set_data(extremity.value, time_x_converter.get_time_by_x(x))
 
 
 def after_each_frame_handle_drag(extremity, uis, x: int):
@@ -102,7 +102,7 @@ def after_each_frame_handle_drag(extremity, uis, x: int):
         Extremity.POST_END: Extremity.END,
     }[extremity]
     if math.isclose(
-        time := coords.get_time_by_x(x),
+        time := time_x_converter.get_time_by_x(x),
         body_extremity_time := uis[0].get_data(body_extremity.value),
     ):
         time = body_extremity_time

--- a/tilia/ui/timelines/hierarchy/element.py
+++ b/tilia/ui/timelines/hierarchy/element.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from PyQt6.QtCore import Qt, QRectF, QPointF
 from PyQt6.QtGui import QColor, QPen, QFont, QFontMetrics, QPixmap
 from PyQt6.QtWidgets import (
-    QGraphicsScene,
     QGraphicsPixmapItem,
     QGraphicsRectItem,
     QGraphicsTextItem,
@@ -148,16 +147,18 @@ class HierarchyUI(TimelineUIElement):
 
     @property
     def pre_start_x(self):
-        return self.timeline_ui.time_x_converter.get_x_by_time(self.get_data("pre_start"))
+        return self.timeline_ui.time_x_converter.get_x_by_time(
+            self.get_data("pre_start")
+        )
 
     @property
     def post_end_x(self):
-        return self.timeline_ui.time_x_converter.get_x_by_time(self.get_data("post_end"))
+        return self.timeline_ui.time_x_converter.get_x_by_time(
+            self.get_data("post_end")
+        )
 
     def frame_handle_y(self, level, tl_height):
-        return tl_height - (
-            self.base_height + (level - 1.5) * self.x_increment_per_lvl
-        )
+        return tl_height - (self.base_height + (level - 1.5) * self.x_increment_per_lvl)
 
     @property
     def ui_color(self):
@@ -231,8 +232,7 @@ class HierarchyUI(TimelineUIElement):
         """
         font_metrics = QFontMetrics(QFont("Arial", 10))
         self.label_substrings_widths = [
-            font_metrics.horizontalAdvance(value[: i + 1])
-            for i in range(len(value))
+            font_metrics.horizontalAdvance(value[: i + 1]) for i in range(len(value))
         ]
 
     def update(self, attr: str, value):
@@ -260,9 +260,9 @@ class HierarchyUI(TimelineUIElement):
         start_x = start_x or self.start_x
         end_x = end_x or self.end_x
         level = level or self.get_data("level")
-        height = height or self.timeline_ui.get_data('height')
+        height = height or self.timeline_ui.get_data("height")
 
-        new_label = self.get_data('label')
+        new_label = self.get_data("label")
         if new_label != self.label.toPlainText():
             self.update_label_substrings_widths(new_label)
 
@@ -280,12 +280,22 @@ class HierarchyUI(TimelineUIElement):
         self.update_position()
 
     def update_pre_start(self):
-        self.update_frame_handle_position(Extremity.PRE_START, self.get_data('level'), self.timeline_ui.get_data('height'), self.start_x)
+        self.update_frame_handle_position(
+            Extremity.PRE_START,
+            self.get_data("level"),
+            self.timeline_ui.get_data("height"),
+            self.start_x,
+        )
         if self.is_selected():
             self.update_frame_handle_visibility(Extremity.PRE_START)
 
     def update_post_end(self):
-        self.update_frame_handle_position(Extremity.POST_END, self.get_data('level'), self.timeline_ui.get_data('height'), self.end_x)
+        self.update_frame_handle_position(
+            Extremity.POST_END,
+            self.get_data("level"),
+            self.timeline_ui.get_data("height"),
+            self.end_x,
+        )
         if self.is_selected():
             self.update_frame_handle_visibility(Extremity.POST_END)
 
@@ -293,7 +303,7 @@ class HierarchyUI(TimelineUIElement):
         start_x = self.start_x
         end_x = self.end_x
         level = self.get_data("level")
-        height = self.timeline_ui.get_data('height')
+        height = self.timeline_ui.get_data("height")
 
         self.update_body_position(level, height, start_x, end_x)
         self.update_comments_icon_position(level, height, end_x)
@@ -312,14 +322,10 @@ class HierarchyUI(TimelineUIElement):
         )
 
     def update_comments_icon_position(self, level, height, end_x):
-        self.comments_icon.set_position(
-            end_x, level, height
-        )
+        self.comments_icon.set_position(end_x, level, height)
 
     def update_loop_icon_position(self, level, height, start_x):
-        self.loop_icon.set_position(
-           start_x, height, level
-        )
+        self.loop_icon.set_position(start_x, height, level)
 
     def update_label_position(self, level, height, start_x, end_x):
         self.label.set_position(
@@ -418,7 +424,9 @@ class HierarchyUI(TimelineUIElement):
             self.scene.addItem(self.end_handle)
 
     def _setup_frame_handles(self):
-        y = self.frame_handle_y(self.get_data("level"), self.timeline_ui.get_data("height"))
+        y = self.frame_handle_y(
+            self.get_data("level"), self.timeline_ui.get_data("height")
+        )
         self.pre_start_handle = HierarchyFrameHandle(self.start_x, self.pre_start_x, y)
         self.scene.addItem(self.pre_start_handle)
 

--- a/tilia/ui/timelines/hierarchy/element.py
+++ b/tilia/ui/timelines/hierarchy/element.py
@@ -102,19 +102,12 @@ class HierarchyUI(TimelineUIElement):
         "color",
     ]
     CONTEXT_MENU_CLASS = HierarchyContextMenu
+    FONT_METRICS = QFontMetrics(QFont("Arial", 10))
 
-    def __init__(
-        self,
-        id: int,
-        timeline_ui: HierarchyTimelineUI,
-        scene: QGraphicsScene,
-        **_,
-    ):
-        super().__init__(id=id, timeline_ui=timeline_ui, scene=scene)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.previous_width = 0
-        self.timeline_ui = timeline_ui
-        self.scene = scene
 
         self.label_substrings_widths: list[int] = []
 
@@ -146,14 +139,6 @@ class HierarchyUI(TimelineUIElement):
         return settings.get("hierarchy_timeline", "default_colors")
 
     @property
-    def start_x(self):
-        return coords.get_x_by_time(self.get_data("start"))
-
-    @property
-    def end_x(self):
-        return coords.get_x_by_time(self.get_data("end"))
-
-    @property
     def has_pre_start(self):
         return self.get_data("pre_start") != self.get_data("start")
 
@@ -163,16 +148,15 @@ class HierarchyUI(TimelineUIElement):
 
     @property
     def pre_start_x(self):
-        return coords.get_x_by_time(self.get_data("pre_start"))
+        return self.timeline_ui.time_x_converter.get_x_by_time(self.get_data("pre_start"))
 
     @property
     def post_end_x(self):
-        return coords.get_x_by_time(self.get_data("post_end"))
+        return self.timeline_ui.time_x_converter.get_x_by_time(self.get_data("post_end"))
 
-    @property
-    def frame_handle_y(self):
-        return self.timeline_ui.get_data("height") - (
-            self.base_height + (self.get_data("level") - 1.5) * self.x_increment_per_lvl
+    def frame_handle_y(self, level, tl_height):
+        return tl_height - (
+            self.base_height + (level - 1.5) * self.x_increment_per_lvl
         )
 
     @property
@@ -192,22 +176,21 @@ class HierarchyUI(TimelineUIElement):
     def seek_time(self):
         return self.get_data("pre_start")
 
-    @property
-    def cropped_label(self):
+    def get_cropped_label(self, start_x, end_x, label):
         """
         Returns largest substring of self.label that fits inside body
         """
 
-        if not self.get_data("label"):
+        if not label:
             return ""
 
-        max_width = self.end_x - self.start_x
+        max_width = end_x - start_x
 
         for i, width in enumerate(self.label_substrings_widths):
             if width > max_width:
-                return self.get_data("label")[:i]
+                return label[:i]
 
-        return self.get_data("label")
+        return label
 
     @property
     def full_name(self) -> str:
@@ -242,15 +225,28 @@ class HierarchyUI(TimelineUIElement):
             self.post_end_handle.horizontal_line,
         ]
 
-    def update_label_substrings_widths(self):
+    def update_label_substrings_widths(self, value):
         """
-        Calculates length of substrings of label and stores it in self.label_measures
+        Calculates and stores width of substrings of 'value'
         """
         font_metrics = QFontMetrics(QFont("Arial", 10))
         self.label_substrings_widths = [
-            font_metrics.horizontalAdvance(self.get_data("label")[: i + 1])
-            for i in range(len(self.get_data("label")))
+            font_metrics.horizontalAdvance(value[: i + 1])
+            for i in range(len(value))
         ]
+
+    def update(self, attr: str, value):
+        if attr not in self.UPDATE_TRIGGERS:
+            return
+
+        update_func_name = "update_" + attr
+        if not hasattr(self, update_func_name):
+            raise ValueError(f"{self} has no updater function for attribute '{attr}'")
+
+        # if attr == "label":
+        #     self.update_label(value)
+        # else:
+        getattr(self, update_func_name)()
 
     def update_color(self):
         self.body.set_fill(self.ui_color)
@@ -258,10 +254,20 @@ class HierarchyUI(TimelineUIElement):
     def update_comments(self):
         self.comments_icon.setVisible(bool(self.get_data("comments")))
 
-    def update_label(self):
-        self.update_label_substrings_widths()
-        self.label.set_text(self.cropped_label)
-        self.update_label_position()
+    def update_label(self, start_x=None, end_x=None, level=None, height=None):
+        # if called from update_position,
+        # start_x and end_x will already be available
+        start_x = start_x or self.start_x
+        end_x = end_x or self.end_x
+        level = level or self.get_data("level")
+        height = height or self.timeline_ui.get_data('height')
+
+        new_label = self.get_data('label')
+        if new_label != self.label.toPlainText():
+            self.update_label_substrings_widths(new_label)
+
+        self.label.set_text(self.get_cropped_label(start_x, end_x, new_label))
+        self.update_label_position(level, height, start_x, end_x)
 
     def update_level(self):
         self.update_position()
@@ -274,71 +280,76 @@ class HierarchyUI(TimelineUIElement):
         self.update_position()
 
     def update_pre_start(self):
-        self.update_frame_handle_position(Extremity.PRE_START)
+        self.update_frame_handle_position(Extremity.PRE_START, self.get_data('level'), self.timeline_ui.get_data('height'), self.start_x)
         if self.is_selected():
             self.update_frame_handle_visibility(Extremity.PRE_START)
 
     def update_post_end(self):
-        self.update_frame_handle_position(Extremity.POST_END)
+        self.update_frame_handle_position(Extremity.POST_END, self.get_data('level'), self.timeline_ui.get_data('height'), self.end_x)
         if self.is_selected():
             self.update_frame_handle_visibility(Extremity.POST_END)
 
     def update_position(self):
-        self.update_body_position()
-        self.update_comments_icon_position()
-        self.update_loop_icon_position()
-        self.update_label_position()
-        self.update_label()
-        self.update_body_handles_position()
-        self.update_frame_handles_position()
+        start_x = self.start_x
+        end_x = self.end_x
+        level = self.get_data("level")
+        height = self.timeline_ui.get_data('height')
 
-    def update_body_position(self):
+        self.update_body_position(level, height, start_x, end_x)
+        self.update_comments_icon_position(level, height, end_x)
+        self.update_loop_icon_position(level, height, start_x)
+        self.update_label_position(level, height, start_x, end_x)
+        self.update_label(start_x, end_x, level, height)
+        self.update_body_handles_position(height, start_x, end_x)
+        self.update_frame_handles_position(level, height, start_x, end_x)
+
+    def update_body_position(self, level, height, start_x, end_x):
         self.body.set_position(
-            self.get_data("level"),
-            self.start_x,
-            self.end_x,
-            self.timeline_ui.get_data("height"),
+            level,
+            start_x,
+            end_x,
+            height,
         )
 
-    def update_comments_icon_position(self):
+    def update_comments_icon_position(self, level, height, end_x):
         self.comments_icon.set_position(
-            self.end_x, self.timeline_ui.get_data("height"), self.get_data("level")
+            end_x, level, height
         )
 
-    def update_loop_icon_position(self):
+    def update_loop_icon_position(self, level, height, start_x):
         self.loop_icon.set_position(
-            self.start_x, self.timeline_ui.get_data("height"), self.get_data("level")
+           start_x, height, level
         )
 
-    def update_label_position(self):
+    def update_label_position(self, level, height, start_x, end_x):
         self.label.set_position(
-            (self.start_x + self.end_x) / 2,
-            self.timeline_ui.get_data("height"),
-            self.get_data("level"),
+            (start_x + end_x) / 2,
+            height,
+            level,
         )
 
-    def update_body_handles_position(self):
+    def update_body_handles_position(self, height, start_x, end_x):
         for extremity in [Extremity.START, Extremity.END]:
             self.extremity_to_handle(extremity).set_position(
-                self.extremity_to_x(extremity),
+                self.extremity_to_x(extremity, start_x, end_x),
                 self.HANDLE_WIDTH,
                 self.handle_height,
-                self.timeline_ui.get_data("height"),
+                height,
                 self.HANDLE_Y_MARGIN,
             )
 
-    def update_frame_handles_position(self):
-        self.update_frame_handle_position(Extremity.PRE_START)
-        self.update_frame_handle_position(Extremity.POST_END)
+    def update_frame_handles_position(self, level, height, start_x, end_x):
+        self.update_frame_handle_position(Extremity.PRE_START, level, height, start_x)
+        self.update_frame_handle_position(Extremity.POST_END, level, height, end_x)
 
-    def update_frame_handle_position(self, extremity: Extremity):
+    def update_frame_handle_position(self, extremity: Extremity, level, height, body_x):
         if extremity == Extremity.PRE_START:
             self.pre_start_handle.set_position(
-                self.start_x, self.pre_start_x, self.frame_handle_y
+                body_x, self.pre_start_x, self.frame_handle_y(level, height)
             )
         elif extremity == Extremity.POST_END:
             self.post_end_handle.set_position(
-                self.end_x, self.post_end_x, self.frame_handle_y
+                body_x, self.post_end_x, self.frame_handle_y(level, height)
             )
         else:
             raise ValueError("Unrecognized extremity")
@@ -369,12 +380,12 @@ class HierarchyUI(TimelineUIElement):
         self.scene.addItem(self.body)
 
     def _setup_label(self):
-        self.update_label_substrings_widths()
+        self.update_label_substrings_widths(self.get_data("label"))
         self.label = HierarchyLabel(
             (self.start_x + self.end_x) / 2,
             self.timeline_ui.get_data("height"),
             self.get_data("level"),
-            self.cropped_label,
+            self.get_cropped_label(self.start_x, self.end_x, self.get_data("label")),
         )
         self.scene.addItem(self.label)
 
@@ -407,7 +418,7 @@ class HierarchyUI(TimelineUIElement):
             self.scene.addItem(self.end_handle)
 
     def _setup_frame_handles(self):
-        y = self.frame_handle_y
+        y = self.frame_handle_y(self.get_data("level"), self.timeline_ui.get_data("height"))
         self.pre_start_handle = HierarchyFrameHandle(self.start_x, self.pre_start_x, y)
         self.scene.addItem(self.pre_start_handle)
 
@@ -450,17 +461,17 @@ class HierarchyUI(TimelineUIElement):
         except KeyError:
             raise ValueError(f"{handle} if not a handle of {self}")
 
-    def extremity_to_x(self, extremity: Extremity):
+    def extremity_to_x(self, extremity: Extremity, start_x, end_x):
         if extremity == Extremity.START:
-            return self.start_x
+            return start_x
         elif extremity == Extremity.END:
-            return self.end_x
+            return end_x
         else:
             raise ValueError("Unrecognized extremity")
 
     def _setup_handle(self, extremity: Extremity):
         return HierarchyBodyHandle(
-            self.extremity_to_x(extremity),
+            self.extremity_to_x(extremity, self.start_x, self.end_x),
             self.HANDLE_WIDTH,
             self.handle_height,
             self.timeline_ui.get_data("height"),
@@ -723,7 +734,8 @@ class HierarchyLabel(CursorMixIn, QGraphicsTextItem):
         self.setZValue(level + 1)
 
     def set_text(self, value: str):
-        self.setPlainText(value)
+        if value != self.toPlainText():
+            self.setPlainText(value)
 
 
 class HierarchyCommentsIcon(CursorMixIn, QGraphicsTextItem):

--- a/tilia/ui/timelines/hierarchy/element.py
+++ b/tilia/ui/timelines/hierarchy/element.py
@@ -21,9 +21,9 @@ from .drag import start_drag
 from .extremity import Extremity
 from .handles import HierarchyBodyHandle, HierarchyFrameHandle
 from ..cursors import CursorMixIn
-from ... import coords
 from ...color import get_tinted_color, get_untinted_color
 from ...consts import TINT_FACTOR_ON_SELECTION
+from ...coords import time_x_converter
 from ...windows.inspect import HIDE_FIELD, InspectRowKind
 
 if TYPE_CHECKING:
@@ -147,15 +147,11 @@ class HierarchyUI(TimelineUIElement):
 
     @property
     def pre_start_x(self):
-        return self.timeline_ui.time_x_converter.get_x_by_time(
-            self.get_data("pre_start")
-        )
+        return time_x_converter.get_x_by_time(self.get_data("pre_start"))
 
     @property
     def post_end_x(self):
-        return self.timeline_ui.time_x_converter.get_x_by_time(
-            self.get_data("post_end")
-        )
+        return time_x_converter.get_x_by_time(self.get_data("post_end"))
 
     def frame_handle_y(self, level, tl_height):
         return tl_height - (self.base_height + (level - 1.5) * self.x_increment_per_lvl)

--- a/tilia/ui/timelines/hierarchy/timeline.py
+++ b/tilia/ui/timelines/hierarchy/timeline.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from tilia.requests import get, Get, Post, listen
+from tilia.requests import get, Get, Post, listen, stop_listening_to_all
 from tilia.timelines.hierarchy.common import (
     update_component_genealogy,
 )
@@ -33,15 +33,15 @@ class HierarchyTimelineUI(TimelineUI):
         super().__init__(*args, **kwargs)
         listen(self, Post.SETTINGS_UPDATED, lambda updated_settings: self.on_settings_updated(updated_settings))
 
-    def on_settings_updated(self, updated_settings):        
+    def on_settings_updated(self, updated_settings):
         if "hierarchy_timeline" in updated_settings:
             get(Get.TIMELINE_COLLECTION).set_timeline_data(self.id, "height", self.timeline.default_height)
             for hierarchy_ui in self:
                 hierarchy_ui.update_position()
-                hierarchy_ui.update_color()            
+                hierarchy_ui.update_color()
 
     def on_timeline_element_request(
-        self, request, selector: ElementSelector, *args, **kwargs
+            self, request, selector: ElementSelector, *args, **kwargs
     ):
         return HierarchyUIRequestHandler(self).on_request(
             request, selector, *args, **kwargs
@@ -68,7 +68,7 @@ class HierarchyTimelineUI(TimelineUI):
             )
 
     def get_units_sharing_handle(
-        self, handle: HierarchyBodyHandle
+            self, handle: HierarchyBodyHandle
     ) -> list[HierarchyBodyHandle]:
         def is_using_handle(e: HierarchyUI):
             return e.start_handle == handle or e.end_handle == handle
@@ -111,11 +111,11 @@ class HierarchyTimelineUI(TimelineUI):
             self.select_element(element)
 
     def _create_child_from_paste_data(
-        self,
-        new_parent: HierarchyUI,
-        prev_parent_start: float,
-        prev_parent_end: float,
-        child_pastedata_: dict,
+            self,
+            new_parent: HierarchyUI,
+            prev_parent_start: float,
+            prev_parent_end: float,
+            child_pastedata_: dict,
     ):
 
         new_parent_length = new_parent.tl_component.end - new_parent.tl_component.start
@@ -124,20 +124,20 @@ class HierarchyTimelineUI(TimelineUI):
         scale_factor = new_parent_length / prev_parent_length
 
         relative_child_start = (
-            child_pastedata_["support_by_component_value"]["start"] - prev_parent_start
+                child_pastedata_["support_by_component_value"]["start"] - prev_parent_start
         )
 
         new_child_start = (
-            relative_child_start * scale_factor
-        ) + new_parent.tl_component.start
+                                  relative_child_start * scale_factor
+                          ) + new_parent.tl_component.start
 
         relative_child_end = (
-            child_pastedata_["support_by_component_value"]["end"] - prev_parent_end
+                child_pastedata_["support_by_component_value"]["end"] - prev_parent_end
         )
 
         new_child_end = (
-            relative_child_end * scale_factor
-        ) + new_parent.tl_component.end
+                                relative_child_end * scale_factor
+                        ) + new_parent.tl_component.end
 
         component, _ = self.timeline.create_timeline_component(
             kind=ComponentKind.HIERARCHY,
@@ -173,12 +173,12 @@ class HierarchyTimelineUI(TimelineUI):
             update_component_genealogy(element.tl_component, children_of_element)
 
     def paste_with_children_into_elements(
-        self, elements: list[HierarchyUI], data: list[dict]
+            self, elements: list[HierarchyUI], data: list[dict]
     ):
         def get_descendants(parent: HierarchyUI):
             is_in_branch = (
                 lambda e: e.tl_component.start >= parent.tl_component.start
-                and e.tl_component.end <= parent.tl_component.end
+                          and e.tl_component.end <= parent.tl_component.end
             )
             elements_in_branch = self.element_manager.get_elements_by_condition(
                 is_in_branch

--- a/tilia/ui/timelines/marker/element.py
+++ b/tilia/ui/timelines/marker/element.py
@@ -17,7 +17,7 @@ from ..drag import DragManager
 from ...color import get_tinted_color
 from ...format import format_media_time
 from ...consts import TINT_FACTOR_ON_SELECTION
-from ...coords import get_x_by_time, get_time_by_x
+from ...coords import time_x_converter
 from tilia.settings import settings
 from tilia.ui.timelines.base.element import TimelineUIElement
 from ...windows.inspect import InspectRowKind
@@ -142,7 +142,7 @@ class MarkerUI(TimelineUIElement):
             self.dragged = True
 
     def after_each_drag(self, drag_x: int):
-        self.set_data("time", get_time_by_x(drag_x))
+        self.set_data("time", time_x_converter.get_time_by_x(drag_x))
 
     def on_drag_end(self):
         if self.dragged:

--- a/tilia/ui/timelines/marker/element.py
+++ b/tilia/ui/timelines/marker/element.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable
 
 from PyQt6.QtCore import QPointF, Qt
 from PyQt6.QtGui import QPolygonF, QPen, QColor, QFont
@@ -49,14 +49,9 @@ class MarkerUI(TimelineUIElement):
 
     CONTEXT_MENU_CLASS = MarkerContextMenu
 
-    def __init__(
-        self,
-        id: int,
-        timeline_ui: MarkerTimelineUI,
-        scene: QGraphicsScene,
-        **_,
-    ):
-        super().__init__(id=id, timeline_ui=timeline_ui, scene=scene)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self._setup_body()
         self._setup_label()
@@ -71,10 +66,6 @@ class MarkerUI(TimelineUIElement):
     def _setup_label(self):
         self.label = MarkerLabel(self.x, self.label_y, self.get_data("label"))
         self.scene.addItem(self.label)
-
-    @property
-    def x(self):
-        return get_x_by_time(self.get_data("time"))
 
     @property
     def label_y(self):
@@ -116,8 +107,9 @@ class MarkerUI(TimelineUIElement):
         self.update_time()
 
     def update_time(self):
-        self.body.set_position(self.x, self.width, self.height)
-        self.label.set_position(self.x, self.label_y)
+        x = self.x
+        self.body.set_position(x, self.width, self.height)
+        self.label.set_position(x, self.label_y)
 
     def child_items(self):
         return [self.body, self.label]

--- a/tilia/ui/timelines/marker/element.py
+++ b/tilia/ui/timelines/marker/element.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any, Callable
 from PyQt6.QtCore import QPointF, Qt
 from PyQt6.QtGui import QPolygonF, QPen, QColor, QFont
 from PyQt6.QtWidgets import (
-    QGraphicsScene,
     QGraphicsItem,
     QGraphicsPolygonItem,
     QGraphicsTextItem,
@@ -49,7 +48,6 @@ class MarkerUI(TimelineUIElement):
 
     CONTEXT_MENU_CLASS = MarkerContextMenu
 
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -74,11 +72,11 @@ class MarkerUI(TimelineUIElement):
     @property
     def seek_time(self):
         return self.get_data("time")
-    
+
     @property
     def width(self):
         return settings.get("marker_timeline", "marker_width")
-    
+
     @property
     def height(self):
         return settings.get("marker_timeline", "marker_height")

--- a/tilia/ui/timelines/pdf/element.py
+++ b/tilia/ui/timelines/pdf/element.py
@@ -25,7 +25,7 @@ from ..copy_paste import CopyAttributes
 from ..cursors import CursorMixIn
 from ..drag import DragManager
 from ...format import format_media_time
-from ...coords import get_x_by_time, get_time_by_x
+from ...coords import time_x_converter
 from tilia.ui.timelines.base.element import TimelineUIElement
 from ...windows.inspect import InspectRowKind
 
@@ -127,7 +127,7 @@ class PdfMarkerUI(TimelineUIElement):
             self.dragged = True
 
     def after_each_drag(self, drag_x: int):
-        self.set_data("time", get_time_by_x(drag_x))
+        self.set_data("time", time_x_converter.get_time_by_x(drag_x))
 
     def on_drag_end(self):
         if self.dragged:

--- a/tilia/ui/timelines/pdf/element.py
+++ b/tilia/ui/timelines/pdf/element.py
@@ -13,7 +13,6 @@ from PyQt6.QtGui import (
     QFontMetrics,
 )
 from PyQt6.QtWidgets import (
-    QGraphicsScene,
     QGraphicsItem,
     QGraphicsTextItem,
     QGraphicsPixmapItem,

--- a/tilia/ui/timelines/pdf/element.py
+++ b/tilia/ui/timelines/pdf/element.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Any
 import logging
 
 from PyQt6.QtCore import QPointF, Qt
@@ -54,14 +54,8 @@ class PdfMarkerUI(TimelineUIElement):
 
     CONTEXT_MENU_CLASS = PdfMarkerContextMenu
 
-    def __init__(
-        self,
-        id: int,
-        timeline_ui: PdfTimelineUI,
-        scene: QGraphicsScene,
-        **_,
-    ):
-        super().__init__(id=id, timeline_ui=timeline_ui, scene=scene)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.INSPECTOR_FIELDS = [
             (
@@ -85,10 +79,6 @@ class PdfMarkerUI(TimelineUIElement):
         self.scene.addItem(self.label)
 
     @property
-    def x(self):
-        return get_x_by_time(self.get_data("time"))
-
-    @property
     def seek_time(self):
         return self.get_data("time")
 
@@ -100,8 +90,9 @@ class PdfMarkerUI(TimelineUIElement):
         self.update_time()
 
     def update_time(self):
-        self.body.set_position(self.x)
-        self.label.set_position(self.x)
+        x = self.x
+        self.body.set_position(x)
+        self.label.set_position(x)
 
     def update_page_number(self):
         self.label.set_text(str(self.get_data("page_number")))

--- a/tilia/ui/timelines/pdf/timeline.py
+++ b/tilia/ui/timelines/pdf/timeline.py
@@ -14,6 +14,7 @@ from tilia.timelines.component_kinds import ComponentKind
 from tilia.requests import Get, get, listen, Post
 from tilia.enums import Side
 from tilia.timelines.timeline_kinds import TimelineKind
+from tilia.ui.coords import TimeXConverter
 from tilia.ui.timelines.base.element import TimelineUIElement
 from tilia.ui.timelines.base.timeline import (
     TimelineUI,
@@ -53,8 +54,9 @@ class PdfTimelineUI(TimelineUI):
         element_manager: ElementManager,
         scene: TimelineScene,
         view: TimelineView,
+        time_x_converter: TimeXConverter | None = None,
     ):
-        super().__init__(id, collection, element_manager, scene, view)
+        super().__init__(id, collection, element_manager, scene, view, time_x_converter)
 
         self._setup_pdf_document()
         self._load_pdf_file()
@@ -107,8 +109,8 @@ class PdfTimelineUI(TimelineUI):
             request, selector, *args, **kwargs
         )
 
-    def on_timeline_component_created(self, kind: ComponentKind, id: int):
-        super().on_timeline_component_created(kind, id)
+    def on_timeline_component_created(self, kind: ComponentKind, id: int, get_data, set_data):
+        super().on_timeline_component_created(kind, id, get_data, set_data)
         self.update_displayed_page(get(Get.MEDIA_CURRENT_TIME))
 
     def on_timeline_component_deleted(self, id: int):

--- a/tilia/ui/timelines/pdf/timeline.py
+++ b/tilia/ui/timelines/pdf/timeline.py
@@ -14,7 +14,6 @@ from tilia.timelines.component_kinds import ComponentKind
 from tilia.requests import Get, get, listen, Post
 from tilia.enums import Side
 from tilia.timelines.timeline_kinds import TimelineKind
-from tilia.ui.coords import TimeXConverter
 from tilia.ui.timelines.base.element import TimelineUIElement
 from tilia.ui.timelines.base.timeline import (
     TimelineUI,
@@ -54,9 +53,8 @@ class PdfTimelineUI(TimelineUI):
         element_manager: ElementManager,
         scene: TimelineScene,
         view: TimelineView,
-        time_x_converter: TimeXConverter | None = None,
     ):
-        super().__init__(id, collection, element_manager, scene, view, time_x_converter)
+        super().__init__(id, collection, element_manager, scene, view)
 
         self._setup_pdf_document()
         self._load_pdf_file()
@@ -109,7 +107,9 @@ class PdfTimelineUI(TimelineUI):
             request, selector, *args, **kwargs
         )
 
-    def on_timeline_component_created(self, kind: ComponentKind, id: int, get_data, set_data):
+    def on_timeline_component_created(
+        self, kind: ComponentKind, id: int, get_data, set_data
+    ):
         super().on_timeline_component_created(kind, id, get_data, set_data)
         self.update_displayed_page(get(Get.MEDIA_CURRENT_TIME))
 

--- a/tilia/ui/timelines/slider/timeline.py
+++ b/tilia/ui/timelines/slider/timeline.py
@@ -9,12 +9,10 @@ from PyQt6.QtWidgets import (
     QGraphicsDropShadowEffect,
 )
 
-import tilia.ui.coords
 from tilia.media.player.base import MediaTimeChangeReason
 from tilia.requests import get, Get, post
 from tilia.timelines.component_kinds import ComponentKind
 from tilia.timelines.timeline_kinds import TimelineKind
-from tilia.ui import coords
 from tilia.ui.modifier_enum import ModifierEnum
 from tilia.settings import settings
 from tilia.requests import Post, listen
@@ -23,7 +21,7 @@ from tilia.ui.timelines.base.timeline import TimelineUI
 from tilia.ui.timelines.base.element_manager import ElementManager
 from tilia.ui.timelines.drag import DragManager
 from tilia.ui.timelines.view import TimelineView
-from tilia.ui.coords import TimeXConverter
+from tilia.ui.coords import time_x_converter
 from ..cursors import CursorMixIn
 
 if TYPE_CHECKING:
@@ -44,7 +42,6 @@ class SliderTimelineUI(TimelineUI):
         element_manager: ElementManager,
         scene: TimelineScene,
         view: TimelineView,
-        time_x_converter: TimeXConverter | None = None,
     ):
         super().__init__(
             id=id,
@@ -52,7 +49,6 @@ class SliderTimelineUI(TimelineUI):
             element_manager=element_manager,
             scene=scene,
             view=view,
-            time_x_converter=time_x_converter,
         )
 
         listen(self, Post.PLAYER_CURRENT_TIME_CHANGED, self.on_audio_time_change)
@@ -131,7 +127,7 @@ class SliderTimelineUI(TimelineUI):
         self, item_id: int, modifier: ModifierEnum, double: bool, x: int, y: int
     ) -> None:
         if item_id == self.line:
-            time = tilia.ui.coords.get_time_by_x(x)
+            time = time_x_converter.get_time_by_x(x)
             if double:
                 post(Post.PLAYER_SEEK, time)
             else:
@@ -159,13 +155,15 @@ class SliderTimelineUI(TimelineUI):
         post(Post.SLIDER_DRAG, x)
 
     def on_drag_end(self):
-        post(Post.PLAYER_SEEK, coords.get_time_by_x(self.x))  # maybe not necessary
+        post(
+            Post.PLAYER_SEEK, time_x_converter.get_time_by_x(self.x)
+        )  # maybe not necessary
         self.dragging = False
         post(Post.SLIDER_DRAG_END)
 
     def on_audio_time_change(self, time: float, _: MediaTimeChangeReason) -> None:
         if not self.dragging:
-            self.x = coords.get_x_by_time(time)
+            self.x = time_x_converter.get_x_by_time(time)
             self.set_trough_position()
 
     def get_ui_for_component(
@@ -174,7 +172,7 @@ class SliderTimelineUI(TimelineUI):
         """No components in SliderTimeline. Must implement abstract method."""
 
     def update_items_position(self):
-        self.x = coords.get_x_by_time(get(Get.MEDIA_CURRENT_TIME))
+        self.x = time_x_converter.get_x_by_time(get(Get.MEDIA_CURRENT_TIME))
         self.set_trough_position()
         self.line.set_position(*self._get_line_pos_args())
 

--- a/tilia/ui/timelines/slider/timeline.py
+++ b/tilia/ui/timelines/slider/timeline.py
@@ -23,6 +23,7 @@ from tilia.ui.timelines.base.timeline import TimelineUI
 from tilia.ui.timelines.base.element_manager import ElementManager
 from tilia.ui.timelines.drag import DragManager
 from tilia.ui.timelines.view import TimelineView
+from tilia.ui.coords import TimeXConverter
 from ..cursors import CursorMixIn
 
 if TYPE_CHECKING:
@@ -43,6 +44,7 @@ class SliderTimelineUI(TimelineUI):
         element_manager: ElementManager,
         scene: TimelineScene,
         view: TimelineView,
+        time_x_converter: TimeXConverter | None = None,
     ):
         super().__init__(
             id=id,
@@ -50,6 +52,7 @@ class SliderTimelineUI(TimelineUI):
             element_manager=element_manager,
             scene=scene,
             view=view,
+            time_x_converter=time_x_converter,
         )
 
         listen(self, Post.PLAYER_CURRENT_TIME_CHANGED, self.on_audio_time_change)


### PR DESCRIPTION
This was actually easier than I expected. I guess there's a first time for everything.

I managed to get the zooming time in a large file (the Amy Beach proof-of-concept) down from ~0.9s to ~0.05s. Some caching, avoding using Get by passing some references around did the trick. There's ceratinly more time to be shaved off if we decide that's necessary.

Maybe Python is fast enough for what we need, after all.