### PR TITLE
Make zooming a lot faster

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,7 +8,7 @@ import pytest
 import tests.utils
 from tests.mock import Serve, PatchPost
 from tilia.media.player import YouTubePlayer, QtAudioPlayer
-from tilia.settings import settings_manager
+from tilia.settings import settings
 
 from tilia.requests import Get, Post, post
 from tilia.ui.actions import TiliaAction
@@ -306,7 +306,7 @@ class TestFileSetup:
 
 def assert_open_failed(tilia, tilia_errors, opened_file_path, prev_file):
     tilia_errors.assert_error()
-    assert settings_manager.get_recent_files()[0] != opened_file_path
+    assert settings.get_recent_files()[0] != opened_file_path
     assert tilia.file_manager.file == prev_file
 
 
@@ -336,7 +336,7 @@ class TestOpen:
         with Serve(Get.FROM_USER_TILIA_FILE_PATH, (True, tmp_file)):
             user_actions.trigger(TiliaAction.FILE_OPEN)
 
-        assert Path(settings_manager.get_recent_files()[0]) == tmp_file
+        assert Path(settings.get_recent_files()[0]) == tmp_file
         assert len(tls) == 2  # Slider timeline is also created by default
         assert len(tls[0]) == 3
 
@@ -344,7 +344,7 @@ class TestOpen:
         tmp_file = tests.utils.get_tmp_file_with_dummy_timeline(tmp_path)
         post(Post.FILE_OPEN, tmp_file)
 
-        assert Path(settings_manager.get_recent_files()[0]) == tmp_file
+        assert Path(settings.get_recent_files()[0]) == tmp_file
         assert len(tls) == 2  # Slider timeline is also created by default
 
     def test_open_file_does_not_exist(self, tilia, tmp_path, tilia_errors):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,8 +1,4 @@
-import itertools
 import json
-import math
-import operator
-from functools import reduce
 from pathlib import Path
 from typing import Literal
 from unittest.mock import patch
@@ -29,11 +25,11 @@ class TestSaveFileOnClose:
             "file_path": "",
         }
 
-    def test_no_changes(self, tilia, tls, user_actions):
+    def test_no_changes(self, user_actions):
         with (
             Serve(Get.FROM_USER_SHOULD_SAVE_CHANGES, (True, False)),
             patch("tilia.file.file_manager.FileManager.save") as save_mock,
-            PatchPost('tilia.app', Post.UI_EXIT) as exit_mock,
+            PatchPost("tilia.app", Post.UI_EXIT) as exit_mock,
         ):
             user_actions.trigger(TiliaAction.APP_CLOSE)
 
@@ -41,14 +37,14 @@ class TestSaveFileOnClose:
         save_mock.assert_not_called()
 
     def test_file_modified_and_user_chooses_to_save_changes(
-        self, tilia, user_actions, tmp_path
+        self, user_actions, tmp_path
     ):
         tmp_file = tmp_path / "test_file_modified_and_user_chooses_to_save_changes.tla"
         with (
             Serve(Get.APP_STATE, self._get_modified_file_state()),
             Serve(Get.FROM_USER_SHOULD_SAVE_CHANGES, (True, True)),
             Serve(Get.FROM_USER_SAVE_PATH_TILIA, (tmp_file, True)),
-            PatchPost('tilia.app', Post.UI_EXIT) as exit_mock,
+            PatchPost("tilia.app", Post.UI_EXIT) as exit_mock,
         ):
             user_actions.trigger(TiliaAction.APP_CLOSE)
 
