### PR TITLE
Improve performance of adding beats

### DIFF
--- a/tilia/timelines/base/timeline.py
+++ b/tilia/timelines/base/timeline.py
@@ -323,6 +323,7 @@ class TimelineComponentManager(Generic[T, TC]):
                 attr,
                 value,
             )
+        return value, success
 
     def get_component_data(self, id: int, attr: str):
         return self.get_component(id).get_data(attr)

--- a/tilia/timelines/beat/components.py
+++ b/tilia/timelines/beat/components.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from tilia.timelines.base.metric_position import MetricPosition
 from tilia.timelines.base.validators import validate_time, validate_bool
@@ -67,12 +67,3 @@ class Beat(PointLikeTimelineComponent):
     @property
     def beat_number(self):
         return self.metric_position.beat
-
-    def set_data(self, attr, value):
-        from tilia.timelines.beat.timeline import BeatTimeline
-
-        value, success = super().set_data(attr, value)
-        if success:
-            self.timeline = cast(BeatTimeline, self.timeline)
-            self.timeline.update_metric_fraction_dicts()
-        return value, success


### PR DESCRIPTION
Caches beat metric position and prevents redudant calls to `BeatTimeline.update_metric_fraction_dict` to greatly improve performance when adding more beats to timelines with hundreds of beats.

This is not a long-term solution to our performance issues, but it solves #321 for the use-case described. Where more precise beat annotations are required, the performance is still subpar.

