### PR TITLE
Option to make room for new child

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,9 @@ class TiliaState:
     def duration(self, value):
         self.app.set_file_media_duration(value)
 
-    def set_duration(self, value, scale_timelines: Literal['yes', 'no', 'prompt'] = 'prompt'):
+    def set_duration(
+        self, value, scale_timelines: Literal["yes", "no", "prompt"] = "prompt"
+    ):
         """Use this if you want to pass scale_timelines."""
         self.app.set_file_media_duration(value, scale_timelines)
 
@@ -162,7 +164,9 @@ def resources() -> Path:
 
 @pytest.fixture(scope="module")
 def use_test_settings(qapplication) -> None:
-    settings_module.settings._settings = QSettings(constants_module.APP_NAME, f"DesktopTests")
+    settings_module.settings._settings = QSettings(
+        constants_module.APP_NAME, f"DesktopTests"
+    )
     settings_module.settings._check_all_default_settings_present()
     yield
 
@@ -216,7 +220,7 @@ def tlui(request, marker_tlui, harmony_tlui, beat_tlui, hierarchy_tlui, audiowav
         "harmony": harmony_tlui,
         "beat": beat_tlui,
         "hierarchy": hierarchy_tlui,
-        "audiowave": audiowave_tlui
+        "audiowave": audiowave_tlui,
     }[request.param]
 
 
@@ -224,6 +228,7 @@ class UserActionManager:
     """
     Class to simulate and mock user interaction with the GUI.
     """
+
     def __init__(self):
         self.action_to_trigger_count = {}
         for action in tilia_actions_module.TiliaAction:
@@ -265,44 +270,87 @@ def user_actions():
 
 def parametrize_tl(func):
     """Adds a parameter 'tl' to a test that receives the name of a fixture that returns a component.
-     To get the timeline from within the test, add the `request` fixture to its arguments and
-     run `request.getfixturevalue('tl')`"""
-    @pytest.mark.parametrize('tl', ['audiowave_tl', 'beat_tl', 'harmony_tl', 'hierarchy_tl', 'marker_tl', 'pdf_tl', 'slider_tl'])
+    To get the timeline from within the test, add the `request` fixture to its arguments and
+    run `request.getfixturevalue('tl')`"""
+
+    @pytest.mark.parametrize(
+        "tl",
+        [
+            "audiowave_tl",
+            "beat_tl",
+            "harmony_tl",
+            "hierarchy_tl",
+            "marker_tl",
+            "pdf_tl",
+            "slider_tl",
+        ],
+    )
     @functools.wraps(func)  # Preserve original function metadata
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
+
     return wrapper
 
 
 def parametrize_tlui(func):
     """Adds a parameter 'tlui' to a test that receives the name of a fixture that returns a component.
-     To get the timeline ui from within the test, add the `request` fixture to its arguments and
-     run `request.getfixturevalue('tlui')`"""
-    @pytest.mark.parametrize('tlui', ['audiowave_tlui', 'beat_tlui', 'harmony_tlui', 'hierarchy_tlui', 'marker_tlui', 'pdf_tlui', 'slider_tlui'])
+    To get the timeline ui from within the test, add the `request` fixture to its arguments and
+    run `request.getfixturevalue('tlui')`"""
+
+    @pytest.mark.parametrize(
+        "tlui",
+        [
+            "audiowave_tlui",
+            "beat_tlui",
+            "harmony_tlui",
+            "hierarchy_tlui",
+            "marker_tlui",
+            "pdf_tlui",
+            "slider_tlui",
+        ],
+    )
     @functools.wraps(func)  # Preserve original function metadata
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
+
     return wrapper
 
 
 def parametrize_component(func):
     """Adds a parameter 'comp' to a test that receives the name of a fixture that returns a component.
-     To get the component from within the test, add the `request` fixture to its arguments and
-     run `request.getfixturevalue('comp')`"""
-    @pytest.mark.parametrize('comp', ['amplitudebar', 'beat', 'harmony', 'hierarchy', 'marker', 'pdf_marker'])
+    To get the component from within the test, add the `request` fixture to its arguments and
+    run `request.getfixturevalue('comp')`"""
+
+    @pytest.mark.parametrize(
+        "comp", ["amplitudebar", "beat", "harmony", "hierarchy", "marker", "pdf_marker"]
+    )
     @functools.wraps(func)  # Preserve original function metadata
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
+
     return wrapper
 
 
 def parametrize_ui_element(func):
     """Adds a parameter 'comp' to a test that receives the name of a fixture that returns a ui element.
