### PR TITLE
Fixes to beat timeline

### DIFF
--- a/tests/timelines/beat/fixtures.py
+++ b/tests/timelines/beat/fixtures.py
@@ -24,7 +24,6 @@ def beat_tl(tls):
         beat, error = tl.create_component(ComponentKind.BEAT, *args, **kwargs)
         if error:
             raise ValueError(f'Unable to create beat: {error}')
-        tl.recalculate_measures()
         return beat, None
 
     tl.create_beat = create_beat

--- a/tests/ui/timelines/beat/test_beat_timeline_ui.py
+++ b/tests/ui/timelines/beat/test_beat_timeline_ui.py
@@ -71,6 +71,18 @@ class TestCreateDeleteBeat:
         assert get_displayed_measure_number(beat_tlui[0]) == "1"
         assert get_displayed_measure_number(beat_tlui[1]) == "2"
 
+    def test_create_update_next_measures_numbers(self, beat_tlui, user_actions, tilia_state):
+        beat_tlui.timeline.beat_pattern = [1]
+        beat_tlui.timeline.measures_to_force_display = [0, 1, 2, 3]
+        beat_tlui.create_beat(0)
+        beat_tlui.create_beat(1)
+        beat_tlui.create_beat(2)
+
+        tilia_state.current_time = 0.5
+        user_actions.trigger(TiliaAction.BEAT_ADD)
+
+        assert [get_displayed_measure_number(beat) for beat in beat_tlui] == ["1", "2", "3", "4"]
+
 
 class TestSelect:
     def test_deselect_all_but_last(self, beat_tlui):

--- a/tests/ui/timelines/beat/test_beat_timeline_ui.py
+++ b/tests/ui/timelines/beat/test_beat_timeline_ui.py
@@ -517,3 +517,26 @@ class TestUndoRedo:
 
         post(Post.EDIT_REDO)
         assert len(beat_tlui) == 0
+
+    def test_undo_redo_updates_displayed_measure_numbers(self, beat_tlui, user_actions):
+        beat_tlui.timeline.beat_pattern = [1]
+        beat_tlui.timeline.measures_to_force_display = [0, 1, 2]
+        beat_tlui.create_beat(0)
+        beat_tlui.create_beat(1)
+        beat_tlui.create_beat(2)
+
+        post(Post.APP_RECORD_STATE, "test")
+
+        beat_tlui.select_element(beat_tlui[0])
+        user_actions.trigger(TiliaAction.TIMELINE_ELEMENT_DELETE)
+
+        user_actions.trigger(TiliaAction.EDIT_UNDO)
+
+        assert [get_displayed_measure_number(beat_ui) for beat_ui in beat_tlui] == ["1", "2", "3"]
+
+        user_actions.trigger(TiliaAction.EDIT_REDO)
+
+        assert [get_displayed_measure_number(beat_ui) for beat_ui in beat_tlui] == ["1", "2"]
+
+
+

--- a/tests/ui/timelines/beat/test_beat_timeline_ui.py
+++ b/tests/ui/timelines/beat/test_beat_timeline_ui.py
@@ -5,6 +5,7 @@ from tilia.requests import Post, post
 from tilia.enums import Side
 from tilia.requests import Get
 from tilia.timelines.beat.timeline import BeatTimeline
+from tilia.settings import settings
 from tilia.ui.actions import TiliaAction
 from tilia.ui.windows import WindowKind
 
@@ -313,7 +314,7 @@ class TestOther:
 DUMMY_MEASURE_NUMBER = 11
 
 
-class TestChangeMeasureNumber:
+class TestSetMeasureNumber:
     @staticmethod
     def _set_measure_number(beat_tlui, actions, number=DUMMY_MEASURE_NUMBER):
         """Assumes there a beat in the measure is selected"""
@@ -395,6 +396,24 @@ class TestChangeMeasureNumber:
         user_actions.trigger(TiliaAction.EDIT_UNDO)
         user_actions.trigger(TiliaAction.EDIT_REDO)
         assert beat_tlui.timeline.measure_numbers[0] == 1
