### PR TITLE
Improve exported JSON

### DIFF
--- a/tests/mock.py
+++ b/tests/mock.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 from typing import Any, Sequence
 from unittest.mock import patch, Mock
 
-from PyQt6.QtWidgets import QFileDialog, QMessageBox
+from PyQt6.QtWidgets import QFileDialog, QMessageBox, QInputDialog
 
 from tilia.requests import Get, Post, serve, server, stop_serving
 from tilia.requests import get as get_original
@@ -173,4 +173,25 @@ def patch_yes_or_no_dialog(success: bool | list[bool]):
         raise ValueError("success must be a bool or a list of bools.")
 
     with patch.object(QMessageBox, "question", side_effect=success):
+        yield
+
+
+@contextmanager
+def patch_ask_for_string_dialog(success: bool | list[bool], string: str | list[str]):
+    """Patches the QInputDialog to return the specified success values and strings.
+
+    Args:
+        success: Whether the dialog was successful. If a list, the success value for each iteration.
+        string: String input by user. If list of string, the input values for each iteration.
+    """
+
+    if not isinstance(success, list):
+        success = [success]
+        if not isinstance(string, list):
+            string = [string]
+        else:
+            raise ValueError("input must be a string if success is a bool.")
+
+    return_values = list(zip(string, success))
+    with (patch.object(QInputDialog, "getText", side_effect=return_values),):
         yield

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -172,5 +172,5 @@ def patch_yes_or_no_dialog(success: bool | list[bool]):
     else:
         raise ValueError("success must be a bool or a list of bools.")
 
-    with patch.object(QMessageBox, "question", return_value=success):
+    with patch.object(QMessageBox, "question", side_effect=success):
         yield

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -166,7 +166,7 @@ def patch_yes_or_no_dialog(success: bool | list[bool]):
         )
 
     if isinstance(success, bool):
-        success = get_button_from_bool(success)
+        success = [get_button_from_bool(success)]
     elif isinstance(success, list):
         success = [get_button_from_bool(s) for s in success]
     else:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -2,9 +2,12 @@ import json
 
 from tests.conftest import parametrize_component
 from tests.constants import EXAMPLE_MEDIA_PATH
-from tests.mock import Serve
+from tests.mock import Serve, patch_ask_for_string_dialog
 from tilia.requests import post, Post, Get
+from tilia.settings import settings
 from tilia.timelines.base.timeline import TimelineFlag
+from tilia.timelines.harmony.timeline import HarmonyTimeline
+from tilia.timelines.timeline_kinds import TimelineKind
 from tilia.ui.actions import TiliaAction
 
 
@@ -16,6 +19,50 @@ def _trigger_export_action(user_actions, path):
         data = json.load(f)
 
     return data