@@ -56,7 +52,7 @@ class TestSaveFileOnClose:
         assert tmp_file.exists()
 
     def test_file_modified_and_user_chooses_to_save_changes_when_file_was_previously_saved(
-        self, tilia, user_actions, tmp_path
+        self, user_actions, tmp_path
     ):
         tmp_file = tmp_path / "test_file_modified_and_user_chooses_to_save_changes.tla"
         with (
@@ -67,7 +63,7 @@ class TestSaveFileOnClose:
 
         with (
             Serve(Get.FROM_USER_SHOULD_SAVE_CHANGES, (True, True)),
-            PatchPost('tilia.app', Post.UI_EXIT) as exit_mock,
+            PatchPost("tilia.app", Post.UI_EXIT) as exit_mock,
         ):
             user_actions.trigger(TiliaAction.APP_CLOSE)
 
@@ -75,26 +71,26 @@ class TestSaveFileOnClose:
         assert tmp_file.exists()
 
     def test_file_is_modified_and_user_cancels_close_on_should_save_changes_dialog(
-        self, tilia, user_actions
+        self, user_actions
     ):
         with (
             Serve(Get.APP_STATE, self._get_modified_file_state()),
             Serve(Get.FROM_USER_SHOULD_SAVE_CHANGES, (False, True)),
             patch("tilia.file.file_manager.FileManager.save") as save_mock,
-            PatchPost('tilia.app', Post.UI_EXIT) as exit_mock,
+            PatchPost("tilia.app", Post.UI_EXIT) as exit_mock,
         ):
             user_actions.trigger(TiliaAction.APP_CLOSE)
 
         exit_mock.assert_not_called()
         save_mock.assert_not_called()
 
-    def test_file_is_modified_and_user_cancels_file_save_dialog(self, tilia, user_actions):
+    def test_file_is_modified_and_user_cancels_file_save_dialog(self, user_actions):
         with (
             Serve(Get.APP_STATE, self._get_modified_file_state()),
             Serve(Get.FROM_USER_SHOULD_SAVE_CHANGES, (True, True)),
             Serve(Get.FROM_USER_SAVE_PATH_TILIA, ("", "")),
             patch("tilia.file.file_manager.FileManager.save") as save_mock,
-            PatchPost('tilia.app', Post.UI_EXIT) as exit_mock,
+            PatchPost("tilia.app", Post.UI_EXIT) as exit_mock,
         ):
             user_actions.trigger(TiliaAction.APP_CLOSE)
 
@@ -104,7 +100,7 @@ class TestSaveFileOnClose:
 
 class TestFileLoad:
     def test_media_path_does_not_exist_and_media_length_available(
-        self, tilia, tilia_state, tmp_path, tls, user_actions
+        self, tilia_state, tmp_path, user_actions
     ):
         file_data = tests.utils.get_blank_file_data()
         file_data["media_metadata"]["media length"] = 101
@@ -119,7 +115,7 @@ class TestFileLoad:
         assert tilia_state.duration == 101
 
     def test_media_path_does_not_exist_and_media_length_not_available(
-        self, tilia, tilia_state, tmp_path, tls, user_actions
+        self, tilia_state, tmp_path, user_actions
     ):
         tilia_state.duration = 0
         file_data = tests.utils.get_blank_file_data()
@@ -136,7 +132,9 @@ class TestFileLoad:
     def test_media_path_exists(self, tilia, tilia_state, tmp_path, tls, user_actions):
         file_data = tests.utils.get_blank_file_data()
         tmp_file = tmp_path / "test_file_load.tla"
-        media_path = str((Path(__file__).parent / "resources" / "example.ogg").resolve())
+        media_path = str(
+            (Path(__file__).parent / "resources" / "example.ogg").resolve()
+        )
         file_data["media_path"] = media_path
         file_data["media_metadata"]["media length"] = 101
         tmp_file.write_text(json.dumps(file_data))
@@ -156,7 +154,7 @@ class TestFileLoad:
         tmp_file.write_text(json.dumps(file_data))
         with (
             Serve(Get.FROM_USER_TILIA_FILE_PATH, (True, tmp_file)),
-            Serve(Get.PLAYER_CLASS, YouTubePlayer)
+            Serve(Get.PLAYER_CLASS, YouTubePlayer),
         ):
             user_actions.trigger(TiliaAction.FILE_OPEN)
 
@@ -166,11 +164,13 @@ class TestFileLoad:
 
 
 class TestMediaLoad:
-    EXAMPLE_PATH_OGG = str((Path(__file__).parent / 'resources' / 'example.ogg').resolve()).replace('\\', '/')
+    EXAMPLE_PATH_OGG = str(
+        (Path(__file__).parent / "resources" / "example.ogg").resolve()
+    ).replace("\\", "/")
     EXAMPLE_OGG_DURATION = 9.952
 
     @staticmethod
-    def _load_media(path, scale_timelines: Literal['yes', 'no', 'prompt'] = 'prompt'):
+    def _load_media(path, scale_timelines: Literal["yes", "no", "prompt"] = "prompt"):
         with Serve(Get.PLAYER_CLASS, QtAudioPlayer):
             post(Post.APP_MEDIA_LOAD, path, scale_timelines=scale_timelines)
 
@@ -195,97 +195,111 @@ class TestMediaLoad:
         tilia_errors.assert_in_error_message("xyz")
         assert not tilia_state.media_path
 
-    def test_load_invalid_extension_with_media_loaded(
-        self, tilia_state, tilia_errors
-    ):
+    def test_load_invalid_extension_with_media_loaded(self, tilia_state, tilia_errors):
         self._load_media(self.EXAMPLE_PATH_OGG)
         self._load_media("invalid.xyz")
         tilia_errors.assert_error()
         tilia_errors.assert_in_error_message("xyz")
         assert tilia_state.media_path == self.EXAMPLE_PATH_OGG
 
-    def test_load_media_after_loading_media_with_invalid_extension(
-        self, tilia_state, tilia_errors
-    ):
+    def test_load_media_after_loading_media_with_invalid_extension(self, tilia_state):
         self._load_media("invalid.xyz")
         self._load_media(self.EXAMPLE_PATH_OGG)
         assert tilia_state.media_path == self.EXAMPLE_PATH_OGG
 
-    def test_scale_timelines_is_no(self, tilia_state, marker_tl, user_actions):
+    def test_scale_timelines_is_no(self, marker_tl):
         marker_tl.create_marker(5)
         marker_tl.create_marker(10)
-        self._load_media(self.EXAMPLE_PATH_OGG, 'no')
+        self._load_media(self.EXAMPLE_PATH_OGG, "no")
         assert len(marker_tl) == 1
-        assert marker_tl[0].get_data('time') == 5
+        assert marker_tl[0].get_data("time") == 5
 
-    def test_scale_timelines_is_yes(self, tilia_state, marker_tl, user_actions):
+    def test_scale_timelines_is_yes(self, tilia_state, marker_tl):
         prev_duration = tilia_state.duration
         marker_tl.create_marker(50)
-        self._load_media(self.EXAMPLE_PATH_OGG, 'yes')
-        assert marker_tl[0].get_data('time') == 50 * self.EXAMPLE_OGG_DURATION / prev_duration
+        self._load_media(self.EXAMPLE_PATH_OGG, "yes")
+        assert (
+            marker_tl[0].get_data("time")
+            == 50 * self.EXAMPLE_OGG_DURATION / prev_duration
+        )
 
 
 class TestScaleCropTimeline:
-    @pytest.mark.parametrize('scale_timelines,scale_factor', [(('yes', 'yes'), (2, 2)), (('yes', 'no'), (2, 2)), (('no', 'yes'), (2, 2)), (('no', 'no'), (2, 2))])
-    def test_set_duration_twice_without_cropping(self, scale_timelines, scale_factor, tilia_state, marker_tlui,
-                                                 user_actions):
+    @pytest.mark.parametrize(
+        "scale_timelines,scale_factor",
+        [
+            (("yes", "yes"), (2, 2)),
+            (("yes", "no"), (2, 2)),
+            (("no", "yes"), (2, 2)),
+            (("no", "no"), (2, 2)),
+        ],
+    )
+    def test_set_duration_twice_without_cropping(
+        self, scale_timelines, scale_factor, tilia_state, marker_tlui, user_actions
+    ):
         marker_time = 50
         tilia_state.current_time = marker_time
         user_actions.trigger(TiliaAction.MARKER_ADD)
         displacement_factor = 1
         for factor, should_scale in zip(scale_factor, scale_timelines, strict=True):
-            tilia_state.set_duration(tilia_state.duration * factor, scale_timelines=should_scale)
-            if should_scale == 'yes':
+            tilia_state.set_duration(
+                tilia_state.duration * factor, scale_timelines=should_scale
+            )
+            if should_scale == "yes":
                 displacement_factor *= factor
-        assert marker_tlui[0].get_data('time') == marker_time * displacement_factor
+        assert marker_tlui[0].get_data("time") == marker_time * displacement_factor
 
     def test_scale_then_crop(self, marker_tl, tilia_state, user_actions):
         tilia_state.current_time = 10
         user_actions.trigger(TiliaAction.MARKER_ADD)
         tilia_state.current_time = 50
         user_actions.trigger(TiliaAction.MARKER_ADD)
-        tilia_state.set_duration(200, scale_timelines='yes')
-        tilia_state.set_duration(50, scale_timelines='no')
+        tilia_state.set_duration(200, scale_timelines="yes")
+        tilia_state.set_duration(50, scale_timelines="no")
         assert len(marker_tl) == 1
-        assert marker_tl[0].get_data('time') == 20
+        assert marker_tl[0].get_data("time") == 20
 
     def test_crop_then_scale(self, marker_tl, tilia_state, user_actions):
         tilia_state.current_time = 10
         user_actions.trigger(TiliaAction.MARKER_ADD)
         tilia_state.current_time = 50
         user_actions.trigger(TiliaAction.MARKER_ADD)
-        tilia_state.set_duration(40, scale_timelines='no')
-        tilia_state.set_duration(80, scale_timelines='yes')
+        tilia_state.set_duration(40, scale_timelines="no")
+        tilia_state.set_duration(80, scale_timelines="yes")
         assert len(marker_tl) == 1
-        assert marker_tl[0].get_data('time') == 20
+        assert marker_tl[0].get_data("time") == 20
 
     def test_crop_twice(self, marker_tlui, tilia_state, user_actions):
         tilia_state.current_time = 10
         user_actions.trigger(TiliaAction.MARKER_ADD)
         tilia_state.current_time = 50
         user_actions.trigger(TiliaAction.MARKER_ADD)
-        tilia_state.set_duration(80, scale_timelines='no')
-        tilia_state.set_duration(40, scale_timelines='no')
+        tilia_state.set_duration(80, scale_timelines="no")
+        tilia_state.set_duration(40, scale_timelines="no")
         assert len(marker_tlui) == 1
-        assert marker_tlui[0].get_data('time') == 10
+        assert marker_tlui[0].get_data("time") == 10
 
 
 class TestFileSetup:
-    def test_slider_timeline_is_created_when_loaded_file_does_not_have_one(self, tls, tmp_path, user_actions):
+    def test_slider_timeline_is_created_when_loaded_file_does_not_have_one(
+        self, tls, tmp_path, user_actions
+    ):
         file_data = tests.utils.get_blank_file_data()
-        file_data['timelines'] = {'1': {
-            'name': '',
-            'height': 40,
-            'is_visible': True,
-            'ordinal': 1,
-            'components': {},
-            'kind': 'HIERARCHY_TIMELINE'
-        }}  # empty hierarchy timeline
+        file_data["timelines"] = {
+            "1": {
+                "name": "",
+                "height": 40,
+                "is_visible": True,
+                "ordinal": 1,
+                "components": {},
+                "kind": "HIERARCHY_TIMELINE",
+            }
+        }  # empty hierarchy timeline
         tmp_file = tmp_path / "test_file_setup.tla"
         tmp_file.write_text(json.dumps(file_data))
         with Serve(Get.FROM_USER_TILIA_FILE_PATH, (True, tmp_file)):
             user_actions.trigger(TiliaAction.FILE_OPEN)
-            
+
         assert len(tls) == 2
         assert TimelineKind.SLIDER_TIMELINE in tls.timeline_kinds
 
@@ -360,7 +374,7 @@ class TestOpen:
         prev_file = tilia.file_manager.file
         tmp_file = tmp_path / "test.tla"
         file_data = tests.utils.get_blank_file_data()
-        file_data['timelines'] = {'nonsense': 404}
+        file_data["timelines"] = {"nonsense": 404}
         tmp_file.write_text(json.dumps(file_data))
         post(Post.FILE_OPEN, tmp_file)
 
@@ -429,7 +443,12 @@ class TestOpen:
             contents = json.load(f)  # read contents
 
         assert len(tls) == 2  # assert load was successful
-        assert contents['timelines'][str(prev_tl_id)]['components'][str(prev_marker_id)]['time'] == 10
+        assert (
+            contents["timelines"][str(prev_tl_id)]["components"][str(prev_marker_id)][
+                "time"
+            ]
+            == 10
+        )
 
     def test_open_without_saving_changes(self, tilia, tls, marker_tlui, tmp_path):
         previous_path = tmp_path / "previous.tla"
@@ -449,9 +468,11 @@ class TestOpen:
             contents = json.load(f)  # read contents
 
         assert len(tls) == 2  # assert load was successful
-        assert len(list(contents['timelines'][str(prev_tl_id)]['components'])) == 0
+        assert len(list(contents["timelines"][str(prev_tl_id)]["components"])) == 0
 
-    def test_open_canceling_should_save_changes_dialog(self, tilia, tls, marker_tlui, tmp_path):
+    def test_open_canceling_should_save_changes_dialog(
+        self, tilia, tls, marker_tlui, tmp_path
+    ):
         previous_path = tmp_path / "previous.tla"
         with Serve(Get.FROM_USER_SAVE_PATH_TILIA, (previous_path, True)):
             post(Post.FILE_SAVE)
@@ -472,9 +493,8 @@ class TestOpen:
         assert len(tls) == 1  # assert file wasn't opened
         assert tilia.get_app_state() == prev_state
 
-    def test_open_then_save(self, tilia, tmp_path, tilia_errors):
+    def test_open_then_save(self, tmp_path, tilia_errors):
         tmp_file = tests.utils.get_tmp_file_with_dummy_timeline(tmp_path)
         post(Post.FILE_OPEN, tmp_file)
         post(Post.FILE_SAVE)
         tilia_errors.assert_no_error()
-

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,7 +12,7 @@ import pytest
 import tests.utils
 from tests.mock import Serve, PatchPost
 from tilia.media.player import YouTubePlayer, QtAudioPlayer
-from tilia.settings import settings
+from tilia.settings import settings_manager
 
 from tilia.requests import Get, Post, post
 from tilia.ui.actions import TiliaAction
@@ -292,7 +292,7 @@ class TestFileSetup:
 
 def assert_open_failed(tilia, tilia_errors, opened_file_path, prev_file):
     tilia_errors.assert_error()
-    assert settings.get_recent_files()[0] != opened_file_path
+    assert settings_manager.get_recent_files()[0] != opened_file_path
     assert tilia.file_manager.file == prev_file
 
 
@@ -322,7 +322,7 @@ class TestOpen:
         with Serve(Get.FROM_USER_TILIA_FILE_PATH, (True, tmp_file)):
             user_actions.trigger(TiliaAction.FILE_OPEN)
 
-        assert Path(settings.get_recent_files()[0]) == tmp_file
+        assert Path(settings_manager.get_recent_files()[0]) == tmp_file
         assert len(tls) == 2  # Slider timeline is also created by default
         assert len(tls[0]) == 3
 
@@ -330,7 +330,7 @@ class TestOpen:
         tmp_file = tests.utils.get_tmp_file_with_dummy_timeline(tmp_path)
         post(Post.FILE_OPEN, tmp_file)
 
-        assert Path(settings.get_recent_files()[0]) == tmp_file
+        assert Path(settings_manager.get_recent_files()[0]) == tmp_file
         assert len(tls) == 2  # Slider timeline is also created by default
 
     def test_open_file_does_not_exist(self, tilia, tmp_path, tilia_errors):

--- a/tests/timelines/hierarchy/test_hierarchy_timeline.py
+++ b/tests/timelines/hierarchy/test_hierarchy_timeline.py
@@ -12,19 +12,6 @@ from tilia.timelines.timeline_kinds import TimelineKind
 from tilia.ui.timelines.hierarchy import HierarchyTimelineUI
 
 
-class HierarchyUIDummy:
-    def __init__(self, component, **kwargs):
-        self.tl_component = component
-        for attr, value in kwargs.items():
-            setattr(self, attr, value)
-
-    def update_position(self):
-        return
-
-    def process_color_before_level_change(self, *args, **kwargs):
-        return
-
-
 class DummyTimelines:
     ID_ITER = itertools.count()
 

--- a/tests/ui/timelines/beat/interact.py
+++ b/tests/ui/timelines/beat/interact.py
@@ -1,12 +1,12 @@
 from tests.ui.timelines.interact import click_timeline_ui_view
-from tilia.ui.coords import get_x_by_time
+from tilia.ui.coords import time_x_converter
 
 
 def click_beat_ui(beat_ui, button="left", modifier=None, double=False):
     click_timeline_ui_view(
         beat_ui.timeline_ui.view,
         button,
-        get_x_by_time(beat_ui.time),
+        time_x_converter.get_x_by_time(beat_ui.time),
         beat_ui.height / 2,
         beat_ui.body,
         modifier,

--- a/tests/ui/timelines/beat/test_beat_ui.py
+++ b/tests/ui/timelines/beat/test_beat_ui.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from tests.ui.timelines.beat.interact import click_beat_ui
 from tests.ui.timelines.interact import drag_mouse_in_timeline_view
 from tilia.requests import get, Get
-from tilia.ui.coords import get_x_by_time
+from tilia.ui.coords import time_x_converter
 
 
 class TestRightClick:
@@ -26,5 +26,5 @@ class TestDoubleClick:
     def test_does_not_trigger_drag(self, beat_tlui):
         beat_tlui.create_beat(0)
         click_beat_ui(beat_tlui[0], double=True)
-        drag_mouse_in_timeline_view(get_x_by_time(50), beat_tlui[0].height / 2)
+        drag_mouse_in_timeline_view(time_x_converter.get_x_by_time(50), beat_tlui[0].height / 2)
         assert beat_tlui[0].get_data("time") == 0

--- a/tests/ui/timelines/harmony/interact.py
+++ b/tests/ui/timelines/harmony/interact.py
@@ -20,4 +20,3 @@ def click_harmony_ui(harmony_ui, button="left", modifier=None, double=False):
 
 def click_mode_ui(mode_ui, button="left", modifier=None, double=False):
     _click_element_ui(mode_ui, button, modifier, double)
-

--- a/tests/ui/timelines/harmony/interact.py
+++ b/tests/ui/timelines/harmony/interact.py
@@ -1,12 +1,12 @@
 from tests.ui.timelines.interact import click_timeline_ui_view
-from tilia.ui.coords import get_x_by_time
+from tilia.ui.coords import time_x_converter
 
 
 def _click_element_ui(element, button, modifier, double):
     click_timeline_ui_view(
         element.timeline_ui.view,
         button,
-        get_x_by_time(element.get_data("time")),
+        time_x_converter.get_x_by_time(element.get_data("time")),
         element.timeline_ui.get_data("height") / 2,
         element.body,
         modifier,

--- a/tests/ui/timelines/interact.py
+++ b/tests/ui/timelines/interact.py
@@ -1,7 +1,7 @@
 from PyQt6.QtCore import Qt
 
 from tilia.requests import Post, post
-from tilia.ui.coords import get_time_by_x, get_x_by_time
+from tilia.ui.coords import time_x_converter
 
 
 def click_timeline_ui_view(view, button, x, y, item, modifier, double):
@@ -29,7 +29,7 @@ def click_timeline_ui_view(view, button, x, y, item, modifier, double):
 def click_timeline_ui(
     timeline_ui, time, y=None, button="left", modifier=None, double=False
 ):
-    x = int(get_x_by_time(time))
+    x = int(time_x_converter.get_x_by_time(time))
     y = int(y or timeline_ui.get_data("height") / 2)
     item = timeline_ui.view.itemAt(x, y)
     click_timeline_ui_view(timeline_ui.view, button, x, y, item, modifier, double)

--- a/tests/ui/timelines/marker/interact.py
+++ b/tests/ui/timelines/marker/interact.py
@@ -2,7 +2,7 @@ from tests.ui.timelines.interact import click_timeline_ui_view
 from tilia.ui.coords import get_x_by_time
 
 
-def click_marker_ui(element, button='left', modifier=None, double=False):
+def click_marker_ui(element, button="left", modifier=None, double=False):
     click_timeline_ui_view(
         element.timeline_ui.view,
         button,

--- a/tests/ui/timelines/marker/interact.py
+++ b/tests/ui/timelines/marker/interact.py
@@ -1,12 +1,12 @@
 from tests.ui.timelines.interact import click_timeline_ui_view
-from tilia.ui.coords import get_x_by_time
+from tilia.ui.coords import time_x_converter
 
 
 def click_marker_ui(element, button="left", modifier=None, double=False):
     click_timeline_ui_view(
         element.timeline_ui.view,
         button,
-        get_x_by_time(element.get_data("time")),
+        time_x_converter.get_x_by_time(element.get_data("time")),
         element.timeline_ui.get_data("height") / 2,
         element.body,
         modifier,

--- a/tests/ui/timelines/marker/test_marker_ui.py
+++ b/tests/ui/timelines/marker/test_marker_ui.py
@@ -5,7 +5,7 @@ from PyQt6.QtGui import QColor
 
 from tests.mock import PatchPost
 from tilia.requests import Post
-from tilia.ui.coords import get_time_by_x, get_x_by_time
+from tilia.ui.coords import time_x_converter
 
 MODULE = "tilia.ui.timelines.marker.element"
 
@@ -28,7 +28,7 @@ class TestMarker:
 
     def test_update_time(self, mrkui):
         mrkui.set_data("time", 100)
-        assert mrkui.x == get_x_by_time(100)
+        assert mrkui.x == time_x_converter.get_x_by_time(100)
 
     def test_update_color(self, mrkui):
         mrkui.set_data("color", "#010101")
@@ -58,7 +58,7 @@ class TestMarkerDrag:
 
     def test_after_each_drag(self, mrkui):
         mrkui.after_each_drag(202)
-        assert mrkui.get_data("time") == get_time_by_x(202)
+        assert mrkui.get_data("time") == time_x_converter.get_time_by_x(202)
 
     def test_on_drag_end_when_dragged(self, mrkui):
         mrkui.dragged = True

--- a/tests/ui/timelines/test_element_manager.py
+++ b/tests/ui/timelines/test_element_manager.py
@@ -8,10 +8,8 @@ class TestElementOrder:
         for i in range(0, 100, 10):
             marker_tlui.create_marker(i)
 
-        for i in range(10):
-            marker_tlui.timeline.set_component_data(
-                marker_tlui[i].id, "time", random.randrange(0, 99)
-            )
+        for marker_ui in marker_tlui:
+            marker_ui.set_data("time", random.randrange(0, 99))
 
         elms = marker_tlui.elements
 

--- a/tests/ui/timelines/test_timelineui_collection.py
+++ b/tests/ui/timelines/test_timelineui_collection.py
@@ -12,7 +12,7 @@ from tilia.timelines.timeline_kinds import (
 )
 from tilia.ui import actions
 from tilia.ui.actions import TiliaAction
-from tilia.ui.coords import get_x_by_time
+from tilia.ui.coords import time_x_converter
 
 
 ADD_TIMELINE_ACTIONS = [
@@ -164,7 +164,7 @@ class TestAutoScroll:
         post(Post.PLAYER_SEEK, 50)
         post(Post.VIEW_ZOOM_IN)
         assert tluis[0].scene.playback_line.line().x1() == pytest.approx(
-            get_x_by_time(50)
+            time_x_converter.get_x_by_time(50)
         )
 
 
@@ -174,7 +174,7 @@ class TestSeek:
     ):
         y = slider_tlui.trough.pos().y()
         click_timeline_ui(slider_tlui, 0, y=y)
-        target_x = get_x_by_time(50)
+        target_x = time_x_converter.get_x_by_time(50)
         drag_mouse_in_timeline_view(target_x, y)
         assert marker_tlui.playback_line.line().x1() == pytest.approx(target_x)
 
@@ -183,7 +183,7 @@ class TestSeek:
     ):
         y = slider_tlui.trough.pos().y()
         click_timeline_ui(slider_tlui, 0, y=y)
-        target_x = get_x_by_time(60)
+        target_x = time_x_converter.get_x_by_time(60)
         drag_mouse_in_timeline_view(target_x, y)
         tilia_state.current_time = 75
         assert marker_tlui.playback_line.line().x1() == target_x
@@ -217,7 +217,7 @@ class TestSeek:
     ):
         y = slider_tlui.trough.pos().y()
         click_timeline_ui(slider_tlui, 0, y=y)
-        drag_mouse_in_timeline_view(get_x_by_time(50), y)
+        drag_mouse_in_timeline_view(time_x_converter.get_x_by_time(50), y)
         tilia_state.current_time = 75
         if request_to_serve:
             with Serve(*request_to_serve):

--- a/tilia/app.py
+++ b/tilia/app.py
@@ -17,7 +17,7 @@ from tilia.timelines.collection.collection import Timelines
 from tilia.timelines.timeline_kinds import TimelineKind
 from tilia.undo_manager import PauseUndoManager
 from tilia.file.file_manager import open_tla
-from tilia.settings import settings_manager
+from tilia.settings import settings
 
 if TYPE_CHECKING:
     from tilia.media.player import Player
@@ -128,7 +128,7 @@ class App:
         except tilia.exceptions.NoReplyToRequest:
             geometry, window_state = None, None
 
-        settings_manager.update_recent_files(
+        settings.update_recent_files(
             self.file_manager.get_file_path(), geometry, window_state
         )
 

--- a/tilia/app.py
+++ b/tilia/app.py
@@ -41,7 +41,7 @@ class App:
         self.undo_manager = undo_manager
         self.player = player
         self.duration = 0.0
-        self.should_scale_timelines = 'prompt'
+        self.should_scale_timelines = "prompt"
         self._setup_timelines()
         self._setup_requests()
 
@@ -80,7 +80,11 @@ class App:
     def _setup_timelines(self):
         self.timelines = Timelines(self)
 
-    def set_file_media_duration(self, duration: float, scale_timelines: Literal['yes', 'no', 'prompt'] | None = None) -> None:
+    def set_file_media_duration(
+        self,
+        duration: float,
+        scale_timelines: Literal["yes", "no", "prompt"] | None = None,
+    ) -> None:
         if scale_timelines:
             self.should_scale_timelines = scale_timelines
         self.on_media_duration_changed(duration)
@@ -124,7 +128,9 @@ class App:
         except tilia.exceptions.NoReplyToRequest:
             geometry, window_state = None, None
 
-        settings_manager.update_recent_files(self.file_manager.get_file_path(), geometry, window_state)
+        settings_manager.update_recent_files(
+            self.file_manager.get_file_path(), geometry, window_state
+        )
 
     def on_export(self, path: Path | str | None = None) -> None:
         if isinstance(path, str):
@@ -148,7 +154,12 @@ class App:
 
         post(Post.UI_EXIT, 0)
 
-    def load_media(self, path: str, record: bool = True, scale_timelines: Literal['yes', 'no', 'prompt'] = 'prompt') -> None:
+    def load_media(
+        self,
+        path: str,
+        record: bool = True,
+        scale_timelines: Literal["yes", "no", "prompt"] = "prompt",
+    ) -> None:
         self.should_scale_timelines = scale_timelines
         if not path:
             self.player.unload_media()
@@ -182,24 +193,24 @@ class App:
 
     def on_media_duration_changed(self, duration: float):
         if not self.timelines.is_blank and duration != self.duration:
-            crop_or_scale = ''
-            if self.should_scale_timelines == 'prompt':
+            crop_or_scale = ""
+            if self.should_scale_timelines == "prompt":
                 if self.prompt_scale_timelines():
-                    crop_or_scale = 'scale'
+                    crop_or_scale = "scale"
                 else:
                     if duration < self.duration:
                         if self.prompt_crop_timelines():
-                            crop_or_scale = 'crop'
+                            crop_or_scale = "crop"
                         else:
-                            crop_or_scale = 'scale'
-            elif self.should_scale_timelines == 'yes':
-                crop_or_scale = 'scale'
+                            crop_or_scale = "scale"
+            elif self.should_scale_timelines == "yes":
+                crop_or_scale = "scale"
             elif duration < self.duration:  # self.should_scale_timelines == 'no'
-                crop_or_scale = 'crop'
+                crop_or_scale = "crop"
 
-            if crop_or_scale == 'scale':
+            if crop_or_scale == "scale":
                 self.timelines.scale_timeline_components(duration / self.duration)
-            elif crop_or_scale == 'crop':
+            elif crop_or_scale == "crop":
                 self.timelines.crop_timeline_components(duration)
 
         self.duration = duration
@@ -281,7 +292,7 @@ class App:
 
     def get_export_data(self):
         return {
-            'timelines': self.timelines.get_export_data(),
+            "timelines": self.timelines.get_export_data(),
             "media_metadata": dict(self.file_manager.file.media_metadata),
             "media_path": get(Get.MEDIA_PATH),
         }

--- a/tilia/app.py
+++ b/tilia/app.py
@@ -17,7 +17,7 @@ from tilia.timelines.collection.collection import Timelines
 from tilia.timelines.timeline_kinds import TimelineKind
 from tilia.undo_manager import PauseUndoManager
 from tilia.file.file_manager import open_tla
-from tilia.settings import settings
+from tilia.settings import settings_manager
 
 if TYPE_CHECKING:
     from tilia.media.player import Player
@@ -124,7 +124,7 @@ class App:
         except tilia.exceptions.NoReplyToRequest:
             geometry, window_state = None, None
 
-        settings.update_recent_files(self.file_manager.get_file_path(), geometry, window_state)
+        settings_manager.update_recent_files(self.file_manager.get_file_path(), geometry, window_state)
 
     def on_export(self, path: Path | str | None = None) -> None:
         if isinstance(path, str):

--- a/tilia/file/file_manager.py
+++ b/tilia/file/file_manager.py
@@ -11,7 +11,7 @@ from tilia.file.common import are_tilia_data_equal, write_tilia_file_to_disk
 from tilia.requests import listen, Post, Get, serve, get, post
 from tilia.file.tilia_file import TiliaFile, validate_tla_data
 from tilia.file.media_metadata import MediaMetadata
-from tilia.settings import settings
+from tilia.settings import settings_manager
 import tilia.errors
 
 

--- a/tilia/file/file_manager.py
+++ b/tilia/file/file_manager.py
@@ -24,7 +24,9 @@ def open_tla(file_path: str | Path) -> tuple[bool, TiliaFile | None]:
         return False, None
     except json.decoder.JSONDecodeError as err:
         tilia.errors.display(
-            tilia.errors.OPEN_FILE_INVALID_TLA, file_path, 'File is not valid JSON.',
+            tilia.errors.OPEN_FILE_INVALID_TLA,
+            file_path,
+            "File is not valid JSON.",
         )
         return False, None
 
@@ -33,7 +35,9 @@ def open_tla(file_path: str | Path) -> tuple[bool, TiliaFile | None]:
         tilia.errors.display(tilia.errors.OPEN_FILE_INVALID_TLA, file_path, reason)
         return False, None
 
-    data["file_path"] = file_path if isinstance(file_path, str) else str(file_path.resolve())
+    data["file_path"] = (
+        file_path if isinstance(file_path, str) else str(file_path.resolve())
+    )
     return True, TiliaFile(**data)
 
 

--- a/tilia/file/file_manager.py
+++ b/tilia/file/file_manager.py
@@ -11,7 +11,6 @@ from tilia.file.common import are_tilia_data_equal, write_tilia_file_to_disk
 from tilia.requests import listen, Post, Get, serve, get, post
 from tilia.file.tilia_file import TiliaFile, validate_tla_data
 from tilia.file.media_metadata import MediaMetadata
-from tilia.settings import settings_manager
 import tilia.errors
 
 

--- a/tilia/requests/get.py
+++ b/tilia/requests/get.py
@@ -2,7 +2,6 @@ import weakref
 from enum import Enum, auto
 from typing import Callable, Any
 
-from tilia.settings import settings
 from tilia.exceptions import NoReplyToRequest, NoCallbackAttached
 
 

--- a/tilia/settings.py
+++ b/tilia/settings.py
@@ -181,4 +181,26 @@ class SettingsManager(QObject):
         return editable_settings
 
 
-settings = SettingsManager()
+class SettingsCache():
+    def __init__(self):
+        self.values = {}
+
+        for group in settings_manager.DEFAULT_SETTINGS.keys():
+            for setting, value in settings_manager.DEFAULT_SETTINGS[group].items():
+                if group not in self.values:
+                   self.values[group] = {}
+                self.values[group][setting] = settings_manager.get(group, setting)
+
+    def get(self, group, setting):
+        return self.values[group][setting]
+
+    def set(self, group, setting, value):
+        try:
+            settings_manager.set(group, setting, value)
+            self.values[group][setting] = value
+        except AttributeError:
+            raise AttributeError(f"{group}.{setting} not found in cache.")
+
+
+settings_manager = SettingsManager()
+settings = SettingsCache()

--- a/tilia/settings.py
+++ b/tilia/settings.py
@@ -84,21 +84,29 @@ class SettingsManager(QObject):
         self._settings = QSettings(
             tilia.constants.APP_NAME, f"Desktop-v.{tilia.constants.VERSION}"
         )
-        self.check_all_default_settings_present()
         self._files_updated_callbacks = set()
+        self._cache = {}
+        self._check_all_default_settings_present()
 
-    def check_all_default_settings_present(self):
+    def _check_all_default_settings_present(self):
         for group_name, setting in self.DEFAULT_SETTINGS.items():
             for name in setting.keys():
-                self.get(group_name, name)
+                if group_name not in self._cache.keys():
+                    self._cache[group_name] = {}
+                self._cache[group_name][name] = self._get(group_name, name)
 
     def reset_to_default(self):
+        self._cache = {}
         self._settings.beginGroup("editable")
         self._settings.remove("")
-        for group, settings in self.DEFAULT_SETTINGS.items():
-            self._settings.beginGroup(group)
+        self._check_all_default_settings_present()
+        for group_name, settings in self.DEFAULT_SETTINGS.items():
+            self._settings.beginGroup(group_name)
             for key, value in settings.items():
                 self._settings.setValue(key, value)
+                if group_name not in self._cache.keys():
+                    self._cache[group_name] = {}
+                self._cache[group_name][key] = value
             self._settings.endGroup()
         self._settings.endGroup()
 
@@ -110,7 +118,7 @@ class SettingsManager(QObject):
     def link_file_update(self, updating_function) -> None:
         self._files_updated_callbacks.add(updating_function)
 
-    def get(self, group_name: str, setting: str, in_default=True):
+    def _get(self, group_name: str, setting: str, in_default=True):
         key = self._get_key(group_name, setting, in_default)
         value = self._settings.value(key, None)
         if not value:
@@ -120,20 +128,29 @@ class SettingsManager(QObject):
                 return None
             self._settings.setValue(key, value)
 
+        # QSettings saves all settings as strings; check typing before parsing
         if value == "true":
             return True
         elif value == "false":
             return False
-        elif sys.platform == 'linux' and isinstance(value, str) and value.isnumeric():
-            # For some reason, PyQt parses numeric values as strings in Linux.
-            # Is this a Qt bug?
+        elif isinstance(value, str) and value.isnumeric():
             return int(value)
 
         return value
 
-    def set(self, group_name: str, setting: str, value, in_default=True):
+    def _set(self, group_name: str, setting: str, value, in_default=True):
         key = self._get_key(group_name, setting, in_default)
         self._settings.setValue(key, value)
+
+    def get(self, group_name: str, setting: str):
+        return self._cache[group_name][setting]
+
+    def set(self, group_name: str, setting: str, value):
+        try:
+            self._cache[group_name][setting] = value
+            self._set(group_name, setting, value)
+        except AttributeError:
+            raise AttributeError(f"{group_name}.{setting} not found in cache.")
 
     @staticmethod
     def _get_key(group_name: str, setting: str, in_default: bool) -> str:
@@ -169,38 +186,7 @@ class SettingsManager(QObject):
         return geometry, state
 
     def get_dict(self) -> dict:
-        editable_settings = {}
-        self._settings.beginGroup("editable")
-        for group_name in self._settings.childGroups():
-            self._settings.beginGroup(group_name)
-            editable_settings[group_name] = {}
-            for setting in self._settings.childKeys():
-                editable_settings[group_name][setting] = self._settings.value(setting)
-            self._settings.endGroup()
-        self._settings.endGroup()
-        return editable_settings
+        return self._cache
 
 
-class SettingsCache():
-    def __init__(self):
-        self.values = {}
-
-        for group in settings_manager.DEFAULT_SETTINGS.keys():
-            for setting, value in settings_manager.DEFAULT_SETTINGS[group].items():
-                if group not in self.values:
-                   self.values[group] = {}
-                self.values[group][setting] = settings_manager.get(group, setting)
-
-    def get(self, group, setting):
-        return self.values[group][setting]
-
-    def set(self, group, setting, value):
-        try:
-            settings_manager.set(group, setting, value)
-            self.values[group][setting] = value
-        except AttributeError:
-            raise AttributeError(f"{group}.{setting} not found in cache.")
-
-
-settings_manager = SettingsManager()
-settings = SettingsCache()
+settings = SettingsManager()

--- a/tilia/timelines/base/timeline.py
+++ b/tilia/timelines/base/timeline.py
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
     # noinspection PyUnresolvedReferences
     from .component import TimelineComponent
 
-
 TC = TypeVar("TC", bound="TimelineComponent")
 T = TypeVar("T", bound="Timeline")
 
@@ -147,7 +146,8 @@ class Timeline(ABC, Generic[TC]):
 
         if success:
             post(
-                Post.TIMELINE_COMPONENT_CREATED, self.KIND, self.id, kind, component.id
+                Post.TIMELINE_COMPONENT_CREATED, self.KIND, self.id, kind, component.id, component.get_data,
+                functools.partial(self.set_component_data, component.id)
             )
             return component, None
         else:
@@ -274,7 +274,7 @@ class TimelineComponentManager(Generic[T, TC]):
         return True, ""
 
     def create_component(
-        self, kind: ComponentKind | None, timeline, id, *args, **kwargs
+        self, kind: ComponentKind, timeline, id, *args, **kwargs
     ) -> tuple[bool, TC | None, str]:
         self._validate_component_kind(kind)
         valid, reason = self._validate_component_creation(kind, *args, **kwargs)

--- a/tilia/ui/coords.py
+++ b/tilia/ui/coords.py
@@ -1,4 +1,3 @@
-import tilia.exceptions
 from tilia.requests import get, Get, listen, Post
 
 
@@ -22,13 +21,19 @@ class TimeXConverter:
 
     def get_time_by_x(self, x):
         try:
-            return (x - self.left_margin_x) * self.media_duration / self.playback_area_width
+            return (
+                (x - self.left_margin_x)
+                * self.media_duration
+                / self.playback_area_width
+            )
         except ZeroDivisionError:
             return 0.0
 
     def get_x_by_time(self, time: float) -> int:
         try:
-            return ((time / self.media_duration) * self.playback_area_width) + self.left_margin_x
+            return (
+                (time / self.media_duration) * self.playback_area_width
+            ) + self.left_margin_x
         except ZeroDivisionError:
             return self.left_margin_x
 
@@ -45,9 +50,9 @@ def get_x_by_time(time: float) -> int:
 def get_time_by_x(x: float) -> float:
     try:
         return (
-                (x - get(Get.LEFT_MARGIN_X))
-                * get(Get.MEDIA_DURATION)
-                / get(Get.PLAYBACK_AREA_WIDTH)
+            (x - get(Get.LEFT_MARGIN_X))
+            * get(Get.MEDIA_DURATION)
+            / get(Get.PLAYBACK_AREA_WIDTH)
         )
     except ZeroDivisionError:
         return 0.0

--- a/tilia/ui/coords.py
+++ b/tilia/ui/coords.py
@@ -1,4 +1,36 @@
-from tilia.requests import get, Get
+import tilia.exceptions
+from tilia.requests import get, Get, listen, Post
+
+
+class TimeXConverter:
+    def __init__(self):
+        self.media_duration = get(Get.MEDIA_DURATION)
+        self.playback_area_width = get(Get.PLAYBACK_AREA_WIDTH)
+        self.left_margin_x = get(Get.LEFT_MARGIN_X)
+
+        listen(self, Post.FILE_MEDIA_DURATION_CHANGED, self.on_media_duration_changed)
+        listen(self, Post.PLAYBACK_AREA_SET_WIDTH, self.on_playback_area_set_width)
+
+    def on_media_duration_changed(self, duration):
+        self.media_duration = duration
+
+    def on_playback_area_set_width(self, width):
+        if width < 0:
+            return
+
+        self.playback_area_width = width
+
+    def get_time_by_x(self, x):
+        try:
+            return (x - self.left_margin_x) * self.media_duration / self.playback_area_width
+        except ZeroDivisionError:
+            return 0.0
+
+    def get_x_by_time(self, time: float) -> int:
+        try:
+            return ((time / self.media_duration) * self.playback_area_width) + self.left_margin_x
+        except ZeroDivisionError:
+            return self.left_margin_x
 
 
 def get_x_by_time(time: float) -> int:
@@ -13,9 +45,9 @@ def get_x_by_time(time: float) -> int:
 def get_time_by_x(x: float) -> float:
     try:
         return (
-            (x - get(Get.LEFT_MARGIN_X))
-            * get(Get.MEDIA_DURATION)
-            / get(Get.PLAYBACK_AREA_WIDTH)
+                (x - get(Get.LEFT_MARGIN_X))
+                * get(Get.MEDIA_DURATION)
+                / get(Get.PLAYBACK_AREA_WIDTH)
         )
     except ZeroDivisionError:
         return 0.0

--- a/tilia/ui/coords.py
+++ b/tilia/ui/coords.py
@@ -3,12 +3,13 @@ from tilia.requests import get, Get, listen, Post
 
 class TimeXConverter:
     def __init__(self):
+        listen(self, Post.FILE_MEDIA_DURATION_CHANGED, self.on_media_duration_changed)
+        listen(self, Post.PLAYBACK_AREA_SET_WIDTH, self.on_playback_area_set_width)
+
+    def setup(self):
         self.media_duration = get(Get.MEDIA_DURATION)
         self.playback_area_width = get(Get.PLAYBACK_AREA_WIDTH)
         self.left_margin_x = get(Get.LEFT_MARGIN_X)
-
-        listen(self, Post.FILE_MEDIA_DURATION_CHANGED, self.on_media_duration_changed)
-        listen(self, Post.PLAYBACK_AREA_SET_WIDTH, self.on_playback_area_set_width)
 
     def on_media_duration_changed(self, duration):
         self.media_duration = duration
@@ -26,6 +27,16 @@ class TimeXConverter:
                 * self.media_duration
                 / self.playback_area_width
             )
+        except AttributeError:
+            self.setup()
+            try:
+                return (
+                    (x - self.left_margin_x)
+                    * self.media_duration
+                    / self.playback_area_width
+                )
+            except ZeroDivisionError:
+                return 0.0
         except ZeroDivisionError:
             return 0.0
 
@@ -34,25 +45,16 @@ class TimeXConverter:
             return (
                 (time / self.media_duration) * self.playback_area_width
             ) + self.left_margin_x
+        except AttributeError:
+            self.setup()
+            try:
+                return (
+                    (time / self.media_duration) * self.playback_area_width
+                ) + self.left_margin_x
+            except ZeroDivisionError:
+                return self.left_margin_x
         except ZeroDivisionError:
             return self.left_margin_x
 
 
-def get_x_by_time(time: float) -> int:
-    try:
-        return ((time / get(Get.MEDIA_DURATION)) * get(Get.PLAYBACK_AREA_WIDTH)) + get(
-            Get.LEFT_MARGIN_X
-        )
-    except ZeroDivisionError:
-        return get(Get.LEFT_MARGIN_X)
-
-
-def get_time_by_x(x: float) -> float:
-    try:
-        return (
-            (x - get(Get.LEFT_MARGIN_X))
-            * get(Get.MEDIA_DURATION)
-            / get(Get.PLAYBACK_AREA_WIDTH)
-        )
-    except ZeroDivisionError:
-        return 0.0
+time_x_converter = TimeXConverter()

--- a/tilia/ui/menus.py
+++ b/tilia/ui/menus.py
@@ -6,7 +6,7 @@ from PyQt6.QtWidgets import QMenu
 from PyQt6.QtGui import QAction
 
 from tilia.ui.actions import TiliaAction, get_qaction
-from tilia.settings import settings
+from tilia.settings import settings_manager
 from tilia.requests.post import post, Post, listen
 from tilia.ui.enums import WindowState
 
@@ -70,10 +70,10 @@ class RecentFilesMenu(QMenu):
         super().__init__()
         self.setTitle("Open Recent File...")
         self.add_items()
-        settings.link_file_update(self.update_items)
+        settings_manager.link_file_update(self.update_items)
 
     def add_items(self):
-        recent_files = settings.get_recent_files()
+        recent_files = settings_manager.get_recent_files()
         qactions = [self._get_action(file) for file in recent_files]
         self.addActions(qactions)
 

--- a/tilia/ui/menus.py
+++ b/tilia/ui/menus.py
@@ -6,7 +6,7 @@ from PyQt6.QtWidgets import QMenu
 from PyQt6.QtGui import QAction
 
 from tilia.ui.actions import TiliaAction, get_qaction
-from tilia.settings import settings_manager
+from tilia.settings import settings
 from tilia.requests.post import post, Post, listen
 from tilia.ui.enums import WindowState
 
@@ -70,10 +70,10 @@ class RecentFilesMenu(QMenu):
         super().__init__()
         self.setTitle("Open Recent File...")
         self.add_items()
-        settings_manager.link_file_update(self.update_items)
+        settings.link_file_update(self.update_items)
 
     def add_items(self):
-        recent_files = settings_manager.get_recent_files()
+        recent_files = settings.get_recent_files()
         qactions = [self._get_action(file) for file in recent_files]
         self.addActions(qactions)
 

--- a/tilia/ui/qtui.py
+++ b/tilia/ui/qtui.py
@@ -42,7 +42,7 @@ from .windows.kinds import WindowKind
 from ..media.player import QtVideoPlayer, QtAudioPlayer, YouTubePlayer
 from ..parsers.csv.beat import beats_from_csv
 from tilia import constants
-from tilia.settings import settings
+from tilia.settings import settings_manager, settings
 from tilia.utils import get_tilia_class_string
 from tilia.timelines.timeline_kinds import TimelineKind as TlKind
 from tilia.requests import Post, listen, post, serve, Get, get
@@ -268,7 +268,7 @@ class QtUI:
         return self.main_window.saveState()
     
     def on_file_load(self, file: TiliaFile) -> None:
-        geometry, state = settings.get_geometry_and_state_from_path(file.file_path)
+        geometry, state = settings_manager.get_geometry_and_state_from_path(file.file_path)
         if geometry and state:
             self.main_window.restoreGeometry(geometry)
             self.main_window.restoreState(state)

--- a/tilia/ui/qtui.py
+++ b/tilia/ui/qtui.py
@@ -30,7 +30,14 @@ from .dialogs.by_time_or_by_measure import ByTimeOrByMeasure
 from .dialogs.crash import CrashDialog
 from .menubar import TiliaMenuBar
 from tilia.ui.timelines.collection.collection import TimelineUIs
-from .menus import TimelinesMenu, HierarchyMenu, MarkerMenu, BeatMenu, HarmonyMenu, PdfMenu
+from .menus import (
+    TimelinesMenu,
+    HierarchyMenu,
+    MarkerMenu,
+    BeatMenu,
+    HarmonyMenu,
+    PdfMenu,
+)
 from .options_toolbar import OptionsToolbar
 from .player import PlayerToolbar
 from .windows.manage_timelines import ManageTimelines
@@ -59,7 +66,7 @@ class TiliaMainWindow(QMainWindow):
     @staticmethod
     def handle_qt_log_message(type, _, msg):
         if type == QtMsgType.QtCriticalMsg or type == QtMsgType.QtFatalMsg:
-            raise Exception(f'{type.name}: {msg}')
+            raise Exception(f"{type.name}: {msg}")
         else:
             print(f"{type.name}: {msg}")
 
@@ -134,25 +141,67 @@ class QtUI:
             (Post.UI_MEDIA_LOAD_YOUTUBE, self.on_media_load_youtube),
             (Post.TIMELINE_ELEMENT_INSPECT, self.on_timeline_element_inspect),
             (Post.WEBSITE_HELP_OPEN, self.on_website_help_open),
-            (Post.WINDOW_ABOUT_CLOSED, lambda: self.on_window_close_done(WindowKind.ABOUT)),
+            (
+                Post.WINDOW_ABOUT_CLOSED,
+                lambda: self.on_window_close_done(WindowKind.ABOUT),
+            ),
             (Post.WINDOW_ABOUT_OPEN, lambda: self.on_window_open(WindowKind.ABOUT)),
-            (Post.WINDOW_INSPECT_CLOSE, lambda: self.on_window_close(WindowKind.INSPECT)),
-            (Post.WINDOW_INSPECT_CLOSED, lambda: self.on_window_close_done(WindowKind.INSPECT)),
+            (
+                Post.WINDOW_INSPECT_CLOSE,
+                lambda: self.on_window_close(WindowKind.INSPECT),
+            ),
+            (
+                Post.WINDOW_INSPECT_CLOSED,
+                lambda: self.on_window_close_done(WindowKind.INSPECT),
+            ),
             (Post.WINDOW_INSPECT_OPEN, lambda: self.on_window_open(WindowKind.INSPECT)),
-            (Post.WINDOW_MANAGE_TIMELINES_CLOSE_DONE, lambda: self.on_window_close_done(WindowKind.MANAGE_TIMELINES)),
-            (Post.WINDOW_MANAGE_TIMELINES_OPEN, lambda: self.on_window_open(WindowKind.MANAGE_TIMELINES)),
-            (Post.WINDOW_METADATA_CLOSED, lambda: self.on_window_close_done(WindowKind.MEDIA_METADATA)),
-            (Post.WINDOW_METADATA_OPEN, lambda: self.on_window_open(WindowKind.MEDIA_METADATA)),
-            (Post.WINDOW_SETTINGS_CLOSED, lambda: self.on_window_close_done(WindowKind.SETTINGS)),
-            (Post.WINDOW_SETTINGS_OPEN, lambda: self.on_window_open(WindowKind.SETTINGS)),
+            (
+                Post.WINDOW_MANAGE_TIMELINES_CLOSE_DONE,
+                lambda: self.on_window_close_done(WindowKind.MANAGE_TIMELINES),
+            ),
+            (
+                Post.WINDOW_MANAGE_TIMELINES_OPEN,
+                lambda: self.on_window_open(WindowKind.MANAGE_TIMELINES),
+            ),
+            (
+                Post.WINDOW_METADATA_CLOSED,
+                lambda: self.on_window_close_done(WindowKind.MEDIA_METADATA),
+            ),
+            (
+                Post.WINDOW_METADATA_OPEN,
+                lambda: self.on_window_open(WindowKind.MEDIA_METADATA),
+            ),
+            (
+                Post.WINDOW_SETTINGS_CLOSED,
+                lambda: self.on_window_close_done(WindowKind.SETTINGS),
+            ),
+            (
+                Post.WINDOW_SETTINGS_OPEN,
+                lambda: self.on_window_open(WindowKind.SETTINGS),
+            ),
             (Post.REQUEST_CLEAR_UI, self.on_clear_ui),
             (Post.TIMELINE_KIND_INSTANCED, self.on_timeline_kind_change),
             (Post.TIMELINE_KIND_NOT_INSTANCED, self.on_timeline_kind_change),
-            (Post.MARKER_IMPORT_FROM_CSV, partial(self.on_import_from_csv, TlKind.MARKER_TIMELINE)),
-            (Post.HIERARCHY_IMPORT_FROM_CSV, partial(self.on_import_from_csv, TlKind.HIERARCHY_TIMELINE)),
-            (Post.BEAT_IMPORT_FROM_CSV, partial(self.on_import_from_csv, TlKind.BEAT_TIMELINE)),
-            (Post.HARMONY_IMPORT_FROM_CSV, partial(self.on_import_from_csv, TlKind.HARMONY_TIMELINE)),
-            (Post.PDF_IMPORT_FROM_CSV, partial(self.on_import_from_csv, TlKind.PDF_TIMELINE)),
+            (
+                Post.MARKER_IMPORT_FROM_CSV,
+                partial(self.on_import_from_csv, TlKind.MARKER_TIMELINE),
+            ),
+            (
+                Post.HIERARCHY_IMPORT_FROM_CSV,
+                partial(self.on_import_from_csv, TlKind.HIERARCHY_TIMELINE),
+            ),
+            (
+                Post.BEAT_IMPORT_FROM_CSV,
+                partial(self.on_import_from_csv, TlKind.BEAT_TIMELINE),
+            ),
+            (
+                Post.HARMONY_IMPORT_FROM_CSV,
+                partial(self.on_import_from_csv, TlKind.HARMONY_TIMELINE),
+            ),
+            (
+                Post.PDF_IMPORT_FROM_CSV,
+                partial(self.on_import_from_csv, TlKind.PDF_TIMELINE),
+            ),
             (Post.DISPLAY_ERROR, display_error),
             (Post.UI_EXIT, self.exit),
         }
@@ -161,7 +210,10 @@ class QtUI:
             (Get.TIMELINE_WIDTH, lambda: self.timeline_width),
             (Get.PLAYBACK_AREA_WIDTH, lambda: self.playback_area_width),
             (Get.LEFT_MARGIN_X, lambda: self.playback_area_margin),
-            (Get.RIGHT_MARGIN_X, lambda: self.playback_area_width + self.playback_area_margin),
+            (
+                Get.RIGHT_MARGIN_X,
+                lambda: self.playback_area_width + self.playback_area_margin,
+            ),
             (Get.WINDOW_GEOMETRY, self.get_window_geometry),
             (Get.WINDOW_STATE, self.get_window_state),
             (Get.PLAYER_CLASS, self.get_player_class),
@@ -187,8 +239,8 @@ class QtUI:
 
     @staticmethod
     def _setup_fonts():
-        fonts_dir = Path(__file__).parent / 'fonts'
-        fonts = ['MusAnalysis.otf']
+        fonts_dir = Path(__file__).parent / "fonts"
+        fonts = ["MusAnalysis.otf"]
         for font in fonts:
             font_path = str(Path(fonts_dir, font).resolve())
             QFontDatabase.addApplicationFont(font_path)
@@ -263,12 +315,14 @@ class QtUI:
 
     def get_window_geometry(self):
         return self.main_window.saveGeometry()
-    
+
     def get_window_state(self):
         return self.main_window.saveState()
-    
+
     def on_file_load(self, file: TiliaFile) -> None:
-        geometry, state = settings_manager.get_geometry_and_state_from_path(file.file_path)
+        geometry, state = settings_manager.get_geometry_and_state_from_path(
+            file.file_path
+        )
         if geometry and state:
             self.main_window.restoreGeometry(geometry)
             self.main_window.restoreState(state)
@@ -319,7 +373,7 @@ class QtUI:
     @staticmethod
     def open_media_metadata_window():
         return MediaMetadataWindow()
-    
+
     @staticmethod
     def open_settings_window():
         return SettingsWindow()
@@ -374,7 +428,7 @@ class QtUI:
         return dialog.get_option()
 
     def on_website_help_open(self):
-        QDesktopServices.openUrl(QUrl(f'{constants.WEBSITE_URL}/help/introduction'))
+        QDesktopServices.openUrl(QUrl(f"{constants.WEBSITE_URL}/help/introduction"))
 
     def on_import_from_csv(self, tlkind: TlKind) -> None:
         if not self._validate_timeline_kind_on_import_from_csv(tlkind):
@@ -431,9 +485,9 @@ class QtUI:
                 "measure": tilia.parsers.csv.harmony.import_by_measure,
             },
             TlKind.PDF_TIMELINE: {
-                'time': tilia.parsers.csv.pdf.import_by_time,
-                'measure': tilia.parsers.csv.pdf.import_by_measure
-            }
+                "time": tilia.parsers.csv.pdf.import_by_time,
+                "measure": tilia.parsers.csv.pdf.import_by_measure,
+            },
         }
 
         timeline.clear()
