### PR TITLE
Fix moving to parent's level

### DIFF
--- a/tests/ui/timelines/hierarchy/test_hierarchy_timeline_ui.py
+++ b/tests/ui/timelines/hierarchy/test_hierarchy_timeline_ui.py
@@ -64,6 +64,19 @@ class TestActions:
         assert tlui[1].get_data('level') == 2
         assert tlui[2].get_data('level') == 2
 
+    def test_increase_level_parent_at_higher_level(self, tlui, user_actions):
+        tlui.create_hierarchy(0, 1, 1)
+        tlui.create_hierarchy(0, 1, 2)
+
+        tlui.timeline.do_genealogy()
+
+        tlui.select_element(tlui[0])
+        tlui.select_element(tlui[1])
+        user_actions.trigger(TiliaAction.HIERARCHY_INCREASE_LEVEL)
+
+        assert tlui[0].get_data('level') == 2
+        assert tlui[1].get_data('level') == 3
+
     def test_decrease_level(self, tlui, user_actions):
         tlui.create_hierarchy(0, 1, 2)
         tlui.create_hierarchy(1, 2, 2)
@@ -89,6 +102,19 @@ class TestActions:
         assert tlui[0].get_data('level') == 1
         assert tlui[1].get_data('level') == 1
         assert tlui[2].get_data('level') == 1
+
+    def test_decrease_level_with_child_at_lower_level(self, tlui, user_actions):
+        tlui.create_hierarchy(0, 1, 2)
+        tlui.create_hierarchy(0, 1, 3)
+
+        tlui.timeline.do_genealogy()
+
+        tlui.select_element(tlui[0])
+        tlui.select_element(tlui[1])
+        user_actions.trigger(TiliaAction.HIERARCHY_DECREASE_LEVEL)
+
+        assert tlui[0].get_data('level') == 1
+        assert tlui[1].get_data('level') == 2
 
     def test_set_color(self, tlui, user_actions):
         tlui.create_hierarchy(0, 1, 1)

--- a/tilia/ui/timelines/base/request_handlers.py
+++ b/tilia/ui/timelines/base/request_handlers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import functools
-from typing import Callable
+from typing import Callable, Iterator
 
 from tilia.requests import Post, get, Get
 from tilia.ui.enums import PasteCardinality
@@ -75,7 +75,7 @@ class ElementRequestHandler(RequestHandler):
         return get(Get.TIMELINE, self.timeline_ui.id)
 
     @staticmethod
-    def elements_to_components(elements: list[TimelineUIElement]):
+    def elements_to_components(elements: Iterator[TimelineUIElement]):
         return [e.tl_component for e in elements]
 
     def on_paste(self, *_, **__):

--- a/tilia/ui/timelines/hierarchy/request_handlers.py
+++ b/tilia/ui/timelines/hierarchy/request_handlers.py
@@ -37,7 +37,7 @@ class HierarchyUIRequestHandler(ElementRequestHandler):
 
     @fallible
     def on_increase_level(self, elements, *_, **__):
-        return self.timeline.alter_levels(self.elements_to_components(elements), 1)
+        return self.timeline.alter_levels(self.elements_to_components(reversed(elements)), 1)
 
     @fallible
     def on_decrease_level(self, elements, *_, **__):


### PR DESCRIPTION
This fixes one of the issues pointed out in #198, where it was not possible to move hierarchies up to their parent's level.