-     To get the element from within the test, add the `request` fixture to its arguments and
-     run `request.getfixturevalue('element')`.
-     Tests that use this must also request the `tluis` fixture, or another fixture that requires it."""
-    @pytest.mark.parametrize('element', ['amplitudebar_ui', 'beat_ui', 'harmony_ui', 'hierarchy_ui', 'marker_ui', 'pdf_marker_ui'])
+    To get the element from within the test, add the `request` fixture to its arguments and
+    run `request.getfixturevalue('element')`.
+    Tests that use this must also request the `tluis` fixture, or another fixture that requires it.
+    """
+
+    @pytest.mark.parametrize(
+        "element",
+        [
+            "amplitudebar_ui",
+            "beat_ui",
+            "harmony_ui",
+            "hierarchy_ui",
+            "marker_ui",
+            "pdf_marker_ui",
+        ],
+    )
     @functools.wraps(func)  # Preserve original function metadata
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
+
     return wrapper

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,11 +4,12 @@ from pathlib import Path
 from typing import Literal
 
 import pytest
+from PyQt6.QtCore import QSettings
 from PyQt6.QtWidgets import QApplication
 
-from tests.mock import Serve
+import tilia.settings as settings_module
+import tilia.constants as constants_module
 from tilia.media.player.base import MediaTimeChangeReason
-from tilia.timelines.timeline_kinds import TimelineKind
 from tilia.ui import actions as tilia_actions_module
 from tilia.app import App
 from tilia.boot import setup_logic
@@ -160,7 +161,14 @@ def resources() -> Path:
 
 
 @pytest.fixture(scope="module")
-def qtui(tilia, cleanup_requests, qapplication):
+def use_test_settings(qapplication) -> None:
+    settings_module.settings._settings = QSettings(constants_module.APP_NAME, f"DesktopTests")
+    settings_module.settings._check_all_default_settings_present()
+    yield
+
+
+@pytest.fixture(scope="module")
+def qtui(tilia, cleanup_requests, qapplication, use_test_settings):
     mw = TiliaMainWindow()
     qtui_ = QtUI(qapplication, mw)
     stop_listening(qtui_, Post.DISPLAY_ERROR)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,7 +163,7 @@ def resources() -> Path:
 
 
 @pytest.fixture(scope="module")
-def use_test_settings(qapplication) -> None:
+def use_test_settings(qapplication):
     settings_module.settings._settings = QSettings(
         constants_module.APP_NAME, f"DesktopTests"
     )

--- a/tests/ui/timelines/hierarchy/test_hierarchy_timeline_ui.py
+++ b/tests/ui/timelines/hierarchy/test_hierarchy_timeline_ui.py
@@ -45,11 +45,11 @@ class TestActions:
         tlui.select_element(tlui[0])
         user_actions.trigger(TiliaAction.HIERARCHY_INCREASE_LEVEL)
 
-        assert tlui[2].get_data('level') == 2
-        assert tlui[2].get_data('start') == 0
-        assert tlui[2].get_data('end') == 1
-        assert tlui[0].get_data('level') == 1
-        assert tlui[1].get_data('level') == 1
+        assert tlui[2].get_data("level") == 2
+        assert tlui[2].get_data("start") == 0
+        assert tlui[2].get_data("end") == 1
+        assert tlui[0].get_data("level") == 1
+        assert tlui[1].get_data("level") == 1
 
     def test_increase_level_multiple_hierarchies(self, tlui, user_actions):
         tlui.create_hierarchy(0, 1, 1)
