### PR TITLE
Fix inspect hierarchy

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -257,7 +257,7 @@ def user_actions():
 
 def parametrize_tl(func):
     """Adds a parameter 'tl' to a test that receives the name of a fixture that returns a component.
-     To get the timeline from inside the test, add the `request` fixture to its arguments and
+     To get the timeline from within the test, add the `request` fixture to its arguments and
      run `request.getfixturevalue('tl')`"""
     @pytest.mark.parametrize('tl', ['audiowave_tl', 'beat_tl', 'harmony_tl', 'hierarchy_tl', 'marker_tl', 'pdf_tl', 'slider_tl'])
     @functools.wraps(func)  # Preserve original function metadata
@@ -268,7 +268,7 @@ def parametrize_tl(func):
 
 def parametrize_tlui(func):
     """Adds a parameter 'tlui' to a test that receives the name of a fixture that returns a component.
-     To get the timeline from inside the test, add the `request` fixture to its arguments and
+     To get the timeline ui from within the test, add the `request` fixture to its arguments and
      run `request.getfixturevalue('tlui')`"""
     @pytest.mark.parametrize('tlui', ['audiowave_tlui', 'beat_tlui', 'harmony_tlui', 'hierarchy_tlui', 'marker_tlui', 'pdf_tlui', 'slider_tlui'])
     @functools.wraps(func)  # Preserve original function metadata
@@ -279,9 +279,21 @@ def parametrize_tlui(func):
 
 def parametrize_component(func):
     """Adds a parameter 'comp' to a test that receives the name of a fixture that returns a component.
-     To get the component from the test, add the `request` fixture to its arguments and
+     To get the component from within the test, add the `request` fixture to its arguments and
      run `request.getfixturevalue('comp')`"""
     @pytest.mark.parametrize('comp', ['amplitudebar', 'beat', 'harmony', 'hierarchy', 'marker', 'pdf_marker'])
+    @functools.wraps(func)  # Preserve original function metadata
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+    return wrapper
+
+
+def parametrize_ui_element(func):
+    """Adds a parameter 'comp' to a test that receives the name of a fixture that returns a ui element.
+     To get the element from within the test, add the `request` fixture to its arguments and
+     run `request.getfixturevalue('element')`.
+     Tests that use this must also request the `tluis` fixture, or another fixture that requires it."""
+    @pytest.mark.parametrize('element', ['amplitudebar_ui', 'beat_ui', 'harmony_ui', 'hierarchy_ui', 'marker_ui', 'pdf_marker_ui'])
     @functools.wraps(func)  # Preserve original function metadata
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)

--- a/tests/timelines/audiowave/fixtures.py
+++ b/tests/timelines/audiowave/fixtures.py
@@ -30,3 +30,8 @@ def audiowave_tl(tls):
 @pytest.fixture
 def amplitudebar(audiowave_tl):
     return audiowave_tl.create_amplitudebar(0, 1, 0.5)[0]
+
+
+@pytest.fixture
+def amplitudebar_ui(audiowave_tlui, amplitudebar):
+    return audiowave_tlui.get_element(amplitudebar.id)

--- a/tests/timelines/beat/fixtures.py
+++ b/tests/timelines/beat/fixtures.py
@@ -35,3 +35,8 @@ def beat_tl(tls):
 @pytest.fixture
 def beat(beat_tl):
     return beat_tl.create_beat(0)[0]
+
+
+@pytest.fixture()
+def beat_ui(beat_tlui, beat):
+    return beat_tlui.get_element(beat.id)

--- a/tests/timelines/harmony/fixtures.py
+++ b/tests/timelines/harmony/fixtures.py
@@ -63,10 +63,15 @@ def harmony(harmony_tl):
 
 
 @pytest.fixture
+def harmony_ui(harmony_tlui, harmony):
+    return harmony_tlui.get_element(harmony.id)
+
+
+@pytest.fixture
 def mode(harmony_tl):
     return harmony_tl.create_mode()[0]
 
 
 @pytest.fixture
