### PR TITLE
Add accelerators ("Alt shortcuts") to main menu

### DIFF
--- a/tilia/ui/actions.py
+++ b/tilia/ui/actions.py
@@ -184,7 +184,7 @@ taction_to_params = {
         Post.BEAT_SET_AMOUNT_IN_MEASURE, "Set beat amount in measure", "", ""
     ),
     TiliaAction.BEAT_IMPORT_FROM_CSV: ActionParams(
-        Post.BEAT_IMPORT_FROM_CSV, "Import from CSV file", "", ""
+        Post.BEAT_IMPORT_FROM_CSV, "&Import from CSV file", "", ""
     ),
     TiliaAction.BEAT_TIMELINE_FILL: ActionParams(
         Post.BEAT_TIMELINE_FILL, "Fill timeline with beats", "", ""
@@ -193,7 +193,7 @@ taction_to_params = {
         Post.MARKER_ADD, "Add marker at current position", "add_marker30", "m"
     ),
     TiliaAction.MARKER_IMPORT_FROM_CSV: ActionParams(
-        Post.MARKER_IMPORT_FROM_CSV, "Import from CSV file", "", ""
+        Post.MARKER_IMPORT_FROM_CSV, "&Import from CSV file", "", ""
     ),
     TiliaAction.TIMELINE_ELEMENT_COLOR_SET: ActionParams(
         Post.TIMELINE_ELEMENT_COLOR_SET, "Change color", "", ""
@@ -227,12 +227,12 @@ taction_to_params = {
     ),
     TiliaAction.TIMELINE_ELEMENT_PASTE_COMPLETE: ActionParams(
         Post.TIMELINE_ELEMENT_PASTE_COMPLETE,
-        "Paste complete",
+        "Pas&te complete",
         "paste_with_data30",
         "Ctrl+Shift+V",
     ),
     TiliaAction.HIERARCHY_IMPORT_FROM_CSV: ActionParams(
-        Post.HIERARCHY_IMPORT_FROM_CSV, "Import from CSV file", "", ""
+        Post.HIERARCHY_IMPORT_FROM_CSV, "&Import from CSV file", "", ""
     ),
     TiliaAction.HARMONY_ADD: ActionParams(
         Post.HARMONY_ADD, "Add harmony", "harmony_add", "h"
@@ -256,56 +256,56 @@ taction_to_params = {
     TiliaAction.HARMONY_TIMELINE_HIDE_KEYS: ActionParams(
         Post.HARMONY_TIMELINE_HIDE_KEYS, "Hide keys", "", ""
     ),
-    TiliaAction.FILE_NEW: ActionParams(Post.REQUEST_FILE_NEW, "New...", "", "Ctrl+N"),
-    TiliaAction.FILE_OPEN: ActionParams(Post.FILE_OPEN, "Open...", "", "Ctrl+O"),
-    TiliaAction.FILE_SAVE: ActionParams(Post.FILE_SAVE, "Save", "", "Ctrl+S"),
-    TiliaAction.FILE_EXPORT: ActionParams(Post.FILE_EXPORT, "Export...", "", ""),
+    TiliaAction.FILE_NEW: ActionParams(Post.REQUEST_FILE_NEW, "&New...", "", "Ctrl+N"),
+    TiliaAction.FILE_OPEN: ActionParams(Post.FILE_OPEN, "&Open...", "", "Ctrl+O"),
+    TiliaAction.FILE_SAVE: ActionParams(Post.FILE_SAVE, "&Save", "", "Ctrl+S"),
     TiliaAction.FILE_SAVE_AS: ActionParams(
-        Post.FILE_SAVE_AS, "Save as...", "", "Ctrl+Shift+S"
+        Post.FILE_SAVE_AS, "Save &As...", "", "Ctrl+Shift+S"
     ),
+    TiliaAction.FILE_EXPORT: ActionParams(Post.FILE_EXPORT, "&Export...", "", ""),
     TiliaAction.MEDIA_LOAD_LOCAL: ActionParams(
-        Post.UI_MEDIA_LOAD_LOCAL, "Local...", "", "Ctrl+Shift+L"
+        Post.UI_MEDIA_LOAD_LOCAL, "&Local...", "", "Ctrl+Shift+L"
     ),
     TiliaAction.MEDIA_LOAD_YOUTUBE: ActionParams(
-        Post.UI_MEDIA_LOAD_YOUTUBE, "YouTube...", "", ""
+        Post.UI_MEDIA_LOAD_YOUTUBE, "&YouTube...", "", ""
     ),
     TiliaAction.METADATA_WINDOW_OPEN: ActionParams(
-        Post.WINDOW_OPEN, "Edit metadata...", "", "", (WindowKind.MEDIA_METADATA,)
+        Post.WINDOW_OPEN, "Edit &Metadata...", "", "", (WindowKind.MEDIA_METADATA,)
     ),
     TiliaAction.SETTINGS_WINDOW_OPEN: ActionParams(
-        Post.WINDOW_OPEN, "Settings...", "", "", (WindowKind.SETTINGS,)
+        Post.WINDOW_OPEN, "&Settings...", "", "", (WindowKind.SETTINGS,)
     ),
     TiliaAction.AUTOSAVES_FOLDER_OPEN: ActionParams(
-        Post.AUTOSAVES_FOLDER_OPEN, "Autosaves...", "", ""
+        Post.AUTOSAVES_FOLDER_OPEN, "Open autosa&ves folder...", "", ""
     ),
-    TiliaAction.EDIT_REDO: ActionParams(Post.EDIT_REDO, "Redo", "", "Ctrl+Shift+Z"),
-    TiliaAction.EDIT_UNDO: ActionParams(Post.EDIT_UNDO, "Undo", "", "Ctrl+Z"),
+    TiliaAction.EDIT_REDO: ActionParams(Post.EDIT_REDO, "&Redo", "", "Ctrl+Shift+Z"),
+    TiliaAction.EDIT_UNDO: ActionParams(Post.EDIT_UNDO, "&Undo", "", "Ctrl+Z"),
     TiliaAction.WINDOW_MANAGE_TIMELINES_OPEN: ActionParams(
-        Post.WINDOW_OPEN, "Manage...", "", "", (WindowKind.MANAGE_TIMELINES,)
+        Post.WINDOW_OPEN, "&Manage...", "", "", (WindowKind.MANAGE_TIMELINES,)
     ),
     TiliaAction.TIMELINES_ADD_HIERARCHY_TIMELINE: ActionParams(
-        Post.TIMELINE_ADD, "Hierarchy", "", "", (TimelineKind.HIERARCHY_TIMELINE,)
+        Post.TIMELINE_ADD, "&Hierarchy", "", "", (TimelineKind.HIERARCHY_TIMELINE,)
     ),
     TiliaAction.TIMELINES_ADD_MARKER_TIMELINE: ActionParams(
-        Post.TIMELINE_ADD, "Marker", "", "", (TimelineKind.MARKER_TIMELINE,)
+        Post.TIMELINE_ADD, "&Marker", "", "", (TimelineKind.MARKER_TIMELINE,)
     ),
     TiliaAction.TIMELINES_ADD_BEAT_TIMELINE: ActionParams(
-        Post.TIMELINE_ADD, "Beat", "", "", (TimelineKind.BEAT_TIMELINE,)
+        Post.TIMELINE_ADD, "&Beat", "", "", (TimelineKind.BEAT_TIMELINE,)
     ),
     TiliaAction.TIMELINES_ADD_HARMONY_TIMELINE: ActionParams(
-        Post.TIMELINE_ADD, "Harmony", "", "", (TimelineKind.HARMONY_TIMELINE,)
+        Post.TIMELINE_ADD, "Ha&rmony", "", "", (TimelineKind.HARMONY_TIMELINE,)
     ),
     TiliaAction.TIMELINES_ADD_PDF_TIMELINE: ActionParams(
-        Post.TIMELINE_ADD, "PDF", "", "", (TimelineKind.PDF_TIMELINE,)
+        Post.TIMELINE_ADD, "&PDF", "", "", (TimelineKind.PDF_TIMELINE,)
     ),
     TiliaAction.TIMELINES_ADD_AUDIOWAVE_TIMELINE: ActionParams(
-        Post.TIMELINE_ADD, "AudioWave", "", "", (TimelineKind.AUDIOWAVE_TIMELINE,)
+        Post.TIMELINE_ADD, "&AudioWave", "", "", (TimelineKind.AUDIOWAVE_TIMELINE,)
     ),
     TiliaAction.TIMELINES_ADD_SCORE_TIMELINE: ActionParams(
-        Post.TIMELINE_ADD, "Score", "", "", (TimelineKind.SCORE_TIMELINE,)
+        Post.TIMELINE_ADD, "&Score", "", "", (TimelineKind.SCORE_TIMELINE,)
     ),
     TiliaAction.HARMONY_IMPORT_FROM_CSV: ActionParams(
-        Post.HARMONY_IMPORT_FROM_CSV, "Import from CSV file", "", ""
+        Post.HARMONY_IMPORT_FROM_CSV, "&Import from CSV file", "", ""
     ),
     TiliaAction.TIMELINES_CLEAR: ActionParams(
         Post.TIMELINES_CLEAR, "Clear all", "", ""
@@ -320,13 +320,13 @@ taction_to_params = {
         Post.TIMELINE_ELEMENT_INSPECT, "Inspect", "", ""
     ),
     TiliaAction.TIMELINE_ELEMENT_EDIT: ActionParams(
-        Post.TIMELINE_ELEMENT_INSPECT, "Edit", "", ""
+        Post.TIMELINE_ELEMENT_INSPECT, "&Edit", "", ""
     ),
     TiliaAction.TIMELINE_ELEMENT_COPY: ActionParams(
-        Post.TIMELINE_ELEMENT_COPY, "Copy", "", "Ctrl+C"
+        Post.TIMELINE_ELEMENT_COPY, "&Copy", "", "Ctrl+C"
     ),
     TiliaAction.TIMELINE_ELEMENT_PASTE: ActionParams(
-        Post.TIMELINE_ELEMENT_PASTE, "Paste", "", "Ctrl+V"
+        Post.TIMELINE_ELEMENT_PASTE, "&Paste", "", "Ctrl+V"
     ),
     TiliaAction.TIMELINE_ELEMENT_EXPORT_AUDIO: ActionParams(
         Post.TIMELINE_ELEMENT_EXPORT_AUDIO, "Export to audio", "", ""
@@ -340,25 +340,25 @@ taction_to_params = {
     TiliaAction.TIMELINE_HEIGHT_SET: ActionParams(
         Post.TIMELINE_HEIGHT_SET, "Change height", "", ""
     ),
-    TiliaAction.VIEW_ZOOM_IN: ActionParams(Post.VIEW_ZOOM_IN, "Zoom in", "", "Ctrl++"),
+    TiliaAction.VIEW_ZOOM_IN: ActionParams(Post.VIEW_ZOOM_IN, "Zoom &In", "", "Ctrl++"),
     TiliaAction.VIEW_ZOOM_OUT: ActionParams(
-        Post.VIEW_ZOOM_OUT, "Zoom out", "", "Ctrl+-"
+        Post.VIEW_ZOOM_OUT, "Zoom &Out", "", "Ctrl+-"
     ),
     TiliaAction.ABOUT_WINDOW_OPEN: ActionParams(
-        Post.WINDOW_OPEN, "About...", "", "", (WindowKind.ABOUT,)
+        Post.WINDOW_OPEN, "&About...", "", "", (WindowKind.ABOUT,)
     ),
     TiliaAction.MEDIA_STOP: ActionParams(Post.PLAYER_STOP, "Stop", "stop15", ""),
     TiliaAction.WEBSITE_HELP_OPEN: ActionParams(
-        Post.WEBSITE_HELP_OPEN, "Help...", "", ""
+        Post.WEBSITE_HELP_OPEN, "&Help...", "", ""
     ),
     TiliaAction.PDF_MARKER_ADD: ActionParams(
         Post.PDF_MARKER_ADD, "Add PDF marker", "pdf_add", "p"
     ),
     TiliaAction.PDF_IMPORT_FROM_CSV: ActionParams(
-        Post.PDF_IMPORT_FROM_CSV, "Import from CSV file", "", ""
+        Post.PDF_IMPORT_FROM_CSV, "&Import from CSV file", "", ""
     ),
     TiliaAction.SCORE_IMPORT_FROM_MUSICXML: ActionParams(
-        Post.SCORE_IMPORT_FROM_MUSICXML, "Import from musicxml file", "", ""
+        Post.SCORE_IMPORT_FROM_MUSICXML, "&Import from musicxml file", "", ""
     ),
     TiliaAction.SCORE_ANNOTATION_ADD: ActionParams(
         None, "Add Annotation (Return)", "annotation_add", "", "", ""

--- a/tilia/ui/menus.py
+++ b/tilia/ui/menus.py
@@ -58,7 +58,7 @@ class TiliaMenu(QMenu):
 
 
 class LoadMediaMenu(TiliaMenu):
-    title = "Load media"
+    title = "&Load media"
     items = [
         (MenuItemKind.ACTION, TiliaAction.MEDIA_LOAD_LOCAL),
         (MenuItemKind.ACTION, TiliaAction.MEDIA_LOAD_YOUTUBE),
@@ -68,7 +68,7 @@ class LoadMediaMenu(TiliaMenu):
 class RecentFilesMenu(QMenu):
     def __init__(self):
         super().__init__()
-        self.setTitle("Open Recent File...")
+        self.setTitle("Open &Recent file")
         self.add_items()
         settings.link_file_update(self.update_items)
 
@@ -88,7 +88,7 @@ class RecentFilesMenu(QMenu):
 
 
 class FileMenu(TiliaMenu):
-    title = "File"
+    title = "&File"
     items = [
         (MenuItemKind.ACTION, TiliaAction.FILE_NEW),
         (MenuItemKind.ACTION, TiliaAction.FILE_OPEN),
@@ -100,14 +100,12 @@ class FileMenu(TiliaMenu):
         (MenuItemKind.SUBMENU, LoadMediaMenu),
         (MenuItemKind.ACTION, TiliaAction.METADATA_WINDOW_OPEN),
         (MenuItemKind.SEPARATOR, None),
-        (MenuItemKind.ACTION, TiliaAction.SETTINGS_WINDOW_OPEN),
-        (MenuItemKind.SEPARATOR, None),
         (MenuItemKind.ACTION, TiliaAction.AUTOSAVES_FOLDER_OPEN),
     ]
 
 
 class EditMenu(TiliaMenu):
-    title = "Edit"
+    title = "&Edit"
     items = [
         (MenuItemKind.ACTION, TiliaAction.EDIT_UNDO),
         (MenuItemKind.ACTION, TiliaAction.EDIT_REDO),
@@ -115,11 +113,13 @@ class EditMenu(TiliaMenu):
         (MenuItemKind.ACTION, TiliaAction.TIMELINE_ELEMENT_COPY),
         (MenuItemKind.ACTION, TiliaAction.TIMELINE_ELEMENT_PASTE),
         (MenuItemKind.ACTION, TiliaAction.TIMELINE_ELEMENT_PASTE_COMPLETE),
+        (MenuItemKind.SEPARATOR, None),
+        (MenuItemKind.ACTION, TiliaAction.SETTINGS_WINDOW_OPEN),
     ]
 
 
 class AddTimelinesMenu(TiliaMenu):
-    title = "Add..."
+    title = "&Add"
     items = [
         (MenuItemKind.ACTION, TiliaAction.TIMELINES_ADD_AUDIOWAVE_TIMELINE),
         (MenuItemKind.ACTION, TiliaAction.TIMELINES_ADD_BEAT_TIMELINE),
@@ -132,37 +132,37 @@ class AddTimelinesMenu(TiliaMenu):
 
 
 class HierarchyMenu(TiliaMenu):
-    title = "Hierarchy"
+    title = "&Hierarchy"
     items = [(MenuItemKind.ACTION, TiliaAction.HIERARCHY_IMPORT_FROM_CSV)]
 
 
 class MarkerMenu(TiliaMenu):
-    title = "Marker"
+    title = "&Marker"
     items = [(MenuItemKind.ACTION, TiliaAction.MARKER_IMPORT_FROM_CSV)]
 
 
 class BeatMenu(TiliaMenu):
-    title = "Beat"
+    title = "&Beat"
     items = [(MenuItemKind.ACTION, TiliaAction.BEAT_IMPORT_FROM_CSV), (MenuItemKind.ACTION, TiliaAction.BEAT_TIMELINE_FILL)]
 
 
 class HarmonyMenu(TiliaMenu):
-    title = "Harmony"
+    title = "Ha&rmony"
     items = [(MenuItemKind.ACTION, TiliaAction.HARMONY_IMPORT_FROM_CSV)]
 
 
 class PdfMenu(TiliaMenu):
-    title = "PDF"
+    title = "&PDF"
     items = [(MenuItemKind.ACTION, TiliaAction.PDF_IMPORT_FROM_CSV)]
 
 
 class ScoreMenu(TiliaMenu):
-    title = "Score"
+    title = "&Score"
     items = [(MenuItemKind.ACTION, TiliaAction.SCORE_IMPORT_FROM_MUSICXML)]
 
 
 class TimelinesMenu(TiliaMenu):
-    title = "Timelines"
+    title = "&Timelines"
     items = [
         (MenuItemKind.SUBMENU, AddTimelinesMenu),
         (MenuItemKind.ACTION, TiliaAction.WINDOW_MANAGE_TIMELINES_OPEN),
@@ -179,7 +179,7 @@ class TimelinesMenu(TiliaMenu):
 class ViewMenu(QMenu):
     def __init__(self):
         super().__init__()
-        self.setTitle("View")
+        self.setTitle("&View")
         self.add_default_items()
 
         self.windows = {}
@@ -222,7 +222,7 @@ class ViewMenu(QMenu):
 
 
 class HelpMenu(TiliaMenu):
-    title = "Help"
+    title = "&Help"
     items = [
         (MenuItemKind.ACTION, TiliaAction.ABOUT_WINDOW_OPEN),
         (MenuItemKind.ACTION, TiliaAction.WEBSITE_HELP_OPEN),


### PR DESCRIPTION
Accelerators enable navigating the main menu with Alt+keys. They are defined by inserting a '&' in front of the letter that triggers the accelerator on the QAction's name.

Ah... how much I missed this feature. Today is a good day.