@@ -61,9 +61,9 @@ class TestActions:
         tlui.select_element(tlui[2])
         user_actions.trigger(TiliaAction.HIERARCHY_INCREASE_LEVEL)
 
-        assert tlui[0].get_data('level') == 2
-        assert tlui[1].get_data('level') == 2
-        assert tlui[2].get_data('level') == 2
+        assert tlui[0].get_data("level") == 2
+        assert tlui[1].get_data("level") == 2
+        assert tlui[2].get_data("level") == 2
 
     def test_increase_level_parent_at_higher_level(self, tlui, user_actions):
         tlui.create_hierarchy(0, 1, 1)
@@ -75,19 +75,19 @@ class TestActions:
         tlui.select_element(tlui[1])
         user_actions.trigger(TiliaAction.HIERARCHY_INCREASE_LEVEL)
 
-        assert tlui[0].get_data('level') == 2
-        assert tlui[1].get_data('level') == 3
+        assert tlui[0].get_data("level") == 2
+        assert tlui[1].get_data("level") == 3
 
     def test_increase_level_gets_hierarchy_out_of_bounds(self, tlui, user_actions):
         tlui.create_hierarchy(0, 1, 1)
-        prev_height = tlui.get_data('height')
+        prev_height = tlui.get_data("height")
 
         tlui.select_element(tlui[0])
 
         for i in range(100):
             user_actions.trigger(TiliaAction.HIERARCHY_INCREASE_LEVEL)
 
-        assert tlui.get_data('height') > prev_height
+        assert tlui.get_data("height") > prev_height
 
     def test_decrease_level(self, tlui, user_actions):
         tlui.create_hierarchy(0, 1, 2)
@@ -97,9 +97,9 @@ class TestActions:
         tlui.select_element(tlui[0])
         user_actions.trigger(TiliaAction.HIERARCHY_DECREASE_LEVEL)
 
-        assert tlui[0].get_data('level') == 1
-        assert tlui[1].get_data('level') == 2
-        assert tlui[2].get_data('level') == 2
+        assert tlui[0].get_data("level") == 1
+        assert tlui[1].get_data("level") == 2
+        assert tlui[2].get_data("level") == 2
 
     def test_decrease_level_multiple_hierarchies(self, tlui, user_actions):
         tlui.create_hierarchy(0, 1, 2)
@@ -111,9 +111,9 @@ class TestActions:
         tlui.select_element(tlui[2])
         user_actions.trigger(TiliaAction.HIERARCHY_DECREASE_LEVEL)
 
-        assert tlui[0].get_data('level') == 1
-        assert tlui[1].get_data('level') == 1
-        assert tlui[2].get_data('level') == 1
+        assert tlui[0].get_data("level") == 1
+        assert tlui[1].get_data("level") == 1
+        assert tlui[2].get_data("level") == 1
 
     def test_decrease_level_with_child_at_lower_level(self, tlui, user_actions):
         tlui.create_hierarchy(0, 1, 2)
@@ -125,8 +125,8 @@ class TestActions:
         tlui.select_element(tlui[1])
         user_actions.trigger(TiliaAction.HIERARCHY_DECREASE_LEVEL)
 
-        assert tlui[0].get_data('level') == 1
-        assert tlui[1].get_data('level') == 2
+        assert tlui[0].get_data("level") == 1
+        assert tlui[1].get_data("level") == 2
 
     def test_set_color(self, tlui, user_actions):
         tlui.create_hierarchy(0, 1, 1)
@@ -135,7 +135,7 @@ class TestActions:
         with Serve(Get.FROM_USER_COLOR, (True, QColor("#000"))):
             user_actions.trigger(TiliaAction.TIMELINE_ELEMENT_COLOR_SET)
 