+
+    def test_measure_zero_number_is_not_displayed(self, beat_tlui, user_actions):
+        settings.set("beat_timeline", "display_measure_periodicity", 2)
+        beat_tlui.timeline.beat_pattern = [1]
+
+        beat_tlui.create_beat(0)
+        beat_tlui.create_beat(1)
+        beat_tlui.create_beat(2)
+        beat_tlui.create_beat(3)
+
+        beat_tlui.timeline.recalculate_measures()
+
+        beat_tlui.select_element(beat_tlui[0])
+
+        self._set_measure_number(beat_tlui, user_actions, 0)
+
+        displayed_measure = [get_displayed_measure_number(b) for b in beat_tlui]
+        assert displayed_measure == ["", "1", "", "3"]
 
 
 class TestActions:

--- a/tests/ui/timelines/beat/test_beat_timeline_ui.py
+++ b/tests/ui/timelines/beat/test_beat_timeline_ui.py
@@ -9,6 +9,10 @@ from tilia.ui.actions import TiliaAction
 from tilia.ui.windows import WindowKind
 
 
+def get_displayed_measure_number(beat_ui):
+    return beat_ui.label.toPlainText()
+
+
 def test_measure_numbers_are_loaded_from_file(beat_tl, tluis, tmp_path):
     beat_tl.beat_pattern = [1]
 
@@ -53,6 +57,19 @@ class TestCreateDeleteBeat:
 
         assert len(beat_tlui) == 0
         assert not beat_tlui.selected_elements
+
+    def test_delete_update_next_measures_numbers(self, beat_tlui, user_actions):
+        beat_tlui.timeline.beat_pattern = [1]
+        beat_tlui.timeline.measures_to_force_display = [0, 1, 2]
+        beat_tlui.create_beat(0)
+        beat_tlui.create_beat(1)
+        beat_tlui.create_beat(2)
+
+        beat_tlui.select_element(beat_tlui[0])
+        user_actions.trigger(TiliaAction.TIMELINE_ELEMENT_DELETE)
+
+        assert get_displayed_measure_number(beat_tlui[0]) == "1"
+        assert get_displayed_measure_number(beat_tlui[1]) == "2"
 
 
 class TestSelect:

--- a/tests/ui/timelines/beat/test_beat_timeline_ui.py
+++ b/tests/ui/timelines/beat/test_beat_timeline_ui.py
@@ -10,7 +10,10 @@ from tilia.ui.windows import WindowKind
 
 
 def get_displayed_measure_number(beat_ui):
-    return beat_ui.label.toPlainText()
+    if beat_ui.label.isVisible():
+        return beat_ui.label.toPlainText()
+    else:
+        return ""
 
 
 def test_measure_numbers_are_loaded_from_file(beat_tl, tluis, tmp_path):
@@ -435,7 +438,9 @@ class TestActions:
         assert beat_tlui[0].get_data("time") == 0
         assert beat_tlui[1].get_data("time") == 1
 
-    def test_change_beats_in_measure(self, beat_tlui, user_actions):
+
+class TestSetBeatAmountInMeasure:
+    def test_set_beat_amount_in_measure(self, beat_tlui, user_actions):
         beat_tlui.create_beat(0)
 
         beat_tlui.select_element(beat_tlui[0])
@@ -445,6 +450,20 @@ class TestActions:
             user_actions.trigger(TiliaAction.BEAT_SET_AMOUNT_IN_MEASURE)
 
         beat_tlui.timeline.set_beat_amount_in_measure.assert_called_with(0, 11)
+
+    def test_updates_measure_numbers(self, beat_tlui, user_actions):
+        beat_tlui.timeline.beat_pattern = [1]
+        beat_tlui.timeline.measures_to_force_display = [0, 1, 2]
+        beat_tlui.create_beat(0)
+        beat_tlui.create_beat(1)
+        beat_tlui.create_beat(2)
+
+        beat_tlui.select_element(beat_tlui[0])
+
+        with Serve(Get.FROM_USER_INT, (True, 2)):
+            user_actions.trigger(TiliaAction.BEAT_SET_AMOUNT_IN_MEASURE)
+
+        assert [get_displayed_measure_number(b) for b in beat_tlui] == ['1', '', '2']
 
 
 class TestFillWithBeats:

--- a/tilia/requests/post.py
+++ b/tilia/requests/post.py
@@ -25,6 +25,7 @@ class Post(Enum):
     BEAT_SET_MEASURE_NUMBER = auto()
     BEAT_TIMELINE_COMPONENTS_DESERIALIZED = auto()
     BEAT_TIMELINE_FILL = auto()
+    BEAT_TIMELINE_MEASURE_NUMBER_CHANGE_DONE = auto()
     CANVAS_RIGHT_CLICK = auto()
     DEBUG = auto()
     DISPLAY_ERROR = auto()

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -159,6 +159,7 @@ class BeatTLComponentManager(TimelineComponentManager):
         super().restore_state(prev_state)
         self.compute_is_first_in_measure = True
         self.update_is_first_in_measure_of_subsequent_beats(0)
+        post(Post.BEAT_TIMELINE_MEASURE_NUMBER_CHANGE_DONE, self.timeline.id, 0)
 
 
 class BeatTimeline(Timeline):

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -151,7 +151,7 @@ class BeatTLComponentManager(TimelineComponentManager):
         self.timeline.set_data("beats_in_measure", beats_in_measure)
         self.timeline.set_data("measures_to_force_display", measures_to_force_display)
 
-        self.timeline.recalculate_measures()  # Not sure if this is needed.
+        self.timeline.recalculate_measures()
         post(Post.BEAT_TIMELINE_COMPONENTS_DESERIALIZED, self.timeline.id)
 
     def restore_state(self, prev_state: dict):
@@ -202,7 +202,6 @@ class BeatTimeline(Timeline):
         self.beat_pattern = beat_pattern or [4]
         self._beats_in_measure = beats_in_measure or []
         self.measure_numbers = measure_numbers or []
-        self.update_beats_that_start_measures()
         self.measures_to_force_display = measures_to_force_display or []
 
     @property

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -52,9 +52,10 @@ class BeatTLComponentManager(TimelineComponentManager):
             self.timeline.recalculate_measures()
             if self.compute_is_first_in_measure:
                 beat.is_first_in_measure = self.timeline.is_first_in_measure(beat)
-                self.update_is_first_in_measure_of_subsequent_beats(
-                    self.get_components().index(beat) + 1
-                )
+                beat_index = self.get_components().index(beat) + 1
+                self.update_is_first_in_measure_of_subsequent_beats(beat_index)
+                measure_index = self.timeline.get_measure_index(beat_index)[0]
+                post(Post.BEAT_TIMELINE_MEASURE_NUMBER_CHANGE_DONE, self.timeline.id, measure_index - 1)
 
         return success, beat, reason
 

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -586,6 +586,8 @@ class BeatTimeline(Timeline):
 
         if not self.is_empty:
             self.component_manager.update_is_first_in_measure_of_subsequent_beats(0)
+            post(Post.BEAT_TIMELINE_MEASURE_NUMBER_CHANGE_DONE, self.id, 0)
+
             # Higher index is possible.
 
     class FillMethod(Enum):

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -465,6 +465,9 @@ class BeatTimeline(Timeline):
         if not extra_measure_count:
             return
         self.measure_numbers = self.measure_numbers[:-extra_measure_count]
+        if self.measures_to_force_display:
+            while self.measures_to_force_display[-1] >= self.measure_count:
+                self.measures_to_force_display.pop(-1)
 
     def update_beats_that_start_measures(self):
         # noinspection PyAttributeOutsideInit
@@ -574,6 +577,7 @@ class BeatTimeline(Timeline):
         new_beats_in_measure = self.beats_in_measure.copy()
         new_beats_in_measure[measure_index] = beat_amount
         self.set_data("beats_in_measure", new_beats_in_measure)