@@ -453,8 +507,8 @@ class QtUI:
     def _validate_timeline_kind_on_import_from_csv(self, tlkind: TlKind):
         if not self.timeline_uis.get_timeline_uis_by_attr("TIMELINE_KIND", tlkind):
             tilia.errors.display(
-                tilia.errors.CSV_IMPORT_FAILED, 
-                f"No timelines of type '{tlkind}' found."
+                tilia.errors.CSV_IMPORT_FAILED,
+                f"No timelines of type '{tlkind}' found.",
             )
             return False
         return True
@@ -473,7 +527,7 @@ class QtUI:
         ):
             tilia.errors.display(
                 tilia.errors.CSV_IMPORT_FAILED,
-                "No beat timelines found. Must have a beat timeline if importing by measure."
+                "No beat timelines found. Must have a beat timeline if importing by measure.",
             )
             return
 
@@ -487,8 +541,8 @@ class QtUI:
     def _display_import_from_csv_errors(errors):
         errors_str = "\n".join(errors)
         tilia.errors.display(
-            tilia.errors.CSV_IMPORT_FAILED, 
-            f"Some components were not imported. The following errors occured:\n{errors_str}"
+            tilia.errors.CSV_IMPORT_FAILED,
+            f"Some components were not imported. The following errors occured:\n{errors_str}",
         )
 
     @staticmethod

