### PR TITLE
chore: add flake8 pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,8 @@ repos:
         args: ['--maxkb=1000']
       - id: debug-statements
       - id: check-yaml
+
+-   repo: https://github.com/pycqa/flake8
+    rev: 7.1.0
+    hooks:
+    -   id: flake8


### PR DESCRIPTION
We are linting on PRs with GH Actions, so catching lint issues before commiting will save a lot of back and forth.