+        post(Post.BEAT_TIMELINE_MEASURE_NUMBER_CHANGE_DONE, self.id, measure_index)
 
     def distribute_beats(self, measure_index: int) -> None:
         self.component_manager.distribute_beats(measure_index)

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -166,8 +166,8 @@ class BeatTLComponentManager(TimelineComponentManager):
 class BeatTimeline(Timeline):
     SERIALIZABLE_BY_VALUE = [
         "beat_pattern",
-        "beats_in_measure",
-        "measure_numbers",
+        "measure_numbers",  # order matters, m. ns. need to be restored
+        "beats_in_measure",  # before beats in measure
         "measures_to_force_display",
         "height",
         "is_visible",

--- a/tilia/ui/timelines/beat/element.py
+++ b/tilia/ui/timelines/beat/element.py
@@ -270,6 +270,9 @@ class BeatLabel(QGraphicsTextItem):
 
     def set_text(self, value: str):
         if not value:
+            # Settting plain text to empty string
+            # keeps the graphics item interactable,
+            # so we need to hide it, instead.
             self.setVisible(False)
         else:
             self.setVisible(True)

--- a/tilia/ui/timelines/beat/request_handlers.py
+++ b/tilia/ui/timelines/beat/request_handlers.py
@@ -51,7 +51,14 @@ class BeatUIRequestHandler(ElementRequestHandler):
 
         return sorted(list(measure_indices))
 
-    def on_set_measure_number(self, elements, number):
+    def on_set_measure_number(self, elements):
+        accepted, number = get(
+            Get.FROM_USER_INT,
+            "Change measure number",
+            "Insert measure number",
+        )
+        if not accepted:
+            return
         for i in reversed(self._get_measure_indices(elements)):
             self.timeline.set_measure_number(i, number)
         return True
@@ -66,7 +73,15 @@ class BeatUIRequestHandler(ElementRequestHandler):
             self.timeline.distribute_beats(i)
         return True
 
-    def on_set_amount_in_measure(self, elements, amount):
+    def on_set_amount_in_measure(self, elements):
+        accepted, amount = get(
+            Get.FROM_USER_INT,
+            "Change beats in measure",
+            "Insert amount of beats in measure",
+            min=1,
+        )
+        if not accepted:
+            return
         for i in reversed(self._get_measure_indices(elements)):
             self.timeline.set_beat_amount_in_measure(i, amount)
         return True

--- a/tilia/ui/timelines/beat/request_handlers.py
+++ b/tilia/ui/timelines/beat/request_handlers.py
@@ -56,6 +56,7 @@ class BeatUIRequestHandler(ElementRequestHandler):
             Get.FROM_USER_INT,
             "Change measure number",
             "Insert measure number",
+            min=0,
         )
         if not accepted:
             return

--- a/tilia/ui/timelines/beat/timeline.py
+++ b/tilia/ui/timelines/beat/timeline.py
@@ -92,6 +92,10 @@ class BeatTimelineUI(TimelineUI):
             self.element_manager.deselect_element(selected_element)
             self.select_element(element_to_select)
 
+    def on_measure_number_change_done(self, start_index: int):
+        for beat_ui in self[start_index:]:
+            beat_ui.update_label()
+
     def get_copy_data_from_selected_elements(self):
         self.validate_copy(self.selected_elements)
 

--- a/tilia/ui/timelines/beat/timeline.py
+++ b/tilia/ui/timelines/beat/timeline.py
@@ -148,7 +148,15 @@ class BeatTimelineUI(TimelineUI):
 
     def update_measure_numbers(self):
         for beat_ui in self:
-            beat_ui.update_label()
+            try:
+                beat_ui.update_label()
+            except IndexError:
+                # State is being restored and
+                # beats in measure has not been
+                # updated yet. This is a dangerous
+                # workaroung, as it might conceal
+                # other exceptions. Let's fix this ASAP.
+                continue
 
     def update_measures_to_force_display(self):
         for beat_ui in self:

--- a/tilia/ui/timelines/collection/collection.py
+++ b/tilia/ui/timelines/collection/collection.py
@@ -46,7 +46,6 @@ from tilia.ui.timelines.collection.requests.timeline import (
 )
 from tilia.ui.timelines.collection.requests.element import TlElmRequestSelector
 from .view import TimelineUIsView