--- a/tilia/ui/qtui.py
+++ b/tilia/ui/qtui.py
@@ -49,7 +49,7 @@ from .windows.kinds import WindowKind
 from ..media.player import QtVideoPlayer, QtAudioPlayer, YouTubePlayer
 from ..parsers.csv.beat import beats_from_csv
 from tilia import constants
-from tilia.settings import settings_manager, settings
+from tilia.settings import settings
 from tilia.utils import get_tilia_class_string
 from tilia.timelines.timeline_kinds import TimelineKind as TlKind
 from tilia.requests import Post, listen, post, serve, Get, get
@@ -320,9 +320,7 @@ class QtUI:
         return self.main_window.saveState()
 
     def on_file_load(self, file: TiliaFile) -> None:
-        geometry, state = settings_manager.get_geometry_and_state_from_path(
-            file.file_path
-        )
+        geometry, state = settings.get_geometry_and_state_from_path(file.file_path)
         if geometry and state:
             self.main_window.restoreGeometry(geometry)
             self.main_window.restoreState(state)

--- a/tilia/ui/timelines/audiowave/element.py
+++ b/tilia/ui/timelines/audiowave/element.py
@@ -8,7 +8,7 @@ from PyQt6.QtWidgets import QGraphicsLineItem
 from tilia.requests import Post, post, get, Get
 from ..cursors import CursorMixIn
 from ..drag import DragManager
-from ...coords import get_x_by_time
+from ...coords import time_x_converter
 from ...color import get_tinted_color
 from ...consts import TINT_FACTOR_ON_SELECTION
 from tilia.settings import settings
@@ -33,7 +33,9 @@ class AmplitudeBarUI(TimelineUIElement):
 
     @property
     def width(self):
-        return get_x_by_time(self.get_data("end") - self.get_data("start"))
+        return time_x_converter.get_x_by_time(
+            self.get_data("end") - self.get_data("start")
+        )
 
     @property
     def amplitude(self):

--- a/tilia/ui/timelines/audiowave/element.py
+++ b/tilia/ui/timelines/audiowave/element.py
@@ -18,28 +18,19 @@ from ...windows.inspect import InspectRowKind
 if TYPE_CHECKING:
     from .timeline import AudioWaveTimelineUI
 
+
 class AmplitudeBarUI(TimelineUIElement):
     INSPECTOR_FIELDS = [
         ("Start / End", InspectRowKind.LABEL, None),
         ("Amplitude", InspectRowKind.LABEL, None)
     ]
 
-    def __init__(
-            self,
-            id: int,
-            timeline_ui: AudioWaveTimelineUI,
-            scene: QGraphicsScene,
-            **_,
-    ):
-        super().__init__(id=id, timeline_ui=timeline_ui, scene=scene)
-        self.timeline_ui = timeline_ui
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
         self._setup_body()
         self.dragged = False
 
-    @property
-    def start_x(self):
-        return get_x_by_time(self.get_data("start"))
-    
     @property
     def width(self):
         return get_x_by_time(self.get_data("end") - self.get_data("start"))