-def har_and_ui(harmony_tlui):
-    return harmony_tlui.create_harmony(0)
+def mode_ui(mode_tlui, mode):
+    return mode_tlui.get_element(mode.id)

--- a/tests/timelines/hierarchy/fixtures.py
+++ b/tests/timelines/hierarchy/fixtures.py
@@ -47,3 +47,8 @@ def hierarchy_tl(tls):
 @pytest.fixture
 def hierarchy(hierarchy_tl):
     return hierarchy_tl.create_hierarchy(0, 1, 1)[0]
+
+
+@pytest.fixture
+def hierarchy_ui(hierarchy_tlui, hierarchy):
+    return hierarchy_tlui.get_element(hierarchy.id)

--- a/tests/timelines/marker/fixtures.py
+++ b/tests/timelines/marker/fixtures.py
@@ -38,5 +38,6 @@ def marker(marker_tlui):
 
 
 @pytest.fixture
-def mrk_and_ui(marker_tlui):
-    return marker_tlui.create_marker(0)
+def marker_ui(marker_tlui, marker):
+    return marker_tlui.get_element(marker.id)
+

--- a/tests/timelines/pdf/fixtures.py
+++ b/tests/timelines/pdf/fixtures.py
@@ -56,5 +56,6 @@ def pdf_marker(pdf_tl):
 
 
 @pytest.fixture
-def pdf_and_ui(pdf_tlui):
-    return pdf_tlui.create_pdf_marker(0)
+def pdf_marker_ui(pdf_tlui, pdf_marker):
+    return pdf_tlui.get_element(pdf_marker.id)
+

--- a/tests/ui/dialogs/test_inspect.py
+++ b/tests/ui/dialogs/test_inspect.py
@@ -1,0 +1,24 @@
+from tests.conftest import parametrize_ui_element
+from tilia.ui.actions import TiliaAction
+from tilia.ui.timelines.beat import BeatUI
+
+
+@parametrize_ui_element
+def test_inspect_elements(tluis, element, user_actions, request):
+    element = request.getfixturevalue(element)
+    element.timeline_ui.select_element(element)
+
+    user_actions.trigger(TiliaAction.TIMELINE_ELEMENT_INSPECT)
+
+
+@parametrize_ui_element
+def test_inspect_elements_with_beat_timeline(element, beat_tlui, user_actions, request):
+    # some properties are only displayed if a beat timeline is present
+    element = request.getfixturevalue(element)
+    if not isinstance(element, BeatUI):
+        for i in range(10):
+            beat_tlui.create_beat(i)
+
+    element.timeline_ui.select_element(element)
+
+    user_actions.trigger(TiliaAction.TIMELINE_ELEMENT_INSPECT)

--- a/tilia/ui/timelines/hierarchy/element.py
+++ b/tilia/ui/timelines/hierarchy/element.py
@@ -587,11 +587,11 @@ class HierarchyUI(TimelineUIElement):
 
     @property
     def metric_position_formatted(self):
-        start_measure, start_beat = self.get_data("start_metric_position")
-        end_measure, end_beat = self.get_data("end_metric_position")
-        if start_measure is None:
+        start_metric_position = self.get_data("start_metric_position")
+        end_metric_position = self.get_data("end_metric_position")
+        if not start_metric_position:
             return "-"
-        return f"{start_measure}.{start_beat} / {end_measure}.{end_beat}"
+        return f"{start_metric_position.measure}.{start_metric_position.beat} / {end_metric_position.measure}.{end_metric_position.beat}"
 
     def get_inspector_dict(self) -> dict:
         data = {


### PR DESCRIPTION
Inspecting a hierarchy was crashing because we forgot to update the `formated_metric_position` method. I also took the opportunity to create a `parametrize_ui_element` fixture.