-        assert tlui[0].get_data('color') == "#000000"
+        assert tlui[0].get_data("color") == "#000000"
 
     def test_reset_color(self, tlui, user_actions):
         tlui.create_hierarchy(0, 1, 1)
@@ -146,7 +146,7 @@ class TestActions:
 
         user_actions.trigger(TiliaAction.TIMELINE_ELEMENT_COLOR_RESET)
 
-        assert tlui[0].get_data('color') is None
+        assert tlui[0].get_data("color") is None
 
     def test_add_pre_start(self, tlui, user_actions):
         tlui.create_hierarchy(0.1, 1, 1)
@@ -155,7 +155,7 @@ class TestActions:
         with Serve(Get.FROM_USER_FLOAT, (True, 0.1)):
             user_actions.trigger(TiliaAction.HIERARCHY_ADD_PRE_START)
 
-        assert tlui[0].get_data('pre_start') != tlui[0].get_data('start')
+        assert tlui[0].get_data("pre_start") != tlui[0].get_data("start")
         assert tlui[0].pre_start_handle
 
     def test_add_post_end(self, tlui, user_actions, tilia_state):
@@ -165,7 +165,7 @@ class TestActions:
         with Serve(Get.FROM_USER_FLOAT, (True, 0.1)):
             user_actions.trigger(TiliaAction.HIERARCHY_ADD_POST_END)
 
-        assert tlui[0].get_data('post_end') != tlui[0].get_data('end')
+        assert tlui[0].get_data("post_end") != tlui[0].get_data("end")
         assert tlui[0].post_end_handle
 
     def test_split(self, tlui, user_actions, tilia_state):
@@ -364,9 +364,7 @@ class TestCopyPaste:
         assert copied_children_2.children[0].start == 1.5
         assert copied_children_2.children[0].end == 2.0
 
-    def test_paste_with_children_into_different_level_fails(
-        self, tlui, user_actions
-    ):
+    def test_paste_with_children_into_different_level_fails(self, tlui, user_actions):
         tlui.create_hierarchy(0, 0.5, 1)
         tlui.create_hierarchy(0.5, 1, 1)
         tlui.create_hierarchy(0, 1, 2)
@@ -518,7 +516,9 @@ class TestUndoRedo:
         user_actions.trigger(TiliaAction.EDIT_REDO)
         assert tlui[1].get_data("label") == "paste test"
 
-    @pytest.mark.skip('Paste complete is not being recorded. This has been fixed in another branch')
+    @pytest.mark.skip(
+        "Paste complete is not being recorded. This has been fixed in another branch"
+    )
     def test_paste_with_children(self, tlui, tluis, user_actions):
         tlui.create_hierarchy(0, 1, 1)
         tlui.create_hierarchy(1, 2, 1)
@@ -562,12 +562,12 @@ class TestCreateChild:
 
         tlui.select_element(tlui[0])
 
-        settings.set('hierarchy_timeline', 'prompt_create_level_below', True)
+        settings.set("hierarchy_timeline", "prompt_create_level_below", True)
         with Serve(Get.FROM_USER_YES_OR_NO, False):
             user_actions.trigger(TiliaAction.HIERARCHY_CREATE_CHILD)
 
         assert len(tlui) == 1
-        assert tlui[0].get_data('level') == 1
+        assert tlui[0].get_data("level") == 1
 
     class TestUserAcceptsNewLevel:
         def test_single_hierarchy(self, tlui, user_actions):
@@ -575,13 +575,13 @@ class TestCreateChild:
 
             tlui.select_element(tlui[0])
 
-            settings.set('hierarchy_timeline', 'prompt_create_level_below', True)
+            settings.set("hierarchy_timeline", "prompt_create_level_below", True)
             with Serve(Get.FROM_USER_YES_OR_NO, True):
                 user_actions.trigger(TiliaAction.HIERARCHY_CREATE_CHILD)
 
             assert len(tlui) == 2