@@ -56,10 +47,6 @@ class AmplitudeBarUI(TimelineUIElement):
     def seek_time(self):
         return self.get_data("start")
 
-    @property
-    def x(self):
-        return get_x_by_time(self.seek_time)
-    
     def _setup_body(self):
         self.body = AmplitudeBarUIBody(
             self.start_x,

--- a/tilia/ui/timelines/audiowave/element.py
+++ b/tilia/ui/timelines/audiowave/element.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from PyQt6.QtCore import Qt, QPointF, QLineF
 from PyQt6.QtGui import QPen, QColor
-from PyQt6.QtWidgets import QGraphicsScene, QGraphicsLineItem
+from PyQt6.QtWidgets import QGraphicsLineItem
 
 from tilia.requests import Post, post, get, Get
 from ..cursors import CursorMixIn
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 class AmplitudeBarUI(TimelineUIElement):
     INSPECTOR_FIELDS = [
         ("Start / End", InspectRowKind.LABEL, None),
-        ("Amplitude", InspectRowKind.LABEL, None)
+        ("Amplitude", InspectRowKind.LABEL, None),
     ]
 
     def __init__(self, *args, **kwargs):
@@ -34,25 +34,22 @@ class AmplitudeBarUI(TimelineUIElement):
     @property
     def width(self):
         return get_x_by_time(self.get_data("end") - self.get_data("start"))
-    
+
     @property
     def amplitude(self):
         return self.get_data("amplitude")
-    
+
     @property
     def height(self):
         return self.timeline_ui.get_data("height")
-        
+
     @property
     def seek_time(self):
         return self.get_data("start")
 
     def _setup_body(self):
         self.body = AmplitudeBarUIBody(
-            self.start_x,
-            self.width,
-            self.amplitude,
-            self.height
+            self.start_x, self.width, self.amplitude, self.height
         )
         self.scene.addItem(self.body)
 
@@ -60,25 +57,20 @@ class AmplitudeBarUI(TimelineUIElement):
         self.update_time()
 
     def update_time(self):
-        self.body.set_position(
-            self.start_x,
-            self.width,
-            self.amplitude, 
-            self.height
-        )
+        self.body.set_position(self.start_x, self.width, self.amplitude, self.height)
 
     def child_items(self):
         return [self.body]
-        
+
     def left_click_triggers(self):
         return [self.body]
-    
+
     def on_left_click(self, _) -> None:
         self.setup_drag()
 
     def double_left_click_triggers(self):
         return [self.body]
-    
+
     def on_double_left_click(self, _):
         post(Post.PLAYER_SEEK, self.seek_time)
 
@@ -88,9 +80,9 @@ class AmplitudeBarUI(TimelineUIElement):
             get_max_x=lambda: get(Get.RIGHT_MARGIN_X),
             before_each=self.before_each_drag,
             after_each=self.after_each_drag,
-            on_release=self.on_drag_end
+            on_release=self.on_drag_end,
         )
-        
+
     def before_each_drag(self):
         if not self.dragged:
             post(Post.ELEMENT_DRAG_START)
@@ -114,6 +106,7 @@ class AmplitudeBarUI(TimelineUIElement):
     def get_inspector_dict(self) -> dict:
         return self.timeline_ui.get_inspector_dict()
 
+
 class AmplitudeBarUIBody(CursorMixIn, QGraphicsLineItem):
     def __init__(self, start_x: float, width: float, amplitude: float, height: float):
         super().__init__(cursor_shape=Qt.CursorShape.PointingHandCursor)
@@ -134,8 +127,14 @@ class AmplitudeBarUIBody(CursorMixIn, QGraphicsLineItem):
         return QLineF(QPointF(x, offset), QPointF(x, offset + height))
 
     def update_pen_style(self):
-        color = get_tinted_color(settings.get("audiowave_timeline", "default_color"), TINT_FACTOR_ON_SELECTION) if self.selected \
+        color = (
+            get_tinted_color(
+                settings.get("audiowave_timeline", "default_color"),
+                TINT_FACTOR_ON_SELECTION,
+            )
+            if self.selected
             else settings.get("audiowave_timeline", "default_color")
+        )
         pen = QPen(QColor(color))
         pen.setStyle(Qt.PenStyle.SolidLine)
         pen.setWidthF(self.width)

--- a/tilia/ui/timelines/base/element.py
+++ b/tilia/ui/timelines/base/element.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import functools
 from abc import ABC, abstractmethod
 
 from typing import Optional, Any, Callable
@@ -12,7 +11,7 @@ from tilia.utils import get_tilia_class_string
 
 from PyQt6.QtWidgets import QGraphicsScene
 
-from tilia.requests import stop_listening_to_all, get, Get
+from tilia.requests import stop_listening_to_all
 
 
 class TimelineUIElement(ABC):
@@ -51,7 +50,7 @@ class TimelineUIElement(ABC):
 
     @property
     def kind(self):
-        return self.tl_component.get_data('KIND')
+        return self.tl_component.get_data("KIND")
 
     def update(self, attr: str, value: Any):
         if attr not in self.UPDATE_TRIGGERS:
@@ -67,7 +66,8 @@ class TimelineUIElement(ABC):
         return self in self.timeline_ui.selected_elements
 
     @abstractmethod
-    def child_items(self): ...
+    def child_items(self):
+        ...
 
     def selection_triggers(self):
         return self.child_items()
@@ -88,9 +88,11 @@ class TimelineUIElement(ABC):
         menu = self.CONTEXT_MENU_CLASS(self)
         menu.exec(QPoint(x, y))
 
-    def on_select(self): ...
+    def on_select(self):
+        ...
 
-    def on_deselect(self): ...
+    def on_deselect(self):
+        ...
 
     def delete(self):
         for item in self.child_items():

--- a/tilia/ui/timelines/base/element.py
+++ b/tilia/ui/timelines/base/element.py
@@ -7,6 +7,7 @@ from typing import Optional, Any, Callable
 from PyQt6.QtCore import QPoint
 
 from tilia.ui.timelines.base.context_menus import TimelineUIElementContextMenu
+from tilia.ui.coords import time_x_converter
 from tilia.utils import get_tilia_class_string
 
 from PyQt6.QtWidgets import QGraphicsScene
@@ -33,8 +34,6 @@ class TimelineUIElement(ABC):
         self.timeline_ui = timeline_ui
         self.id = id
         self.scene = scene
-        self.get_x_by_time = self.timeline_ui.time_x_converter.get_x_by_time
-        self.get_time_by_x = self.timeline_ui.time_x_converter.get_time_by_x
         self.get_data = get_data
         self.set_data = set_data
 
@@ -106,12 +105,12 @@ class TimelineUIElement(ABC):
 
     @property
     def start_x(self):
-        return self.get_x_by_time(self.get_data("start"))
+        return time_x_converter.get_x_by_time(self.get_data("start"))
 
     @property
     def end_x(self):
-        return self.get_x_by_time(self.get_data("end"))
+        return time_x_converter.get_x_by_time(self.get_data("end"))
 
     @property
     def x(self):
-        return self.get_x_by_time(self.get_data("time"))
+        return time_x_converter.get_x_by_time(self.get_data("time"))

--- a/tilia/ui/timelines/base/element.py
+++ b/tilia/ui/timelines/base/element.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
+
+import functools
 from abc import ABC, abstractmethod
 
-from typing import Optional, Any
+from typing import Optional, Any, Callable
 
 from PyQt6.QtCore import QPoint
 
@@ -10,7 +12,7 @@ from tilia.utils import get_tilia_class_string
 
 from PyQt6.QtWidgets import QGraphicsScene
 
-from tilia.requests import stop_listening_to_all
+from tilia.requests import stop_listening_to_all, get, Get
 
 
 class TimelineUIElement(ABC):
@@ -20,10 +22,11 @@ class TimelineUIElement(ABC):
 
     def __init__(
         self,
-        *args,
         id: int,
         timeline_ui,
         scene: QGraphicsScene,
+        get_data: Callable[[str], Any],
+        set_data: Callable[[str, Any], None],
         **kwargs,
     ):
         super().__init__()
@@ -31,6 +34,10 @@ class TimelineUIElement(ABC):
         self.timeline_ui = timeline_ui
         self.id = id
         self.scene = scene
+        self.get_x_by_time = self.timeline_ui.time_x_converter.get_x_by_time
+        self.get_time_by_x = self.timeline_ui.time_x_converter.get_time_by_x
+        self.get_data = get_data
+        self.set_data = set_data
 
     def __repr__(self):
         return get_tilia_class_string(self)
@@ -46,13 +53,7 @@ class TimelineUIElement(ABC):
     def kind(self):
         return self.tl_component.get_data('KIND')
 
-    def get_data(self, attr: str):
-        return self.timeline_ui.get_component_data(self.id, attr)
-
-    def set_data(self, attr: str, value: Any):
-        self.timeline_ui.set_component_data(self.id, attr, value)
-
-    def update(self, attr: str):
+    def update(self, attr: str, value: Any):
         if attr not in self.UPDATE_TRIGGERS:
             return
 
@@ -100,3 +101,15 @@ class TimelineUIElement(ABC):
             self.scene.removeItem(item)
 
         stop_listening_to_all(self)
+
+    @property
+    def start_x(self):
+        return self.get_x_by_time(self.get_data("start"))
+
+    @property
+    def end_x(self):
+        return self.get_x_by_time(self.get_data("end"))
+
+    @property
+    def x(self):
+        return self.get_x_by_time(self.get_data("time"))

--- a/tilia/ui/timelines/base/element_manager.py
+++ b/tilia/ui/timelines/base/element_manager.py
@@ -48,11 +48,13 @@ class ElementManager(Generic[TE]):
         id: int,
         timeline_ui: TimelineUI,
         scene: TimelineScene,
+        get_data: Callable[[str], Any],
+        set_data: Callable[[str, Any], None],
     ):
         if self.is_single_element:
-            element = self.element_classes[0](id, timeline_ui, scene)
+            element = self.element_classes[0](id, timeline_ui, scene, get_data, set_data)
         else:
-            element = get_element_class_by_kind(kind)(id, timeline_ui, scene)
+            element = get_element_class_by_kind(kind)(id, timeline_ui, scene, get_data, set_data)
 
         self._add_to_elements_set(element)
 

--- a/tilia/ui/timelines/base/timeline.py
+++ b/tilia/ui/timelines/base/timeline.py
@@ -200,8 +200,12 @@ class TimelineUI(ABC):
     def on_timeline_request(self, request, *args, **kwargs):
         return TimelineRequestHandler(self, {}).on_request(request, *args, **kwargs)
 
-    def on_timeline_component_created(self, kind: ComponentKind, id: int, get_data, set_data):
-        return self.element_manager.create_element(kind, id, self, self.scene, get_data, set_data)
+    def on_timeline_component_created(
+        self, kind: ComponentKind, id: int, get_data, set_data
+    ):
+        return self.element_manager.create_element(
+            kind, id, self, self.scene, get_data, set_data
+        )
 
     def on_timeline_component_deleted(self, id: int):
         self.delete_element(self.id_to_element[id])

--- a/tilia/ui/timelines/base/timeline.py
+++ b/tilia/ui/timelines/base/timeline.py
@@ -28,7 +28,7 @@ from tilia.ui.timelines.copy_paste import (
 from .request_handlers import TimelineRequestHandler
 from ..collection.requests.enums import ElementSelector
 from ..view import TimelineView
-from ...coords import get_x_by_time, TimeXConverter
+from ...coords import time_x_converter
 
 if TYPE_CHECKING:
     from tilia.ui.timelines.collection.collection import TimelineUIs
@@ -54,12 +54,10 @@ class TimelineUI(ABC):
         element_manager: ElementManager,
         scene: TimelineScene,
         view: TimelineView,
-        time_x_converter: TimeXConverter | None = None,
     ):
         super().__init__()
         self.id = id
         self.collection = collection
-        self.time_x_converter = time_x_converter
         self.scene = scene
         self.view = view
 
@@ -159,10 +157,13 @@ class TimelineUI(ABC):
         self.scene.set_width(int(width))
         self.view.setFixedWidth(int(width))
         self.element_manager.update_time_on_elements()
-        self.scene.set_playback_line_pos(get_x_by_time(get(Get.SELECTED_TIME)))
+        self.scene.set_playback_line_pos(
+            time_x_converter.get_x_by_time(get(Get.SELECTED_TIME))
+        )
         (loop_start, loop_end) = get(Get.LOOP_TIME)
         self.scene.set_loop_box_position(
-            get_x_by_time(loop_start), get_x_by_time(loop_end)
+            time_x_converter.get_x_by_time(loop_start),
+            time_x_converter.get_x_by_time(loop_end),
         )
 
     def update_ordinal(self):

