### PR TITLE
Improve zooming perfomance (for real, this time)

### DIFF
--- a/tilia/ui/timelines/view.py
+++ b/tilia/ui/timelines/view.py
@@ -28,6 +28,7 @@ class TimelineView(QGraphicsView):
         self.setRenderHint(QPainter.RenderHint.Antialiasing)
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.setViewportUpdateMode(QGraphicsView.ViewportUpdateMode.FullViewportUpdate)
         self.setBackgroundBrush(QBrush(QColor(settings.get("general", "timeline_background_color"))))
         listen(self, Post.SETTINGS_UPDATED, lambda updated_settings: self.on_settings_updated(updated_settings))
 


### PR DESCRIPTION
Sets the `ViewportUpdateMode` of `TimelineViews` to `FullViewportUpdate`. As per the documentation, this is better for making many small changes to a scene:

"When any visible part of the scene changes or is reexposed, QGraphicsView will update the entire viewport. This approach is fastest when QGraphicsView spends more time figuring out what to draw than it would spend drawing (e.g., when very many small items are repeatedly updated). This is the preferred update mode for viewports that do not support partial updates, such as QOpenGLWidget, and for viewports that need to disable scroll optimization."

This makes a great impact when zooming in and out of timeline with thousands of elements. I have got acceptable performance for up to 10.000 notes in a score timeline with this. The Python code wasn't the bottleneck at the 1000-10000 scale, it seems (who would have thought!). Above that, things start to get choppy again (I blame Python again).