-            assert tlui[0].get_data('level') == 1
-            assert tlui[1].get_data('level') == 2
+            assert tlui[0].get_data("level") == 1
+            assert tlui[1].get_data("level") == 2
 
         def test_with_parent(self, tlui, user_actions):
             tlui.create_hierarchy(0, 1, 1)
@@ -591,14 +591,14 @@ class TestCreateChild:
 
             tlui.select_element(tlui[0])
 
-            settings.set('hierarchy_timeline', 'prompt_create_level_below', True)
+            settings.set("hierarchy_timeline", "prompt_create_level_below", True)
             with Serve(Get.FROM_USER_YES_OR_NO, True):
                 user_actions.trigger(TiliaAction.HIERARCHY_CREATE_CHILD)
 
             assert len(tlui) == 3
-            assert tlui[0].get_data('level') == 1
-            assert tlui[1].get_data('level') == 2
-            assert tlui[2].get_data('level') == 3
+            assert tlui[0].get_data("level") == 1
+            assert tlui[1].get_data("level") == 2
+            assert tlui[2].get_data("level") == 3
 
         def test_with_siblings(self, tlui, user_actions):
             tlui.create_hierarchy(0, 1, 1)
@@ -607,24 +607,22 @@ class TestCreateChild:
 
             tlui.select_element(tlui[0])
 
-            settings.set('hierarchy_timeline', 'prompt_create_level_below', True)
+            settings.set("hierarchy_timeline", "prompt_create_level_below", True)
             with Serve(Get.FROM_USER_YES_OR_NO, True):
                 user_actions.trigger(TiliaAction.HIERARCHY_CREATE_CHILD)
 
             assert len(tlui) == 4
-            assert tlui[0].get_data('level') == 1
-            assert tlui[1].get_data('level') == 2
-            assert tlui[2].get_data('level') == 2
-            assert tlui[3].get_data('level') == 2
+            assert tlui[0].get_data("level") == 1
+            assert tlui[1].get_data("level") == 2
+            assert tlui[2].get_data("level") == 2
+            assert tlui[3].get_data("level") == 2
 
         def test_prompt_create_level_below_is_false(self, tlui, user_actions):
             tlui.create_hierarchy(0, 1, 1)
 
             tlui.select_element(tlui[0])
 
-            settings.set('hierarchy_timeline', 'prompt_create_level_below', False)
+            settings.set("hierarchy_timeline", "prompt_create_level_below", False)
             user_actions.trigger(TiliaAction.HIERARCHY_CREATE_CHILD)
 
             assert len(tlui) == 2
-
-

--- a/tilia/file/file_manager.py
+++ b/tilia/file/file_manager.py
@@ -12,6 +12,7 @@ from tilia.requests import listen, Post, Get, serve, get, post
 from tilia.file.tilia_file import TiliaFile, validate_tla_data
 from tilia.file.media_metadata import MediaMetadata
 import tilia.errors
+from tilia.settings import settings
 
 
 def open_tla(file_path: str | Path) -> tuple[bool, TiliaFile | None]:
@@ -174,6 +175,12 @@ class FileManager:
         write_tilia_file_to_disk(TiliaFile(**data), str(path))
         data["file_path"] = str(path.resolve()) if isinstance(path, Path) else path
         self.file = TiliaFile(**data)
+
+        try:
+            geometry, window_state = get(Get.WINDOW_GEOMETRY), get(Get.WINDOW_STATE)
+        except tilia.exceptions.NoReplyToRequest:
+            geometry, window_state = None, None
+        settings.update_recent_files(path, geometry, window_state)
 
     def new(self):
         self.file = TiliaFile()

--- a/tilia/settings.py
+++ b/tilia/settings.py
@@ -66,6 +66,7 @@ class SettingsManager(QObject):
             "base_height": 25,
             "level_height_diff": 25,
             "divider_height": 10,