--- a/tilia/ui/timelines/beat/element.py
+++ b/tilia/ui/timelines/beat/element.py
@@ -3,7 +3,7 @@ Defines the ui corresponding to a Beat object.
 """
 
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Any
 
 from PyQt6.QtCore import Qt, QLineF, QPointF
 from PyQt6.QtGui import QPen, QColor, QFont
@@ -63,9 +63,11 @@ class BeatUI(TimelineUIElement):
         id: int,
         timeline_ui: BeatTimelineUI,
         scene: QGraphicsScene,
+        get_data: Callable[[str], Any],
+        set_data: Callable[[str, Any], None],
         **_,
     ):
-        super().__init__(id=id, timeline_ui=timeline_ui, scene=scene)
+        super().__init__(id=id, timeline_ui=timeline_ui, scene=scene, get_data=get_data, set_data=set_data)
 
         self._setup_body()
         self._setup_label()
@@ -84,10 +86,6 @@ class BeatUI(TimelineUIElement):
     @property
     def time(self):
         return self.tl_component.time
-
-    @property
-    def x(self):
-        return get_x_by_time(self.time)
 
     @property
     def label_y(self):

--- a/tilia/ui/timelines/beat/element.py
+++ b/tilia/ui/timelines/beat/element.py
@@ -15,7 +15,7 @@ from ..copy_paste import CopyAttributes
 from ..cursors import CursorMixIn
 from ..drag import DragManager
 from ...format import format_media_time
-from ...coords import get_x_by_time, get_time_by_x
+from ...coords import time_x_converter
 from tilia.ui.timelines.base.element import TimelineUIElement
 from ...windows.inspect import InspectRowKind
 
@@ -171,13 +171,18 @@ class BeatUI(TimelineUIElement):
         previous_beat = self.timeline_ui.get_previous_element(self)
         if not previous_beat:
             return get(Get.LEFT_MARGIN_X)
-        return get_x_by_time(previous_beat.time) + self.DRAG_PROXIMITY_LIMIT
+        return (
+            time_x_converter.get_x_by_time(previous_beat.time)
+            + self.DRAG_PROXIMITY_LIMIT
+        )
 
     def get_drag_right_limit(self):
         next_beat = self.timeline_ui.get_next_element(self)
         if not next_beat:
             return get(Get.RIGHT_MARGIN_X)
-        return get_x_by_time(next_beat.time) - self.DRAG_PROXIMITY_LIMIT
+        return (
+            time_x_converter.get_x_by_time(next_beat.time) - self.DRAG_PROXIMITY_LIMIT
+        )
 
     def before_each_drag(self):
         if not self.dragged:
@@ -185,7 +190,7 @@ class BeatUI(TimelineUIElement):
             self.dragged = True
 
     def after_each_drag(self, drag_x: int):
-        self.tl_component.time = get_time_by_x(drag_x)
+        self.tl_component.time = time_x_converter.get_time_by_x(drag_x)
         self.update_position()
 
     def on_drag_end(self):

--- a/tilia/ui/timelines/beat/element.py
+++ b/tilia/ui/timelines/beat/element.py
@@ -45,9 +45,9 @@ class BeatUI(TimelineUIElement):
         ("Beat", InspectRowKind.LABEL, None),
     ]
 
-    FIELD_NAMES_TO_ATTRIBUTES: dict[str, str] = (
-        {}
-    )  # only needed if attrs will be set by Inspect
+    FIELD_NAMES_TO_ATTRIBUTES: dict[
+        str, str
+    ] = {}  # only needed if attrs will be set by Inspect
 
     DEFAULT_COPY_ATTRIBUTES = CopyAttributes(
         by_element_value=[],
@@ -67,7 +67,13 @@ class BeatUI(TimelineUIElement):
         set_data: Callable[[str, Any], None],
         **_,
     ):
-        super().__init__(id=id, timeline_ui=timeline_ui, scene=scene, get_data=get_data, set_data=set_data)
+        super().__init__(
+            id=id,
+            timeline_ui=timeline_ui,
+            scene=scene,
+            get_data=get_data,
+            set_data=set_data,
+        )
 
         self._setup_body()
         self._setup_label()

--- a/tilia/ui/timelines/collection/collection.py
+++ b/tilia/ui/timelines/collection/collection.py
@@ -30,7 +30,7 @@ from tilia.requests import get, Get, serve
 from tilia.requests import listen, Post, post
 from tilia.timelines.base.timeline import Timeline
 from tilia.timelines.timeline_kinds import TimelineKind as TlKind, TimelineKind
-from tilia.ui.coords import get_x_by_time, get_time_by_x, TimeXConverter
+from tilia.ui.coords import time_x_converter
 from tilia.ui.dialogs.choose import ChooseDialog
 from tilia.ui.modifier_enum import ModifierEnum
 from tilia.ui.player import PlayerToolbarElement
@@ -74,7 +74,6 @@ class TimelineUIs:
         self._setup_widgets(main_window)
         self._setup_requests()
 
-        self.time_x_converter = TimeXConverter()
         self._setup_selection_box()
         self._setup_drag_tracking_vars()
         self._setup_auto_scroll()
@@ -241,7 +240,6 @@ class TimelineUIs:
             element_manager=element_manager,
             scene=scene,
             view=view,
-            time_x_converter=self.time_x_converter,
         )
 
         self._add_to_timeline_uis_set(tl_ui)
@@ -796,7 +794,8 @@ class TimelineUIs:
         start_time, end_time = self.loop_time
         for tl_ui in self:
             tl_ui.scene.set_loop_box_position(
-                get_x_by_time(start_time), get_x_by_time(end_time)
+                time_x_converter.get_x_by_time(start_time),
+                time_x_converter.get_x_by_time(end_time),
             )
 
     def update_loop_elements_ui(self, is_looping: bool) -> None:
@@ -1009,7 +1008,7 @@ class TimelineUIs:
             self.clear_selection_boxes()
 
     def on_slider_drag(self, x: float):
-        time = get_time_by_x(x)
+        time = time_x_converter.get_time_by_x(x)
         self.selected_time = time
         self.set_playback_lines_position(time)
 
@@ -1019,7 +1018,7 @@ class TimelineUIs:
         self.auto_scroll_is_enabled = value
 
     def center_on_time(self, time: float):
-        self.view.move_to_x(get_x_by_time(time))
+        self.view.move_to_x(time_x_converter.get_x_by_time(time))
 
     @staticmethod
     def change_playback_line_position(timeline_ui: TimelineUI, time: float):

--- a/tilia/ui/timelines/collection/collection.py
+++ b/tilia/ui/timelines/collection/collection.py
@@ -241,7 +241,7 @@ class TimelineUIs:
             element_manager=element_manager,
             scene=scene,
             view=view,
-            time_x_converter=self.time_x_converter
+            time_x_converter=self.time_x_converter,
         )
 
         self._add_to_timeline_uis_set(tl_ui)
@@ -253,9 +253,13 @@ class TimelineUIs:
         return tl_ui
 
     def on_timeline_component_created(
-            self, _: TlKind, tl_id: int, component_kind: ComponentKind, component_id: int,
-            get_data: Callable[[str, Any], None],
-            set_data: Callable[[str], Any],
+        self,
+        _: TlKind,
+        tl_id: int,
+        component_kind: ComponentKind,
+        component_id: int,
+        get_data: Callable[[str, Any], None],
+        set_data: Callable[[str], Any],
     ):
         self.get_timeline_ui(tl_id).on_timeline_component_created(
             component_kind, component_id, get_data, set_data
@@ -270,7 +274,7 @@ class TimelineUIs:
         self.get_timeline_ui(tl_id).on_timeline_component_deleted(component_id)
 
     def on_timeline_component_set_data_done(
-            self, timeline_id: int, component_id: int, attr: str, value: Any
+        self, timeline_id: int, component_id: int, attr: str, value: Any
     ):
         timeline_ui = self.get_timeline_ui(timeline_id)
         element = timeline_ui.get_element(component_id)
@@ -1022,7 +1026,7 @@ class TimelineUIs:
         if timeline_ui.timeline.KIND == TlKind.SLIDER_TIMELINE:
             return
 
-        timeline_ui.scene.set_playback_line_pos(get_x_by_time(time))
+        timeline_ui.scene.set_playback_line_pos(time_x_converter.get_x_by_time(time))
 
     def on_timelines_crop_done(self):
         for tlui in self:

--- a/tilia/ui/timelines/harmony/elements/harmony.py
+++ b/tilia/ui/timelines/harmony/elements/harmony.py
@@ -5,7 +5,7 @@ import typing
 import music21
 from PyQt6.QtCore import QPointF
 from PyQt6.QtGui import QFont, QColor
-from PyQt6.QtWidgets import QGraphicsScene, QGraphicsItem, QGraphicsTextItem
+from PyQt6.QtWidgets import QGraphicsItem, QGraphicsTextItem
 from music21.roman import RomanNumeral
 
 from . import harmony_attrs
@@ -46,10 +46,8 @@ class HarmonyUI(TimelineUIElement):
 
     CONTEXT_MENU_CLASS = HarmonyContextMenu
 
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
 
         self._setup_body()
 
@@ -209,7 +207,6 @@ class HarmonyUI(TimelineUIElement):
 
     def update_label(self):
         self.body.set_text(self.label)
-        # self.body.set_alternate_text(self.alternate_lable)
         self.body.set_position(self.x, self.y)
 
     def update_position(self):

--- a/tilia/ui/timelines/harmony/elements/harmony.py
+++ b/tilia/ui/timelines/harmony/elements/harmony.py
@@ -10,7 +10,7 @@ from music21.roman import RomanNumeral
 
 from . import harmony_attrs
 from tilia.requests import get, Get, post, Post
-from tilia.ui.coords import get_x_by_time, get_time_by_x
+from tilia.ui.coords import time_x_converter
 from tilia.ui.timelines.base.element import TimelineUIElement
 from tilia.ui.timelines.drag import DragManager
 from tilia.ui.timelines.harmony.constants import (
@@ -248,7 +248,7 @@ class HarmonyUI(TimelineUIElement):
             self.dragged = True
 
     def after_each_drag(self, drag_x: int):
-        self.set_data("time", get_time_by_x(drag_x))
+        self.set_data("time", time_x_converter.get_time_by_x(drag_x))
         self.update_label()
 
     def on_drag_end(self):

--- a/tilia/ui/timelines/harmony/elements/harmony.py
+++ b/tilia/ui/timelines/harmony/elements/harmony.py
@@ -46,14 +46,10 @@ class HarmonyUI(TimelineUIElement):
 
     CONTEXT_MENU_CLASS = HarmonyContextMenu
 
-    def __init__(
-        self,
-        id: int,
-        timeline_ui: HarmonyTimelineUI,
-        scene: QGraphicsScene,
-        **_,
-    ):
-        super().__init__(id=id, timeline_ui=timeline_ui, scene=scene)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
 
         self._setup_body()
 
@@ -63,10 +59,6 @@ class HarmonyUI(TimelineUIElement):
     def _setup_body(self):
         self.body = HarmonyBody(self.x, self.y, self.label, self.font_type)
         self.scene.addItem(self.body)
-
-    @property
-    def x(self):
-        return get_x_by_time(self.get_data("time"))
 
     @property
     def y(self):

--- a/tilia/ui/timelines/harmony/elements/mode.py
+++ b/tilia/ui/timelines/harmony/elements/mode.py
@@ -5,7 +5,7 @@ import typing
 import music21
 from PyQt6.QtCore import QPointF
 from PyQt6.QtGui import QFont, QColor
-from PyQt6.QtWidgets import QGraphicsScene, QGraphicsItem, QGraphicsTextItem
+from PyQt6.QtWidgets import QGraphicsItem, QGraphicsTextItem
 
 from tilia.requests import get, Get, post, Post
 from tilia.ui.coords import get_x_by_time, get_time_by_x
@@ -40,10 +40,6 @@ class ModeUI(TimelineUIElement):
     def _setup_body(self):
         self.body = ModeBody(self.x, self.y, self.label)
         self.scene.addItem(self.body)
-
-    @property
-    def x(self):
-        return get_x_by_time(self.get_data("time"))
 
     @property
     def y(self):
@@ -151,10 +147,10 @@ class ModeUI(TimelineUIElement):
 
 class ModeBody(QGraphicsTextItem):
     def __init__(
-            self,
-            x: float,
-            y: float,
-            text: str,
+        self,
+        x: float,
+        y: float,
+        text: str,
     ):
         super().__init__()
         self._setup_font()

--- a/tilia/ui/timelines/harmony/elements/mode.py
+++ b/tilia/ui/timelines/harmony/elements/mode.py
@@ -29,14 +29,8 @@ class ModeUI(TimelineUIElement):
     UPDATE_TRIGGERS = ["time", "step", "accidental", "type", "level"]
     CONTEXT_MENU_CLASS = ModeContextMenu
 
-    def __init__(
-        self,
-        id: int,
-        timeline_ui: HarmonyTimelineUI,
-        scene: QGraphicsScene,
-        **_,
-    ):
-        super().__init__(id=id, timeline_ui=timeline_ui, scene=scene)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self._setup_body()
 
@@ -157,10 +151,10 @@ class ModeUI(TimelineUIElement):
 
 class ModeBody(QGraphicsTextItem):
     def __init__(
-        self,
-        x: float,
-        y: float,
-        text: str,
+            self,
+            x: float,
+            y: float,
+            text: str,
     ):
         super().__init__()
         self._setup_font()

--- a/tilia/ui/timelines/harmony/elements/mode.py
+++ b/tilia/ui/timelines/harmony/elements/mode.py
@@ -8,7 +8,7 @@ from PyQt6.QtGui import QFont, QColor
 from PyQt6.QtWidgets import QGraphicsItem, QGraphicsTextItem
 
 from tilia.requests import get, Get, post, Post
-from tilia.ui.coords import get_x_by_time, get_time_by_x
+from tilia.ui.coords import time_x_converter
 from tilia.ui.timelines.base.element import TimelineUIElement
 from tilia.ui.timelines.drag import DragManager
 from tilia.ui.timelines.harmony.constants import (
@@ -125,7 +125,7 @@ class ModeUI(TimelineUIElement):
             self.dragged = True
 
     def after_each_drag(self, drag_x: int):
-        self.set_data("time", get_time_by_x(drag_x))
+        self.set_data("time", time_x_converter.get_time_by_x(drag_x))
 
     def on_drag_end(self):
         if self.dragged:

--- a/tilia/ui/timelines/hierarchy/drag.py
+++ b/tilia/ui/timelines/hierarchy/drag.py
@@ -2,7 +2,7 @@ import functools
 import math
 
 from tilia.requests import get, Get, post, Post
-from tilia.ui import coords
+from tilia.ui.coords import time_x_converter
 from tilia.ui.timelines.drag import DragManager
 from tilia.ui.timelines.hierarchy.handles import (
     HierarchyBodyHandle,
@@ -93,7 +93,7 @@ def before_each_drag(hierarchy_ui):
 
 
 def after_each_body_handle_drag(hierarchy_ui, extremity, x: int) -> None:
-    hierarchy_ui.set_data(extremity.value, coords.get_time_by_x(x))
+    hierarchy_ui.set_data(extremity.value, time_x_converter.get_time_by_x(x))
 
 
 def after_each_frame_handle_drag(extremity, uis, x: int):
@@ -102,7 +102,7 @@ def after_each_frame_handle_drag(extremity, uis, x: int):
         Extremity.POST_END: Extremity.END,
     }[extremity]
     if math.isclose(
-        time := coords.get_time_by_x(x),
+        time := time_x_converter.get_time_by_x(x),
         body_extremity_time := uis[0].get_data(body_extremity.value),
     ):
         time = body_extremity_time

--- a/tilia/ui/timelines/hierarchy/element.py
+++ b/tilia/ui/timelines/hierarchy/element.py
@@ -102,19 +102,12 @@ class HierarchyUI(TimelineUIElement):
         "color",
     ]
     CONTEXT_MENU_CLASS = HierarchyContextMenu
+    FONT_METRICS = QFontMetrics(QFont("Arial", 10))
 
-    def __init__(
-        self,
-        id: int,
-        timeline_ui: HierarchyTimelineUI,
-        scene: QGraphicsScene,
-        **_,
-    ):
-        super().__init__(id=id, timeline_ui=timeline_ui, scene=scene)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.previous_width = 0
-        self.timeline_ui = timeline_ui
-        self.scene = scene
 
         self.label_substrings_widths: list[int] = []
 
@@ -146,14 +139,6 @@ class HierarchyUI(TimelineUIElement):
         return settings.get("hierarchy_timeline", "default_colors")
 
     @property
-    def start_x(self):
-        return coords.get_x_by_time(self.get_data("start"))
-
-    @property
-    def end_x(self):
-        return coords.get_x_by_time(self.get_data("end"))
-
-    @property
     def has_pre_start(self):
         return self.get_data("pre_start") != self.get_data("start")
 
@@ -163,16 +148,15 @@ class HierarchyUI(TimelineUIElement):
 
     @property
     def pre_start_x(self):
-        return coords.get_x_by_time(self.get_data("pre_start"))
+        return self.timeline_ui.time_x_converter.get_x_by_time(self.get_data("pre_start"))
 
     @property
     def post_end_x(self):
-        return coords.get_x_by_time(self.get_data("post_end"))
+        return self.timeline_ui.time_x_converter.get_x_by_time(self.get_data("post_end"))
 
-    @property
-    def frame_handle_y(self):
-        return self.timeline_ui.get_data("height") - (
-            self.base_height + (self.get_data("level") - 1.5) * self.x_increment_per_lvl
+    def frame_handle_y(self, level, tl_height):
+        return tl_height - (
+            self.base_height + (level - 1.5) * self.x_increment_per_lvl
         )
 
     @property
@@ -192,22 +176,21 @@ class HierarchyUI(TimelineUIElement):
     def seek_time(self):
         return self.get_data("pre_start")
 
-    @property
-    def cropped_label(self):
+    def get_cropped_label(self, start_x, end_x, label):
         """
         Returns largest substring of self.label that fits inside body
         """
 
-        if not self.get_data("label"):
+        if not label:
             return ""
 
-        max_width = self.end_x - self.start_x
+        max_width = end_x - start_x
 
         for i, width in enumerate(self.label_substrings_widths):
             if width > max_width:
-                return self.get_data("label")[:i]
+                return label[:i]
 
-        return self.get_data("label")
+        return label
 
     @property
     def full_name(self) -> str:
@@ -242,15 +225,25 @@ class HierarchyUI(TimelineUIElement):
             self.post_end_handle.horizontal_line,
         ]
 
-    def update_label_substrings_widths(self):
+    def update_label_substrings_widths(self, value):
         """
