### PR TITLE
Improve readability of tristan, pedal and power harmonies symbols

### DIFF
--- a/tilia/ui/timelines/harmony/elements/harmony.py
+++ b/tilia/ui/timelines/harmony/elements/harmony.py
@@ -139,9 +139,11 @@ class HarmonyUI(TimelineUIElement):
             case "Neapolitan":
                 return "N6"
             case "power":
-                return figure.replace("o", "@o")
+                return figure.replace("power", "&5")
             case "Tristan":
-                return figure.replace("n", "@n")
+                return figure.replace("tristan", "`t`r`i`s`t")
+            case "pedal":
+                return figure.replace("pedal", "`p`e`d")
             case "seventh-flat-five":
                 return figure.replace("dom7dim5", "7((b5))")
         match self.get_data("accidental"):

--- a/tilia/ui/timelines/harmony/utils.py
+++ b/tilia/ui/timelines/harmony/utils.py
@@ -18,8 +18,6 @@ def _handle_special_qualities(quality: str) -> str | None:
             return "Gr6+"
         case "Neapolitan":
             return "N6"
-        case "Tristan":
-            return "Trista@n"
 
 
 QUALITY_TO_ROMAN_NUMERAL_SUFFIX = {
@@ -92,8 +90,9 @@ QUALITY_TO_ROMAN_NUMERAL_SUFFIX = {
     "suspended-second": ("52", "74", "54", None),
     "suspended-fourth": ("54", "52", "74", None),
     "suspended-fourth-seventh": ("74", "54", "52", None),
-    "pedal": ("`p`e`d`a`l", None, None, None),
-    "power": ("`p`o`w`e`r", None, None, None),
+    "pedal": ("`p`e`d", None, None, None),
+    "power": ("5", None, None, None),
+    "Tristan": ("`t`r`i`s`t", None, None, None),
 }
 
 INT_TO_APPLIED_TO_SUFFIX = {


### PR DESCRIPTION
Made "tristan" and "pedal" subscripts for chord symbols and abbbreviated them in chord symbols and roman numerals. Also used "X5" instead of "Xpower" for chord symbols of power chords. That is more conventional and more concise as pointed in #264. I opted to use a "pow" superscript as power chord suffix for roman numerals, as the "5" looks like an inversion suffix. 

Before:
![image](https://github.com/user-attachments/assets/21d73b16-a56d-4114-bdb8-a8fb53a2bb08)

After:
![image](https://github.com/user-attachments/assets/2f198a48-a598-42aa-9f46-b32703d20552)