+            "prompt_create_level_below": True,
         },
         "marker_timeline": {
             "default_height": 30,

--- a/tilia/ui/strings.py
+++ b/tilia/ui/strings.py
@@ -5,3 +5,9 @@ BEAT_PATTERN_DIALOG_TOOLTIP = """Empty spaces separate measures, line breaks are
 Examples:
   - '5' = 5 beats per measure;
   - '4 3 3' = a cycle of 4, then 3, then 3 beats per measure."""
+PROMPT_CREATE_LEVEL_BELOW_TITLE = "Create level below"
+PROMPT_CREATE_LEVEL_BELOW_MESSAGE = (
+    "Node is at already lowest level."
+    "\nDo you want to create a new lowest level for the child?"
+)
+

--- a/tilia/ui/strings.py
+++ b/tilia/ui/strings.py
@@ -10,4 +10,3 @@ PROMPT_CREATE_LEVEL_BELOW_MESSAGE = (
     "Node is at already lowest level."
     "\nDo you want to create a new lowest level for the child?"
 )
-

--- a/tilia/ui/timelines/hierarchy/request_handlers.py
+++ b/tilia/ui/timelines/hierarchy/request_handlers.py
@@ -40,11 +40,15 @@ class HierarchyUIRequestHandler(ElementRequestHandler):
     @fallible
     def on_increase_level(self, elements, *_, **__):
         min_margin = 10
-        success = self.timeline.alter_levels(self.elements_to_components(reversed(elements)), 1)
+        success = self.timeline.alter_levels(
+            self.elements_to_components(reversed(elements)), 1
+        )
         if success:
             max_height = self.timeline_ui.get_max_hierarchy_height()
-            if max_height > self.timeline_ui.get_data('height') + min_margin:
-                get(Get.TIMELINE_COLLECTION).set_timeline_data(self.timeline_ui.id, 'height', max_height + min_margin)
+            if max_height > self.timeline_ui.get_data("height") + min_margin:
+                get(Get.TIMELINE_COLLECTION).set_timeline_data(
+                    self.timeline_ui.id, "height", max_height + min_margin
+                )
 
         return success
 
@@ -67,16 +71,16 @@ class HierarchyUIRequestHandler(ElementRequestHandler):
     @fallible
     def on_create_child(self, elements, *_, **__):
         def _should_prompt_create_level_below() -> bool:
-            return settings.get('hierarchy_timeline', 'prompt_create_level_below')
+            return settings.get("hierarchy_timeline", "prompt_create_level_below")
 
         def _prompt_create_level_below() -> bool:
             return get(
                 Get.FROM_USER_YES_OR_NO,
                 tilia.ui.strings.PROMPT_CREATE_LEVEL_BELOW_TITLE,
-                tilia.ui.strings.PROMPT_CREATE_LEVEL_BELOW_MESSAGE
+                tilia.ui.strings.PROMPT_CREATE_LEVEL_BELOW_MESSAGE,
             )
 
-        if any([e.get_data('level') == 1 for e in elements]):
+        if any([e.get_data("level") == 1 for e in elements]):
             if not _should_prompt_create_level_below() or _prompt_create_level_below():
                 self.on_increase_level(self.timeline_ui.elements, *_, **__)
             else:
@@ -165,7 +169,7 @@ class HierarchyUIRequestHandler(ElementRequestHandler):
                 _display_paste_complete_error(reason)
                 return False
 
-            self.timeline.delete_components(element.get_data('children'))
+            self.timeline.delete_components(element.get_data("children"))
             self.timeline_ui.paste_with_children_into_element(data, element)
 
         return True


### PR DESCRIPTION
The user will have the option of raising all existing hierarchies one level to make room for the new child. The prompt can be turned off by changing the hierarchy_timeline/prompt_create_level_below setting to False, in which case the new level will always be created.

This also creates a fixture for "patching" the `SettingsManager` enabling changing setings for testings purposes without the risk of altering production settings.

Closes #198.