-        Calculates length of substrings of label and stores it in self.label_measures
+        Calculates and stores width of substrings of 'value'
         """
         font_metrics = QFontMetrics(QFont("Arial", 10))
         self.label_substrings_widths = [
-            font_metrics.horizontalAdvance(self.get_data("label")[: i + 1])
-            for i in range(len(self.get_data("label")))
+            font_metrics.horizontalAdvance(value[: i + 1])
+            for i in range(len(value))
         ]
+
+    def update(self, attr: str, value):
+        if attr not in self.UPDATE_TRIGGERS:
+            return
+
+        update_func_name = "update_" + attr
+        if not hasattr(self, update_func_name):
+            raise ValueError(f"{self} has no updater function for attribute '{attr}'")
+
+        getattr(self, update_func_name)()
 
     def update_color(self):
         self.body.set_fill(self.ui_color)
@@ -258,10 +251,20 @@ class HierarchyUI(TimelineUIElement):
     def update_comments(self):
         self.comments_icon.setVisible(bool(self.get_data("comments")))
 
-    def update_label(self):
-        self.update_label_substrings_widths()
-        self.label.set_text(self.cropped_label)
-        self.update_label_position()
+    def update_label(self, start_x=None, end_x=None, level=None, height=None):
+        # if called from update_position,
+        # start_x and end_x will already be available
+        start_x = start_x or self.start_x
+        end_x = end_x or self.end_x
+        level = level or self.get_data("level")
+        height = height or self.timeline_ui.get_data('height')
+
+        new_label = self.get_data('label')
+        if new_label != self.label.toPlainText():
+            self.update_label_substrings_widths(new_label)
+
+        self.label.set_text(self.get_cropped_label(start_x, end_x, new_label))
+        self.update_label_position(level, height, start_x, end_x)
 
     def update_level(self):
         self.update_position()
@@ -274,71 +277,76 @@ class HierarchyUI(TimelineUIElement):
         self.update_position()
 
     def update_pre_start(self):
-        self.update_frame_handle_position(Extremity.PRE_START)
+        self.update_frame_handle_position(Extremity.PRE_START, self.get_data('level'), self.timeline_ui.get_data('height'), self.start_x)
         if self.is_selected():
             self.update_frame_handle_visibility(Extremity.PRE_START)
 
     def update_post_end(self):
-        self.update_frame_handle_position(Extremity.POST_END)
+        self.update_frame_handle_position(Extremity.POST_END, self.get_data('level'), self.timeline_ui.get_data('height'), self.end_x)
         if self.is_selected():
             self.update_frame_handle_visibility(Extremity.POST_END)
 
     def update_position(self):
-        self.update_body_position()
-        self.update_comments_icon_position()
-        self.update_loop_icon_position()
-        self.update_label_position()
-        self.update_label()
-        self.update_body_handles_position()
-        self.update_frame_handles_position()
+        start_x = self.start_x
+        end_x = self.end_x
+        level = self.get_data("level")
+        height = self.timeline_ui.get_data('height')
 
-    def update_body_position(self):
+        self.update_body_position(level, height, start_x, end_x)
+        self.update_comments_icon_position(level, height, end_x)
+        self.update_loop_icon_position(level, height, start_x)
+        self.update_label_position(level, height, start_x, end_x)
+        self.update_label(start_x, end_x, level, height)
+        self.update_body_handles_position(height, start_x, end_x)
+        self.update_frame_handles_position(level, height, start_x, end_x)
+
+    def update_body_position(self, level, height, start_x, end_x):
         self.body.set_position(
-            self.get_data("level"),
-            self.start_x,
-            self.end_x,
-            self.timeline_ui.get_data("height"),
+            level,
+            start_x,
+            end_x,
+            height,
         )
 
-    def update_comments_icon_position(self):
+    def update_comments_icon_position(self, level, height, end_x):
         self.comments_icon.set_position(
-            self.end_x, self.timeline_ui.get_data("height"), self.get_data("level")
+            end_x, level, height
         )
 
-    def update_loop_icon_position(self):
+    def update_loop_icon_position(self, level, height, start_x):
         self.loop_icon.set_position(
-            self.start_x, self.timeline_ui.get_data("height"), self.get_data("level")
+           start_x, height, level
         )
 
-    def update_label_position(self):
+    def update_label_position(self, level, height, start_x, end_x):
         self.label.set_position(
-            (self.start_x + self.end_x) / 2,
-            self.timeline_ui.get_data("height"),
-            self.get_data("level"),
+            (start_x + end_x) / 2,
+            height,
+            level,
         )
 
-    def update_body_handles_position(self):
+    def update_body_handles_position(self, height, start_x, end_x):
         for extremity in [Extremity.START, Extremity.END]:
             self.extremity_to_handle(extremity).set_position(
-                self.extremity_to_x(extremity),
+                self.extremity_to_x(extremity, start_x, end_x),
                 self.HANDLE_WIDTH,
                 self.handle_height,
-                self.timeline_ui.get_data("height"),
+                height,
                 self.HANDLE_Y_MARGIN,
             )
 
-    def update_frame_handles_position(self):
-        self.update_frame_handle_position(Extremity.PRE_START)
-        self.update_frame_handle_position(Extremity.POST_END)
+    def update_frame_handles_position(self, level, height, start_x, end_x):
+        self.update_frame_handle_position(Extremity.PRE_START, level, height, start_x)
+        self.update_frame_handle_position(Extremity.POST_END, level, height, end_x)
 
-    def update_frame_handle_position(self, extremity: Extremity):
+    def update_frame_handle_position(self, extremity: Extremity, level, height, body_x):
         if extremity == Extremity.PRE_START:
             self.pre_start_handle.set_position(
-                self.start_x, self.pre_start_x, self.frame_handle_y
+                body_x, self.pre_start_x, self.frame_handle_y(level, height)
             )
         elif extremity == Extremity.POST_END:
             self.post_end_handle.set_position(
-                self.end_x, self.post_end_x, self.frame_handle_y
+                body_x, self.post_end_x, self.frame_handle_y(level, height)
             )
         else:
             raise ValueError("Unrecognized extremity")
@@ -369,12 +377,12 @@ class HierarchyUI(TimelineUIElement):
         self.scene.addItem(self.body)
 
     def _setup_label(self):
-        self.update_label_substrings_widths()
+        self.update_label_substrings_widths(self.get_data("label"))
         self.label = HierarchyLabel(
             (self.start_x + self.end_x) / 2,
             self.timeline_ui.get_data("height"),
             self.get_data("level"),
-            self.cropped_label,
+            self.get_cropped_label(self.start_x, self.end_x, self.get_data("label")),
         )
         self.scene.addItem(self.label)
 
@@ -407,7 +415,7 @@ class HierarchyUI(TimelineUIElement):
             self.scene.addItem(self.end_handle)
 
     def _setup_frame_handles(self):
-        y = self.frame_handle_y
+        y = self.frame_handle_y(self.get_data("level"), self.timeline_ui.get_data("height"))
         self.pre_start_handle = HierarchyFrameHandle(self.start_x, self.pre_start_x, y)
         self.scene.addItem(self.pre_start_handle)
 
@@ -450,17 +458,17 @@ class HierarchyUI(TimelineUIElement):
         except KeyError:
             raise ValueError(f"{handle} if not a handle of {self}")
 
-    def extremity_to_x(self, extremity: Extremity):
+    def extremity_to_x(self, extremity: Extremity, start_x, end_x):
         if extremity == Extremity.START:
-            return self.start_x
+            return start_x
         elif extremity == Extremity.END:
-            return self.end_x
+            return end_x
         else:
             raise ValueError("Unrecognized extremity")
 
     def _setup_handle(self, extremity: Extremity):
         return HierarchyBodyHandle(
-            self.extremity_to_x(extremity),
+            self.extremity_to_x(extremity, self.start_x, self.end_x),
             self.HANDLE_WIDTH,
             self.handle_height,
             self.timeline_ui.get_data("height"),
@@ -713,7 +721,8 @@ class HierarchyLabel(CursorMixIn, QGraphicsTextItem):
         self.setZValue(level + 1)
 
     def set_text(self, value: str):
-        self.setPlainText(value)
+        if value != self.toPlainText():
+            self.setPlainText(value)
 
 
 class HierarchyCommentsIcon(CursorMixIn, QGraphicsTextItem):

--- a/tilia/ui/timelines/hierarchy/element.py
+++ b/tilia/ui/timelines/hierarchy/element.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from PyQt6.QtCore import Qt, QRectF, QPointF
 from PyQt6.QtGui import QColor, QPen, QFont, QFontMetrics, QPixmap
 from PyQt6.QtWidgets import (
-    QGraphicsScene,
     QGraphicsPixmapItem,
     QGraphicsRectItem,
     QGraphicsTextItem,
@@ -148,16 +147,18 @@ class HierarchyUI(TimelineUIElement):
 
     @property
     def pre_start_x(self):
-        return self.timeline_ui.time_x_converter.get_x_by_time(self.get_data("pre_start"))
+        return self.timeline_ui.time_x_converter.get_x_by_time(
+            self.get_data("pre_start")
+        )
 
     @property
     def post_end_x(self):
-        return self.timeline_ui.time_x_converter.get_x_by_time(self.get_data("post_end"))
+        return self.timeline_ui.time_x_converter.get_x_by_time(
+            self.get_data("post_end")
+        )
 
     def frame_handle_y(self, level, tl_height):
-        return tl_height - (
-            self.base_height + (level - 1.5) * self.x_increment_per_lvl
-        )
+        return tl_height - (self.base_height + (level - 1.5) * self.x_increment_per_lvl)
 
     @property
     def ui_color(self):
@@ -231,8 +232,7 @@ class HierarchyUI(TimelineUIElement):
         """
         font_metrics = QFontMetrics(QFont("Arial", 10))
         self.label_substrings_widths = [
-            font_metrics.horizontalAdvance(value[: i + 1])
-            for i in range(len(value))
+            font_metrics.horizontalAdvance(value[: i + 1]) for i in range(len(value))
         ]
 
     def update(self, attr: str, value):
@@ -257,9 +257,9 @@ class HierarchyUI(TimelineUIElement):
         start_x = start_x or self.start_x
         end_x = end_x or self.end_x
         level = level or self.get_data("level")
-        height = height or self.timeline_ui.get_data('height')
+        height = height or self.timeline_ui.get_data("height")
 
-        new_label = self.get_data('label')
+        new_label = self.get_data("label")
         if new_label != self.label.toPlainText():
             self.update_label_substrings_widths(new_label)
 
@@ -277,12 +277,22 @@ class HierarchyUI(TimelineUIElement):
         self.update_position()
 
     def update_pre_start(self):
-        self.update_frame_handle_position(Extremity.PRE_START, self.get_data('level'), self.timeline_ui.get_data('height'), self.start_x)
+        self.update_frame_handle_position(
+            Extremity.PRE_START,
+            self.get_data("level"),
+            self.timeline_ui.get_data("height"),
+            self.start_x,
+        )
         if self.is_selected():
             self.update_frame_handle_visibility(Extremity.PRE_START)
 
     def update_post_end(self):
-        self.update_frame_handle_position(Extremity.POST_END, self.get_data('level'), self.timeline_ui.get_data('height'), self.end_x)
+        self.update_frame_handle_position(
+            Extremity.POST_END,
+            self.get_data("level"),
+            self.timeline_ui.get_data("height"),
+            self.end_x,
+        )
         if self.is_selected():
             self.update_frame_handle_visibility(Extremity.POST_END)
 
@@ -290,7 +300,7 @@ class HierarchyUI(TimelineUIElement):
         start_x = self.start_x
         end_x = self.end_x
         level = self.get_data("level")
-        height = self.timeline_ui.get_data('height')
+        height = self.timeline_ui.get_data("height")
 
         self.update_body_position(level, height, start_x, end_x)
         self.update_comments_icon_position(level, height, end_x)
@@ -309,14 +319,10 @@ class HierarchyUI(TimelineUIElement):
         )
 
     def update_comments_icon_position(self, level, height, end_x):
-        self.comments_icon.set_position(
-            end_x, level, height
-        )
+        self.comments_icon.set_position(end_x, level, height)
 
     def update_loop_icon_position(self, level, height, start_x):
