### PR TITLE
Fix smooth scroll performance

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -191,7 +191,7 @@ def use_test_settings(qapplication):
         constants_module.APP_NAME, f"DesktopTests"
     )
     settings_module.settings._check_all_default_settings_present()
-    settings_module.settings.set("general", "smooth-scroll", False)
+    settings_module.settings.set("general", "prioritise_performance", True)
     yield
 
 

--- a/tilia/settings.py
+++ b/tilia/settings.py
@@ -88,9 +88,7 @@ class SettingsManager(QObject):
     }
 
     def __init__(self):
-        self._settings = QSettings(
-            tilia.constants.APP_NAME, f"Desktop-v.{tilia.constants.VERSION}"
-        )
+        self._settings = QSettings(tilia.constants.APP_NAME, f"Desktop Settings")
         self._files_updated_callbacks = set()
         self._cache = {}
         self._check_all_default_settings_present()

--- a/tilia/settings.py
+++ b/tilia/settings.py
@@ -14,7 +14,7 @@ class SettingsManager(QObject):
             "window_y": 10,
             "timeline_background_color": "#EEE",
             "loop_box_shade": "#78c0c0c0",
-            "smooth-scroll": "true",
+            "prioritise_performance": "true",
         },
         "auto-save": {"max_stored_files": 100, "interval_(seconds)": 300},
         "media_metadata": {

--- a/tilia/ui/smooth_scroll.py
+++ b/tilia/ui/smooth_scroll.py
@@ -25,7 +25,7 @@ def smooth(self: Any, args_getter: Callable[[], tuple[Any]]):
 
     `args_getter` and `args_setter` must refer to the same variables in `args_setpoint` in the same order.
     """
-    fps = 500
+    fps = 100
     smoothing_duration = 150
     steps_total = fps * smoothing_duration / 1000
     is_ints = [isinstance(o, int) for o in args_getter()]

--- a/tilia/ui/smooth_scroll.py
+++ b/tilia/ui/smooth_scroll.py
@@ -31,7 +31,7 @@ def smooth(self: Any, args_getter: Callable[[], tuple[Any]]):
     is_ints = [isinstance(o, int) for o in args_getter()]
 
     def wrapper(args_setter: Callable[[tuple[Any]], None]) -> Callable:
-        if settings.get("general", "smooth-scroll") is False:
+        if settings.get("general", "prioritise_performance") is True:
             return args_setter
 
         def wrapped_setter(*args_setpoint: tuple[Any]) -> None:

--- a/tilia/ui/timelines/collection/collection.py
+++ b/tilia/ui/timelines/collection/collection.py
@@ -53,7 +53,7 @@ from ...actions import TiliaAction
 
 
 class TimelineUIs:
-    ZOOM_FACTOR = 0.1
+    ZOOM_FACTOR = 1.1
     UPDATE_TRIGGERS = ["height", "level_count", "visible_level_count"]
 
     def __init__(
@@ -160,11 +160,11 @@ class TimelineUIs:
             (Post.PLAYER_CURRENT_TIME_CHANGED, self.on_media_time_change),
             (
                 Post.VIEW_ZOOM_IN,
-                functools.partial(self.on_zoom, TimelineUIs.ZOOM_FACTOR),
+                functools.partial(self.on_zoom, True),
             ),
             (
                 Post.VIEW_ZOOM_OUT,
-                functools.partial(self.on_zoom, -TimelineUIs.ZOOM_FACTOR),
+                functools.partial(self.on_zoom, False),
             ),
             (Post.SELECTION_BOX_SELECT_ITEM, self.on_selection_box_select_item),
             (Post.SELECTION_BOX_DESELECT_ITEM, self.on_selection_box_deselect_item),
@@ -1055,7 +1055,7 @@ class TimelineUIs:
         except KeyError:
             raise NotImplementedError(f"Can't select with {selector=}")
 
-    def on_zoom(self, zoom_factor: float):
+    def on_zoom(self, is_zoom_in: bool):
         prev_smooth_scroll = settings.get("general", "prioritise_performance")
         if not prev_smooth_scroll:
             settings.set("general", "prioritise_performance", True)
@@ -1063,7 +1063,8 @@ class TimelineUIs:
         self.view.setUpdatesEnabled(False)
         post(
             Post.PLAYBACK_AREA_SET_WIDTH,
-            get(Get.PLAYBACK_AREA_WIDTH) * (1 + zoom_factor),
+            get(Get.PLAYBACK_AREA_WIDTH)
+            * (self.ZOOM_FACTOR if is_zoom_in else 1 / self.ZOOM_FACTOR),
         )
         self.center_on_time(self.selected_time)
         self.view.setUpdatesEnabled(True)

--- a/tilia/ui/timelines/collection/collection.py
+++ b/tilia/ui/timelines/collection/collection.py
@@ -1056,9 +1056,9 @@ class TimelineUIs:
             raise NotImplementedError(f"Can't select with {selector=}")
 
     def on_zoom(self, zoom_factor: float):
-        prev_smooth_scroll = settings.get("general", "smooth-scroll")
-        if prev_smooth_scroll:
-            settings.set("general", "smooth-scroll", False)
+        prev_smooth_scroll = settings.get("general", "prioritise_performance")
+        if not prev_smooth_scroll:
+            settings.set("general", "prioritise_performance", True)
 
         self.view.setUpdatesEnabled(False)
         post(
@@ -1068,8 +1068,8 @@ class TimelineUIs:
         self.center_on_time(self.selected_time)
         self.view.setUpdatesEnabled(True)
 
-        if prev_smooth_scroll:
-            settings.set("general", "smooth-scroll", True)
+        if not prev_smooth_scroll:
+            settings.set("general", "prioritise_performance", False)
 
     def _should_auto_scroll(self, media_time_change_reason) -> bool:
         return all(


### PR DESCRIPTION
potentially closes #267.

These performance issues are likely related to the user's computer running out of memory. Setting this to default to off and at a more moderate value when it is on will likely reduce the number of such incidents.