-from ..score import ScoreTimelineUI
 from ..beat import BeatTimelineUI
 from ..selection_box import SelectionBoxQt
 from ..slider.timeline import SliderTimelineUI
@@ -165,6 +164,7 @@ class TimelineUIs:
             (Post.SELECTION_BOX_DESELECT_ITEM, self.on_selection_box_deselect_item),
             (Post.TIMELINE_WIDTH_SET_DONE, self.on_timeline_width_set_done),
             (Post.TIMELINES_CROP_DONE, self.on_timelines_crop_done),
+            (Post.BEAT_TIMELINE_MEASURE_NUMBER_CHANGE_DONE, self.on_beat_timeline_measure_number_change_done),
             (Post.HIERARCHY_SELECTED, self.on_hierarchy_selected),
             (Post.HIERARCHY_DESELECTED, self.on_hierarchy_deselected),
             (Post.HIERARCHY_MERGE_SPLIT_DONE, self.on_hierarchy_merge_split),
@@ -646,6 +646,10 @@ class TimelineUIs:
                 tlui.on_horizontal_arrow_press(arrow)
             if direction == "vertical" and tlui.ACCEPTS_VERTICAL_ARROWS:
                 tlui.on_vertical_arrow_press(arrow)
+
+    def on_beat_timeline_measure_number_change_done(self, id: int, start_index: int):
+        timeline_ui = cast(BeatTimelineUI, self.get_timeline_ui(id))
+        timeline_ui.on_measure_number_change_done(start_index)
 
     @staticmethod
     def on_hierarchy_selected():

--- a/tilia/ui/timelines/collection/collection.py
+++ b/tilia/ui/timelines/collection/collection.py
@@ -903,6 +903,7 @@ class TimelineUIs:
         except Exception:
             post(Post.APP_STATE_RECOVER, state_backup)
             tilia.errors.display(tilia.errors.COMMAND_FAILED, traceback.format_exc())
+            traceback.print_exc()
             return
 
         self.validate_request_return_value(request, result)
@@ -932,6 +933,7 @@ class TimelineUIs:
         except Exception:
             post(Post.APP_STATE_RECOVER, state_backup)
             tilia.errors.display(tilia.errors.COMMAND_FAILED, traceback.format_exc())
+            traceback.print_exc()
             return
 
         self.validate_request_return_value(request, success)
@@ -970,6 +972,7 @@ class TimelineUIs:
         except Exception:
             post(Post.APP_STATE_RECOVER, state_backup)
             tilia.errors.display(tilia.errors.COMMAND_FAILED, traceback.format_exc())
+            traceback.print_exc()
             return
 
         self.validate_request_return_value(request, result)

--- a/tilia/ui/timelines/collection/requests/args.py
+++ b/tilia/ui/timelines/collection/requests/args.py
@@ -112,27 +112,6 @@ def _get_args_for_timelines_clear(_):
     return (confirmed,), {}
 
 
-def _get_args_for_beat_set_measure_number(_):
-    accepted, number = get(
-        Get.FROM_USER_INT, "Change measure number", "Insert measure number", min=0
-    )
-    if not accepted:
-        raise UserCancelledDialog
-    return (number,), {}
-
-
-def _get_args_for_beat_set_amount_in_measure(_):
-    accepted, number = get(
-        Get.FROM_USER_INT,
-        "Change beats in measure",
-        "Insert amount of beats in measure",
-        min=1,
-    )
-    if not accepted:
-        raise UserCancelledDialog
-    return (number,), {}
-
-
 def _get_args_for_hierarchy_add_pre_start(_):
     accept, number = get(Get.FROM_USER_FLOAT, "Add pre-start", "Pre-start length")
     if not accept:


### PR DESCRIPTION
Surprisingly, there were a lot of issues with numbering of measures. I'm not sure those were there before v0.5, but that might have been the case, as there were no tests in place for the relevant behaviors. Also, some of those bugs only happen when `BeatTimeline.beat_pattern = [1]` which is something I just recently found out that can be very useful, so they might have been there all along.

I also commited a couple of QoL enchancements: accelerators and printing tracebacks on timeline request errors.