-        self.loop_icon.set_position(
-           start_x, height, level
-        )
+        self.loop_icon.set_position(start_x, height, level)
 
     def update_label_position(self, level, height, start_x, end_x):
         self.label.set_position(
@@ -415,7 +421,9 @@ class HierarchyUI(TimelineUIElement):
             self.scene.addItem(self.end_handle)
 
     def _setup_frame_handles(self):
-        y = self.frame_handle_y(self.get_data("level"), self.timeline_ui.get_data("height"))
+        y = self.frame_handle_y(
+            self.get_data("level"), self.timeline_ui.get_data("height")
+        )
         self.pre_start_handle = HierarchyFrameHandle(self.start_x, self.pre_start_x, y)
         self.scene.addItem(self.pre_start_handle)
 

--- a/tilia/ui/timelines/hierarchy/element.py
+++ b/tilia/ui/timelines/hierarchy/element.py
@@ -21,9 +21,9 @@ from .drag import start_drag
 from .extremity import Extremity
 from .handles import HierarchyBodyHandle, HierarchyFrameHandle
 from ..cursors import CursorMixIn
-from ... import coords
 from ...color import get_tinted_color, get_untinted_color
 from ...consts import TINT_FACTOR_ON_SELECTION
+from ...coords import time_x_converter
 from ...windows.inspect import HIDE_FIELD, InspectRowKind
 
 if TYPE_CHECKING:
@@ -147,15 +147,11 @@ class HierarchyUI(TimelineUIElement):
 
     @property
     def pre_start_x(self):
-        return self.timeline_ui.time_x_converter.get_x_by_time(
-            self.get_data("pre_start")
-        )
+        return time_x_converter.get_x_by_time(self.get_data("pre_start"))
 
     @property
     def post_end_x(self):
-        return self.timeline_ui.time_x_converter.get_x_by_time(
-            self.get_data("post_end")
-        )
+        return time_x_converter.get_x_by_time(self.get_data("post_end"))
 
     def frame_handle_y(self, level, tl_height):
         return tl_height - (self.base_height + (level - 1.5) * self.x_increment_per_lvl)

--- a/tilia/ui/timelines/hierarchy/timeline.py
+++ b/tilia/ui/timelines/hierarchy/timeline.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from tilia.requests import get, Get, Post, listen
+from tilia.requests import get, Get, Post, listen, stop_listening_to_all
 from tilia.timelines.hierarchy.common import (
     update_component_genealogy,
 )
@@ -33,15 +33,15 @@ class HierarchyTimelineUI(TimelineUI):
         super().__init__(*args, **kwargs)
         listen(self, Post.SETTINGS_UPDATED, lambda updated_settings: self.on_settings_updated(updated_settings))
 
-    def on_settings_updated(self, updated_settings):        
+    def on_settings_updated(self, updated_settings):
         if "hierarchy_timeline" in updated_settings:
             get(Get.TIMELINE_COLLECTION).set_timeline_data(self.id, "height", self.timeline.default_height)
             for hierarchy_ui in self:
                 hierarchy_ui.update_position()
-                hierarchy_ui.update_color()            
+                hierarchy_ui.update_color()
 
     def on_timeline_element_request(
-        self, request, selector: ElementSelector, *args, **kwargs
+            self, request, selector: ElementSelector, *args, **kwargs
     ):
         return HierarchyUIRequestHandler(self).on_request(
             request, selector, *args, **kwargs
@@ -68,7 +68,7 @@ class HierarchyTimelineUI(TimelineUI):
             )
 
     def get_units_sharing_handle(
-        self, handle: HierarchyBodyHandle
+            self, handle: HierarchyBodyHandle
     ) -> list[HierarchyBodyHandle]:
         def is_using_handle(e: HierarchyUI):
             return e.start_handle == handle or e.end_handle == handle
@@ -111,11 +111,11 @@ class HierarchyTimelineUI(TimelineUI):
             self.select_element(element)
 
     def _create_child_from_paste_data(
-        self,
-        new_parent: HierarchyUI,
-        prev_parent_start: float,
-        prev_parent_end: float,
-        child_pastedata_: dict,
+            self,
+            new_parent: HierarchyUI,
+            prev_parent_start: float,
+            prev_parent_end: float,
+            child_pastedata_: dict,
     ):
 
         new_parent_length = new_parent.tl_component.end - new_parent.tl_component.start
@@ -124,20 +124,20 @@ class HierarchyTimelineUI(TimelineUI):
         scale_factor = new_parent_length / prev_parent_length
 
         relative_child_start = (
-            child_pastedata_["support_by_component_value"]["start"] - prev_parent_start
+                child_pastedata_["support_by_component_value"]["start"] - prev_parent_start
         )
 
         new_child_start = (
-            relative_child_start * scale_factor
-        ) + new_parent.tl_component.start
+                                  relative_child_start * scale_factor
+                          ) + new_parent.tl_component.start
 
         relative_child_end = (
-            child_pastedata_["support_by_component_value"]["end"] - prev_parent_end
+                child_pastedata_["support_by_component_value"]["end"] - prev_parent_end
         )
 
         new_child_end = (
-            relative_child_end * scale_factor
-        ) + new_parent.tl_component.end
+                                relative_child_end * scale_factor
+                        ) + new_parent.tl_component.end
 
         component, _ = self.timeline.create_component(
             kind=ComponentKind.HIERARCHY,
@@ -173,12 +173,12 @@ class HierarchyTimelineUI(TimelineUI):
             update_component_genealogy(element.tl_component, children_of_element)
 
     def paste_with_children_into_elements(
-        self, elements: list[HierarchyUI], data: list[dict]
+            self, elements: list[HierarchyUI], data: list[dict]
     ):
         def get_descendants(parent: HierarchyUI):
             is_in_branch = (
                 lambda e: e.tl_component.start >= parent.tl_component.start
-                and e.tl_component.end <= parent.tl_component.end
+                          and e.tl_component.end <= parent.tl_component.end
             )
             elements_in_branch = self.element_manager.get_elements_by_condition(
                 is_in_branch

--- a/tilia/ui/timelines/marker/element.py
+++ b/tilia/ui/timelines/marker/element.py
@@ -17,7 +17,7 @@ from ..drag import DragManager
 from ...color import get_tinted_color
 from ...format import format_media_time
 from ...consts import TINT_FACTOR_ON_SELECTION
-from ...coords import get_x_by_time, get_time_by_x
+from ...coords import time_x_converter
 from tilia.settings import settings
 from tilia.ui.timelines.base.element import TimelineUIElement
 from ...windows.inspect import InspectRowKind
@@ -142,7 +142,7 @@ class MarkerUI(TimelineUIElement):
             self.dragged = True
 
     def after_each_drag(self, drag_x: int):
-        self.set_data("time", get_time_by_x(drag_x))
+        self.set_data("time", time_x_converter.get_time_by_x(drag_x))
 
     def on_drag_end(self):
         if self.dragged:

--- a/tilia/ui/timelines/marker/element.py
+++ b/tilia/ui/timelines/marker/element.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable
 
 from PyQt6.QtCore import QPointF, Qt
 from PyQt6.QtGui import QPolygonF, QPen, QColor, QFont
@@ -49,14 +49,9 @@ class MarkerUI(TimelineUIElement):
 
     CONTEXT_MENU_CLASS = MarkerContextMenu
 
-    def __init__(
-        self,
-        id: int,
-        timeline_ui: MarkerTimelineUI,
-        scene: QGraphicsScene,
-        **_,
-    ):
-        super().__init__(id=id, timeline_ui=timeline_ui, scene=scene)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self._setup_body()
         self._setup_label()
@@ -71,10 +66,6 @@ class MarkerUI(TimelineUIElement):
     def _setup_label(self):
         self.label = MarkerLabel(self.x, self.label_y, self.get_data("label"))
         self.scene.addItem(self.label)
-
-    @property
-    def x(self):
-        return get_x_by_time(self.get_data("time"))
 
     @property
     def label_y(self):
@@ -116,8 +107,9 @@ class MarkerUI(TimelineUIElement):
         self.update_time()
 
     def update_time(self):
-        self.body.set_position(self.x, self.width, self.height)
-        self.label.set_position(self.x, self.label_y)
+        x = self.x
+        self.body.set_position(x, self.width, self.height)
+        self.label.set_position(x, self.label_y)
 
     def child_items(self):
         return [self.body, self.label]

--- a/tilia/ui/timelines/marker/element.py
+++ b/tilia/ui/timelines/marker/element.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any, Callable
 from PyQt6.QtCore import QPointF, Qt
 from PyQt6.QtGui import QPolygonF, QPen, QColor, QFont
 from PyQt6.QtWidgets import (
-    QGraphicsScene,
     QGraphicsItem,
     QGraphicsPolygonItem,
     QGraphicsTextItem,
@@ -49,7 +48,6 @@ class MarkerUI(TimelineUIElement):
 
     CONTEXT_MENU_CLASS = MarkerContextMenu
 
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -74,11 +72,11 @@ class MarkerUI(TimelineUIElement):
     @property
     def seek_time(self):
         return self.get_data("time")
-    
+
     @property
     def width(self):
         return settings.get("marker_timeline", "marker_width")
-    
+
     @property
     def height(self):
         return settings.get("marker_timeline", "marker_height")

--- a/tilia/ui/timelines/pdf/element.py
+++ b/tilia/ui/timelines/pdf/element.py
@@ -23,7 +23,7 @@ from ..copy_paste import CopyAttributes
 from ..cursors import CursorMixIn
 from ..drag import DragManager
 from ...format import format_media_time
-from ...coords import get_time_by_x
+from ...coords import time_x_converter
 from tilia.ui.timelines.base.element import TimelineUIElement
 from ...windows.inspect import InspectRowKind
 
@@ -120,7 +120,7 @@ class PdfMarkerUI(TimelineUIElement):
             self.dragged = True
 
     def after_each_drag(self, drag_x: int):
-        self.set_data("time", get_time_by_x(drag_x))
+        self.set_data("time", time_x_converter.get_time_by_x(drag_x))
 
     def on_drag_end(self):
         if self.dragged:

--- a/tilia/ui/timelines/pdf/element.py
+++ b/tilia/ui/timelines/pdf/element.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from PyQt6.QtCore import QPointF, Qt
 from PyQt6.QtGui import (
@@ -12,7 +11,6 @@ from PyQt6.QtGui import (
     QFontMetrics,
 )
 from PyQt6.QtWidgets import (
-    QGraphicsScene,
     QGraphicsItem,
     QGraphicsTextItem,
     QGraphicsPixmapItem,
@@ -25,12 +23,9 @@ from ..copy_paste import CopyAttributes
 from ..cursors import CursorMixIn
 from ..drag import DragManager
 from ...format import format_media_time
-from ...coords import get_x_by_time, get_time_by_x
+from ...coords import get_time_by_x
 from tilia.ui.timelines.base.element import TimelineUIElement
 from ...windows.inspect import InspectRowKind
-
-if TYPE_CHECKING:
-    from .timeline import PdfTimelineUI
 
 
 class PdfMarkerUI(TimelineUIElement):
@@ -51,14 +46,8 @@ class PdfMarkerUI(TimelineUIElement):
 
     CONTEXT_MENU_CLASS = PdfMarkerContextMenu
 
-    def __init__(
-        self,
-        id: int,
-        timeline_ui: PdfTimelineUI,
-        scene: QGraphicsScene,
-        **_,
-    ):
-        super().__init__(id=id, timeline_ui=timeline_ui, scene=scene)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.INSPECTOR_FIELDS = [
             (
@@ -82,10 +71,6 @@ class PdfMarkerUI(TimelineUIElement):
         self.scene.addItem(self.label)
 
     @property
-    def x(self):
-        return get_x_by_time(self.get_data("time"))
-
-    @property
     def seek_time(self):
         return self.get_data("time")
 
@@ -97,8 +82,9 @@ class PdfMarkerUI(TimelineUIElement):
         self.update_time()
 
     def update_time(self):
-        self.body.set_position(self.x)
-        self.label.set_position(self.x)
+        x = self.x
+        self.body.set_position(x)
+        self.label.set_position(x)
 
     def update_page_number(self):
         self.label.set_text(str(self.get_data("page_number")))

--- a/tilia/ui/timelines/pdf/timeline.py
+++ b/tilia/ui/timelines/pdf/timeline.py
@@ -13,6 +13,7 @@ from tilia.timelines.component_kinds import ComponentKind
 from tilia.requests import Get, get, listen, Post
 from tilia.enums import Side
 from tilia.timelines.timeline_kinds import TimelineKind
+from tilia.ui.coords import TimeXConverter
 from tilia.ui.timelines.base.element import TimelineUIElement
 from tilia.ui.timelines.base.timeline import (
     TimelineUI,
@@ -50,8 +51,9 @@ class PdfTimelineUI(TimelineUI):
         element_manager: ElementManager,
         scene: TimelineScene,
         view: TimelineView,
+        time_x_converter: TimeXConverter | None = None,
     ):
-        super().__init__(id, collection, element_manager, scene, view)
+        super().__init__(id, collection, element_manager, scene, view, time_x_converter)
 
         self._setup_pdf_document()
         self._load_pdf_file()
@@ -113,8 +115,8 @@ class PdfTimelineUI(TimelineUI):
             request, selector, *args, **kwargs
         )
 
-    def on_timeline_component_created(self, kind: ComponentKind, id: int):
-        super().on_timeline_component_created(kind, id)
+    def on_timeline_component_created(self, kind: ComponentKind, id: int, get_data, set_data):
+        super().on_timeline_component_created(kind, id, get_data, set_data)
         self.update_displayed_page(get(Get.MEDIA_CURRENT_TIME))
 
     def on_timeline_component_deleted(self, id: int):

--- a/tilia/ui/timelines/pdf/timeline.py
+++ b/tilia/ui/timelines/pdf/timeline.py
@@ -13,7 +13,6 @@ from tilia.timelines.component_kinds import ComponentKind
 from tilia.requests import Get, get, listen, Post
 from tilia.enums import Side
 from tilia.timelines.timeline_kinds import TimelineKind
-from tilia.ui.coords import TimeXConverter
 from tilia.ui.timelines.base.element import TimelineUIElement
 from tilia.ui.timelines.base.timeline import (
     TimelineUI,
@@ -51,9 +50,8 @@ class PdfTimelineUI(TimelineUI):
         element_manager: ElementManager,
         scene: TimelineScene,
         view: TimelineView,
-        time_x_converter: TimeXConverter | None = None,
     ):
-        super().__init__(id, collection, element_manager, scene, view, time_x_converter)
+        super().__init__(id, collection, element_manager, scene, view)
 
         self._setup_pdf_document()
         self._load_pdf_file()
@@ -115,7 +113,9 @@ class PdfTimelineUI(TimelineUI):
             request, selector, *args, **kwargs
         )
 
-    def on_timeline_component_created(self, kind: ComponentKind, id: int, get_data, set_data):
+    def on_timeline_component_created(
+        self, kind: ComponentKind, id: int, get_data, set_data
+    ):
         super().on_timeline_component_created(kind, id, get_data, set_data)
         self.update_displayed_page(get(Get.MEDIA_CURRENT_TIME))
 

--- a/tilia/ui/timelines/slider/timeline.py
+++ b/tilia/ui/timelines/slider/timeline.py
@@ -9,12 +9,10 @@ from PyQt6.QtWidgets import (
     QGraphicsDropShadowEffect,
 )
 
-import tilia.ui.coords
 from tilia.media.player.base import MediaTimeChangeReason
 from tilia.requests import get, Get, post
 from tilia.timelines.component_kinds import ComponentKind
 from tilia.timelines.timeline_kinds import TimelineKind
-from tilia.ui import coords
 from tilia.ui.modifier_enum import ModifierEnum
 from tilia.settings import settings
 from tilia.requests import Post, listen
@@ -23,7 +21,7 @@ from tilia.ui.timelines.base.timeline import TimelineUI
 from tilia.ui.timelines.base.element_manager import ElementManager
 from tilia.ui.timelines.drag import DragManager
 from tilia.ui.timelines.view import TimelineView
-from tilia.ui.coords import TimeXConverter
+from tilia.ui.coords import time_x_converter
 from ..cursors import CursorMixIn
 
 if TYPE_CHECKING:
@@ -44,7 +42,6 @@ class SliderTimelineUI(TimelineUI):
         element_manager: ElementManager,
         scene: TimelineScene,
         view: TimelineView,
-        time_x_converter: TimeXConverter | None = None,
     ):
         super().__init__(
             id=id,
@@ -52,7 +49,6 @@ class SliderTimelineUI(TimelineUI):
             element_manager=element_manager,
             scene=scene,
             view=view,
-            time_x_converter=time_x_converter,
         )
 
         listen(self, Post.PLAYER_CURRENT_TIME_CHANGED, self.on_audio_time_change)
@@ -131,7 +127,7 @@ class SliderTimelineUI(TimelineUI):
         self, item_id: int, modifier: ModifierEnum, double: bool, x: int, y: int
     ) -> None:
         if item_id == self.line:
-            time = tilia.ui.coords.get_time_by_x(x)
+            time = time_x_converter.get_time_by_x(x)
             if double:
                 post(Post.PLAYER_SEEK, time)
             else:
@@ -159,13 +155,15 @@ class SliderTimelineUI(TimelineUI):
         post(Post.SLIDER_DRAG, x)
 
     def on_drag_end(self):
-        post(Post.PLAYER_SEEK, coords.get_time_by_x(self.x))  # maybe not necessary
+        post(
+            Post.PLAYER_SEEK, time_x_converter.get_time_by_x(self.x)
+        )  # maybe not necessary
         self.dragging = False
         post(Post.SLIDER_DRAG_END)
 
     def on_audio_time_change(self, time: float, _: MediaTimeChangeReason) -> None:
         if not self.dragging:
-            self.x = coords.get_x_by_time(time)
+            self.x = time_x_converter.get_x_by_time(time)
             self.set_trough_position()
 
     def get_ui_for_component(
@@ -174,7 +172,7 @@ class SliderTimelineUI(TimelineUI):
         """No components in SliderTimeline. Must implement abstract method."""
 
     def update_items_position(self):
-        self.x = coords.get_x_by_time(get(Get.MEDIA_CURRENT_TIME))
+        self.x = time_x_converter.get_x_by_time(get(Get.MEDIA_CURRENT_TIME))
         self.set_trough_position()
         self.line.set_position(*self._get_line_pos_args())
 

--- a/tilia/ui/timelines/slider/timeline.py
+++ b/tilia/ui/timelines/slider/timeline.py
@@ -23,6 +23,7 @@ from tilia.ui.timelines.base.timeline import TimelineUI
 from tilia.ui.timelines.base.element_manager import ElementManager
 from tilia.ui.timelines.drag import DragManager
 from tilia.ui.timelines.view import TimelineView
+from tilia.ui.coords import TimeXConverter
 from ..cursors import CursorMixIn
 
 if TYPE_CHECKING:
@@ -43,6 +44,7 @@ class SliderTimelineUI(TimelineUI):
         element_manager: ElementManager,
         scene: TimelineScene,
         view: TimelineView,
+        time_x_converter: TimeXConverter | None = None,
     ):
         super().__init__(
             id=id,
@@ -50,6 +52,7 @@ class SliderTimelineUI(TimelineUI):
             element_manager=element_manager,
             scene=scene,
             view=view,
+            time_x_converter=time_x_converter,
         )
 
         listen(self, Post.PLAYER_CURRENT_TIME_CHANGED, self.on_audio_time_change)

--- a/tilia/ui/windows/settings.py
+++ b/tilia/ui/windows/settings.py
@@ -221,6 +221,12 @@ def select_color_button(value, text=None):
 
 def get_widget_for_value(value, text=None) -> QWidget:
     match value:
+        case bool():
+            checkbox = QCheckBox()
+            checkbox.setChecked(value)
+            checkbox.setObjectName("checkbox")
+            return checkbox
+
         case int():
             int_input = QSpinBox()
             int_input.setMaximum(2147483647)
@@ -246,12 +252,6 @@ def get_widget_for_value(value, text=None) -> QWidget:
             return widget
 
         case str():
-            if value in ["true", "false"]:
-                checkbox = QCheckBox()
-                checkbox.setChecked(True if value == "true" else False)
-                checkbox.setObjectName("checkbox")
-                return checkbox
-
             if len(value) and value[0] == "#":
                 return select_color_button(value, text)
 
@@ -288,7 +288,7 @@ def get_value_for_widget(widget: QWidget):
             return output_list
 
         case "checkbox":
-            return "true" if widget.isChecked() else "false"
+            return widget.isChecked()
 
         case "color":
             return widget.styleSheet().lstrip("background-color: ").split(";")[0]


### PR DESCRIPTION
This implements a lot of small optimizations that add up to a ~20x speed increase in zooming. This makes zooming on large files, previously prohibitively slow, smooth enough to not be bothersome.

The main optimizations were:
- Passing `get_data` and `set_data` functions to `TimelinUIElement` instances so they have faster access to component properties
- Creating a `TimeXConverter` class to cache values (such as media duration) used in almost every `TimelineUIElement` position caculation
- Remove duplicate calculation of positions values on specific `TimelineUIElement` subclasses (e.g. `HierarchyUI`
- Optmizing `HierarchyUI.update_lavel`
- Cache settings, as some are acessed every time a component needs to be repositioned