+
+
+def test_timelines_attributes_are_exported(
+    tilia, marker_tlui, user_actions, tmp_path, use_test_settings
+):
+    # Marker timeline is chosen as an example. Ideally this should be parametrized for all timelines kinds.
+    tl_name = "my name"
+    with patch_ask_for_string_dialog(True, tl_name):
+        user_actions.trigger(TiliaAction.TIMELINE_NAME_SET)
+
+    tmp_file = tmp_path / "test.json"
+
+    data = _trigger_export_action(user_actions, tmp_file)
+
+    timeline_data = data["timelines"][0]
+    assert "hash" not in timeline_data
+    assert timeline_data["ordinal"] == 1
+    assert timeline_data["name"] == tl_name
+    assert timeline_data["is_visible"] is True
+    assert timeline_data["height"] == settings.get("marker_timeline", "default_height")
+    assert timeline_data["kind"] == TimelineKind.MARKER_TIMELINE.name
+    assert timeline_data["components"] == []
+
+
+def test_timeline_not_exportable_attributes_are_not_exported(
+    tilia, harmony_tlui, user_actions, tmp_path
+):
+    # Harmony timeline is chosen as an example. Ideally this should be parametrized for all timelines kinds that have not exportable attributes.
+    tmp_file = tmp_path / "test.json"
+    data = _trigger_export_action(user_actions, tmp_file)
+
+    timeline_data = data["timelines"][0]
+    for attr in HarmonyTimeline.NOT_EXPORTABLE_ATTRS:
+        assert attr not in timeline_data
+
+
+def test_not_exportble_timelines_are_not_exported(
+    tilia, marker_tlui, audiowave_tlui, user_actions, tmp_path
+):
+    # Audiowave timeline is chosen as an example. Ideally this should be parametrized for all non-exportable timeline types.
+    tmp_file = tmp_path / "test.json"
+    data = _trigger_export_action(user_actions, tmp_file)
+
+    assert len(data["timelines"]) == 1
 
 
 def test_export_timelines(

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,14 +1,10 @@
 import json
 
-from tests.conftest import parametrize_tl, parametrize_component
+from tests.conftest import parametrize_component
 from tests.constants import EXAMPLE_MEDIA_PATH
 from tests.mock import Serve
 from tilia.requests import post, Post, Get
 from tilia.timelines.base.timeline import TimelineFlag
-from tilia.timelines.component_kinds import ComponentKind
-from tilia.timelines.harmony.components import Harmony, Mode
-from tilia.timelines.hierarchy.components import Hierarchy
-from tilia.timelines.marker.components import Marker
 from tilia.ui.actions import TiliaAction
 
 
@@ -39,22 +35,16 @@ def test_export_timelines(
     assert data["timelines"][1]["kind"] == "HARMONY_TIMELINE"
 
     # check marker timeline components
-    assert data["timelines"][0]["component_kinds"] == [Marker.KIND.name]
-    assert (
-        data["timelines"][0]["component_attributes"][ComponentKind.MARKER.name]
-        == Marker.get_export_attributes()
-    )
-    assert len(data["timelines"][0]["components"][ComponentKind.MARKER.name]) == 5
+    components = data["timelines"][0]["components"]
+    assert len(components) == 5
+    assert [c["kind"] for c in components] == ["MARKER"] * 5
+    assert [c["time"] for c in components] == [0, 1, 2, 3, 4]
 
     # check harmony timeline components
-    assert Harmony.KIND.name in data["timelines"][1]["component_kinds"]
-    assert Mode.KIND.name in data["timelines"][1]["component_kinds"]
-    assert data["timelines"][1]["component_attributes"] == {
-        "HARMONY": Harmony.get_export_attributes(),
-        "MODE": Mode.get_export_attributes(),
-    }
-    assert len(data["timelines"][1]["components"][ComponentKind.HARMONY.name]) == 1
-    assert len(data["timelines"][1]["components"][ComponentKind.MODE.name]) == 1
+    components = data["timelines"][1]["components"]
+    assert len(components) == 2
+    assert [c["kind"] for c in components] == ["HARMONY", "MODE"]
+    assert [c["time"] for c in components] == [0, 0]
 
 
 def test_export_has_media_path(tilia, user_actions, tmp_path):
@@ -92,67 +82,6 @@ def test_export_without_path(tilia, user_actions, tmp_path):
     assert tmp_file.exists()
 
 
-def test_export_attributes_are_present(tilia, user_actions, hierarchy_tl, tmp_path):
-    hierarchy_tl.create_hierarchy(start=0, end=1, level=1)
-
-    tmp_file = tmp_path / "test.json"
-
-    _trigger_export_action(user_actions, tmp_file)
-
-    with open(tmp_file, encoding="utf-8") as f:
-        data = json.load(f)
-
-    exported_attributes = data["timelines"][0]["component_attributes"][
-        Hierarchy.KIND.name
-    ]
-    expected = [
-        "start",
-        "pre_start",
-        "end",
-        "post_end",
-        "level",
-        "label",
-        "comments",
-        "start_measure",
-        "start_beat",
-        "end_measure",
-        "end_beat",
-        "length",
-        "length_in_measures",
-    ]
-    not_expected = ["color"]
-
-    for attr in expected:
-        assert attr in exported_attributes
-
-    for attr in not_expected:
-        assert attr not in exported_attributes
-
-
-@parametrize_tl
-def test_appropriate_attributes_are_exported(
-    tl, user_actions, tilia, request, tmp_path
-):
-    tl = request.getfixturevalue(tl)
-    tmp_file = tmp_path / "test.json"
-
-    _trigger_export_action(user_actions, tmp_file)
-
-    with open(tmp_file, encoding="utf-8") as f:
-        data = json.load(f)
-
-    if TimelineFlag.NOT_EXPORTABLE in tl.FLAGS:
-        assert not data["timelines"]
-    else:
-        for kind in tl.component_manager.component_kinds:
-            exported_attributes = data["timelines"][0]["component_attributes"][
-                kind.name
-            ]
-            comp_cls = tl.component_manager._get_component_class_by_kind(kind)
-            expected_attrs = comp_cls.get_export_attributes()
-            assert set(exported_attributes) == set(expected_attrs)
-
-
 @parametrize_component
 def test_exported_component_attributes_values_are_correct(
     tilia, user_actions, comp, tmp_path, request
@@ -168,9 +97,10 @@ def test_exported_component_attributes_values_are_correct(
     with open(tmp_file, encoding="utf-8") as f:
         data = json.load(f)
 
-    exported_values = data["timelines"][0]["components"][comp.KIND.name][0]
-    for i, attr in enumerate(comp.get_export_attributes()):
+    exported_component = data["timelines"][0]["components"][0]
+
+    for attr in comp.get_export_attributes():
         comp_value = getattr(comp, attr)
         if isinstance(comp_value, tuple):
             comp_value = list(comp_value)  # JSON converts tuples to lists
-        assert comp_value == exported_values[i]
+        assert comp_value == exported_component[attr]

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -12,6 +12,11 @@ def _trigger_export_action(user_actions, path):
     with Serve(Get.FROM_USER_EXPORT_PATH, (True, path)):
         user_actions.trigger(TiliaAction.FILE_EXPORT)
 
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    return data
+
 
 def test_export_timelines(
     tilia, marker_tlui, harmony_tlui, user_actions, tilia_state, tmp_path
@@ -25,10 +30,7 @@ def test_export_timelines(
 
     tmp_file = tmp_path / "test.json"
 
-    _trigger_export_action(user_actions, tmp_file)
-
-    with open(tmp_file, encoding="utf-8") as f:
-        data = json.load(f)
+    data = _trigger_export_action(user_actions, tmp_file)
 
     assert len(data["timelines"]) == 2
     assert data["timelines"][0]["kind"] == "MARKER_TIMELINE"
@@ -52,10 +54,7 @@ def test_export_has_media_path(tilia, user_actions, tmp_path):
 
     tmp_file = tmp_path / "test.json"
 
-    _trigger_export_action(user_actions, tmp_file)
-
-    with open(tmp_file, encoding="utf-8") as f:
-        data = json.load(f)
+    data = _trigger_export_action(user_actions, tmp_file)
 
     assert data["media_path"] == EXAMPLE_MEDIA_PATH
 
@@ -65,10 +64,7 @@ def test_export_has_media_metadata(tilia, user_actions, tmp_path):
 
     tmp_file = tmp_path / "test.json"
 
-    _trigger_export_action(user_actions, tmp_file)
-
-    with open(tmp_file, encoding="utf-8") as f:
-        data = json.load(f)
+    data = _trigger_export_action(user_actions, tmp_file)
 
     assert data["media_metadata"]["title"] == "Test Title"
 
@@ -92,10 +88,7 @@ def test_exported_component_attributes_values_are_correct(
 
     tmp_file = tmp_path / "test.json"
 
-    _trigger_export_action(user_actions, tmp_file)
-
-    with open(tmp_file, encoding="utf-8") as f:
-        data = json.load(f)
+    data = _trigger_export_action(user_actions, tmp_file)
 
     exported_component = data["timelines"][0]["components"][0]
 

--- a/tests/ui/cli/test_export.py
+++ b/tests/ui/cli/test_export.py
@@ -1,8 +1,6 @@
 import json
 from unittest.mock import patch
 
-from tilia.timelines.marker.components import Marker
-
 
 def test_export(tilia_state, cli, marker_tl, tmp_path):
     marker_tl.set_data("name", "test")
@@ -19,7 +17,7 @@ def test_export(tilia_state, cli, marker_tl, tmp_path):
     tl_data = data["timelines"][0]
 
     assert tl_data["name"] == "test"
-    assert len(tl_data["components"][Marker.KIND.name]) == 3
+    assert len(tl_data["components"]) == 3
 
 
 def test_export_file_exists_do_not_overwrite(tilia_state, cli, marker_tl, tmp_path):
@@ -55,7 +53,7 @@ def test_export_file_exists_overwrite(tilia_state, cli, marker_tl, tmp_path):
 
     tl_data = data["timelines"][0]
     assert tl_data["name"] == "test"
-    assert len(tl_data["components"][Marker.KIND.name]) == 3
+    assert len(tl_data["components"]) == 3
 
 
 def test_export_file_exists_overwrite_with_flag(tilia_state, cli, marker_tl, tmp_path):

--- a/tilia/timelines/base/timeline.py
+++ b/tilia/timelines/base/timeline.py
@@ -239,21 +239,14 @@ class Timeline(ABC, Generic[TC]):
     def get_export_data(self) -> dict[str, Any]:
         result = self._get_base_state()
 
-        result["component_kinds"] = [
-            kind.name for kind in self.component_manager.component_kinds
-        ]
-        result["components"] = {name: [] for name in result["component_kinds"]}
-        result[
-            "component_attributes"
-        ] = self.component_manager.get_component_attributes()
-        for kind in self.component_manager.component_kinds:
-            components = self.component_manager.get_components_by_condition(
-                lambda _: True, kind
-            )
-            result["components"][kind.name] = [
-                [getattr(comp, attr) for attr in comp.get_export_attributes()]
-                for comp in components
-            ]
+        result["components"] = []
+        for component in self.component_manager:
+            data = {
+                attr: getattr(component, attr)
+                for attr in component.get_export_attributes()
+            }
+            data["kind"] = component.KIND.name
+            result["components"].append(data)
 
         return result
 
@@ -495,12 +488,6 @@ class TimelineComponentManager(Generic[T, TC]):
 
     def scale(self, length: float) -> None:
         raise NotImplementedError
-
-    def get_component_attributes(self) -> dict[str, list[str]]:
-        return {
-            kind.name: self._get_component_class_by_kind(kind).get_export_attributes()
-            for kind in self.component_kinds
-        }
 
 
 class TimelineFlag(Enum):

--- a/tilia/timelines/base/timeline.py
+++ b/tilia/timelines/base/timeline.py
@@ -35,6 +35,7 @@ T = TypeVar("T", bound="Timeline")
 
 class Timeline(ABC, Generic[TC]):
     SERIALIZABLE = ["name", "height", "is_visible", "ordinal"]
+    NOT_EXPORTABLE_ATTRS = []
     KIND: TimelineKind | None = None
     FLAGS = []
     COMPONENT_MANAGER_CLASS = None
@@ -238,6 +239,9 @@ class Timeline(ABC, Generic[TC]):
 
     def get_export_data(self) -> dict[str, Any]:
         result = self._get_base_state()
+        result.pop("hash")
+        for attr in self.NOT_EXPORTABLE_ATTRS:
+            result.pop(attr)
 
         result["components"] = []
         for component in self.component_manager:

--- a/tilia/timelines/harmony/timeline.py
+++ b/tilia/timelines/harmony/timeline.py
@@ -141,6 +141,7 @@ class HarmonyTimeline(Timeline):
         "ordinal",
         "visible_level_count",
     ]
+    NOT_EXPORTABLE_ATTRS = ["level_count", "level_height"]
     COMPONENT_MANAGER_CLASS = HarmonyTLComponentManager
 
     def __init__(

--- a/tilia/timelines/score/timeline.py
+++ b/tilia/timelines/score/timeline.py
@@ -47,6 +47,7 @@ class ScoreTimeline(Timeline):
         "svg_data",
         "viewer_beat_x",
     ]
+    NOT_EXPORTABLE_ATTRS = ["svg_data", "viewer_beat_x"]
     COMPONENT_MANAGER_CLASS = ScoreTLComponentManager
 
     def __init__(


### PR DESCRIPTION
This makes files exported with the export feature more aligned with what JSON users would expect. We were using lists instead of objects to store components to reduce duplication. However, compression can take care of the key duplication in a size-sensitive context. Using object has the benefit of making the output format less complex, less surprising and easier to document.

Also added some tests for the export function and some fixes to test convenience functions.

This is made in preparation to documentation on the export feature.