### PR TITLE
Prevent setting non-positive media duration

### DIFF
--- a/tilia/ui/dialogs/basic.py
+++ b/tilia/ui/dialogs/basic.py
@@ -13,17 +13,17 @@ def ask_for_color(
 
 def ask_for_int(title: str, prompt: str, **kwargs) -> tuple[bool, int]:
     number, accepted = QInputDialog().getInt(None, title, prompt, **kwargs)
-    return bool(accepted) & True, number
+    return accepted, number
 
 
 def ask_for_string(title: str, prompt: str, **kwargs) -> tuple[bool, str]:
     string, accepted = QInputDialog().getText(None, title, prompt, **kwargs)
-    return bool(accepted) & True, string
+    return accepted, string
 
 
 def ask_for_float(title: str, prompt: str, **kwargs) -> tuple[bool, float]:
     number, accepted = QInputDialog().getDouble(None, title, prompt, **kwargs)
-    return bool(accepted) & True, number
+    return accepted, number
 
 
 def ask_yes_no_or_cancel(title: str, prompt: str) -> tuple[bool, bool]:

--- a/tilia/ui/dialogs/basic.py
+++ b/tilia/ui/dialogs/basic.py
@@ -11,23 +11,17 @@ def ask_for_color(
     return color.isValid(), color  # returned color is invalid if user cancels
 
 
-def ask_for_int(
-    title: str, prompt: str, **kwargs
-) -> tuple[bool, int]:
+def ask_for_int(title: str, prompt: str, **kwargs) -> tuple[bool, int]:
     number, accepted = QInputDialog().getInt(None, title, prompt, **kwargs)
     return accepted, number
 
 
-def ask_for_string(
-    title: str, prompt: str, **kwargs
-) -> tuple[bool, str]:
+def ask_for_string(title: str, prompt: str, **kwargs) -> tuple[bool, str]:
     string, accepted = QInputDialog().getText(None, title, prompt, **kwargs)
     return accepted, string
 
 
-def ask_for_float(
-    title: str, prompt: str, **kwargs
-) -> tuple[bool, float]:
+def ask_for_float(title: str, prompt: str, **kwargs) -> tuple[bool, float]:
     number, accepted = QInputDialog().getDouble(None, title, prompt, **kwargs)
     return accepted, number
 

--- a/tilia/ui/dialogs/basic.py
+++ b/tilia/ui/dialogs/basic.py
@@ -13,17 +13,17 @@ def ask_for_color(
 
 def ask_for_int(title: str, prompt: str, **kwargs) -> tuple[bool, int]:
     number, accepted = QInputDialog().getInt(None, title, prompt, **kwargs)
-    return accepted, number
+    return bool(accepted) & True, number
 
 
 def ask_for_string(title: str, prompt: str, **kwargs) -> tuple[bool, str]:
     string, accepted = QInputDialog().getText(None, title, prompt, **kwargs)
-    return accepted, string
+    return bool(accepted) & True, string
 
 
 def ask_for_float(title: str, prompt: str, **kwargs) -> tuple[bool, float]:
     number, accepted = QInputDialog().getDouble(None, title, prompt, **kwargs)
-    return accepted, number
+    return bool(accepted) & True, number
 
 
 def ask_yes_no_or_cancel(title: str, prompt: str) -> tuple[bool, bool]:

--- a/tilia/ui/dialogs/basic.py
+++ b/tilia/ui/dialogs/basic.py
@@ -12,23 +12,23 @@ def ask_for_color(
 
 
 def ask_for_int(
-    title: str, prompt: str, initial: Optional[int] = 0, **kwargs
+    title: str, prompt: str, **kwargs
 ) -> tuple[bool, int]:
-    number, accepted = QInputDialog().getInt(None, title, prompt, initial, **kwargs)
+    number, accepted = QInputDialog().getInt(None, title, prompt, **kwargs)
     return accepted, number
 
 
 def ask_for_string(
-    title: str, prompt: str, initial: Optional[str] = ""
+    title: str, prompt: str, **kwargs
 ) -> tuple[bool, str]:
-    string, accepted = QInputDialog().getText(None, title, prompt, text=initial)
+    string, accepted = QInputDialog().getText(None, title, prompt, **kwargs)
     return accepted, string
 
 
 def ask_for_float(
-    title: str, prompt: str, initial: Optional[float] = 0.0
+    title: str, prompt: str, **kwargs
 ) -> tuple[bool, float]:
-    number, accepted = QInputDialog().getDouble(None, title, prompt, initial)
+    number, accepted = QInputDialog().getDouble(None, title, prompt, **kwargs)
     return accepted, number
 
 

--- a/tilia/ui/timelines/collection/request_handler.py
+++ b/tilia/ui/timelines/collection/request_handler.py
@@ -45,7 +45,7 @@ class TimelineUIsRequestHandler(RequestHandler):
 
         if action_to_take == AddTimelineWithoutMedia.Result.SET_DURATION:
             success, duration = get(
-                Get.FROM_USER_FLOAT, "Set duration", "Insert duration"
+                Get.FROM_USER_FLOAT, "Set duration", "Insert duration", value=60, min=1
             )
             if not success:
                 return False

--- a/tilia/ui/timelines/collection/request_handler.py
+++ b/tilia/ui/timelines/collection/request_handler.py
@@ -6,7 +6,10 @@ from tilia.timelines.beat.timeline import BeatTimeline
 from tilia.timelines.timeline_kinds import TimelineKind
 from tilia.ui.dialogs.add_timeline_without_media import AddTimelineWithoutMedia
 from tilia.ui.request_handler import RequestHandler
-from tilia.ui.strings import BEAT_TIMELINE_FILL_TITLE, BEAT_TIMELINE_DELETE_EXISTING_BEATS_PROMPT
+from tilia.ui.strings import (
+    BEAT_TIMELINE_FILL_TITLE,
+    BEAT_TIMELINE_DELETE_EXISTING_BEATS_PROMPT,
+)
 
 
 def _get_media_is_loaded():
@@ -45,7 +48,11 @@ class TimelineUIsRequestHandler(RequestHandler):
 
         if action_to_take == AddTimelineWithoutMedia.Result.SET_DURATION:
             success, duration = get(
-                Get.FROM_USER_FLOAT, "Set duration", "Insert duration", value=60, min=1
+                Get.FROM_USER_FLOAT,
+                "Set duration",
+                "Insert duration (s)",
+                value=60,
+                min=1,
             )
             if not success:
                 return False
@@ -76,9 +83,7 @@ class TimelineUIsRequestHandler(RequestHandler):
                 return False
             kwargs |= additional_args
 
-        self.timelines.create_timeline(
-            kind=kind, components=None, name=name, **kwargs
-        )
+        self.timelines.create_timeline(kind=kind, components=None, name=name, **kwargs)
 
         return True
 
@@ -100,7 +105,7 @@ class TimelineUIsRequestHandler(RequestHandler):
             confirmed = get(
                 Get.FROM_USER_YES_OR_NO,
                 BEAT_TIMELINE_FILL_TITLE,
-                BEAT_TIMELINE_DELETE_EXISTING_BEATS_PROMPT
+                BEAT_TIMELINE_DELETE_EXISTING_BEATS_PROMPT,
             )
             if not confirmed:
                 return False

--- a/tilia/ui/timelines/collection/requests/args.py
+++ b/tilia/ui/timelines/collection/requests/args.py
@@ -114,9 +114,7 @@ def _get_args_for_timelines_clear(_):
 
 def _get_args_for_beat_set_measure_number(_):
     accepted, number = get(
-        Get.FROM_USER_INT,
-        "Change measure number",
-        "Insert measure number",
+        Get.FROM_USER_INT, "Change measure number", "Insert measure number", min=0
     )
     if not accepted:
         raise UserCancelledDialog

--- a/tilia/ui/timelines/collection/requests/args.py
+++ b/tilia/ui/timelines/collection/requests/args.py
@@ -18,7 +18,7 @@ def _get_args_for_timeline_name_set(timeline_uis):
         Get.FROM_USER_STRING,
         "Change timeline name",
         "Choose new name",
-        get(Get.TIMELINE, timeline_ui.id).name,
+        text=get(Get.TIMELINE, timeline_ui.id).name,
     )
     if not accepted:
         raise UserCancelledDialog
@@ -31,7 +31,7 @@ def _get_args_for_timeline_height_set(timeline_uis):
         Get.FROM_USER_INT,
         "Change timeline height",
         "Insert new timeline height",
-        initial=timeline_ui.get_data("height"),
+        value=timeline_ui.get_data("height"),
         min=10,
     )
     if not accepted:

--- a/tilia/ui/windows/svg_viewer.py
+++ b/tilia/ui/windows/svg_viewer.py
@@ -379,7 +379,7 @@ class SvgViewer(ViewDockWidget):
             return
         for item in to_edit:
             success, annotation = get(
-                Get.FROM_USER_STRING, "Score Annotation", "Edit Annotation", item.text()
+                Get.FROM_USER_STRING, "Score Annotation", "Edit Annotation", text=item.text()
             )
             if not success:
                 continue


### PR DESCRIPTION
Min is necessary as non-positive values may lead to crashes and default is nice when the user (or the developer) just wants to create a timeline and does not care about the specific media duration.

I also generalized some ask_for_ functions to make this change easier.