### PR TITLE
fix: use current measure number as initial value in set measure number dialog

### DIFF
--- a/tests/ui/timelines/beat/test_beat_timeline_ui.py
+++ b/tests/ui/timelines/beat/test_beat_timeline_ui.py
@@ -1,6 +1,7 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
+from PySide6.QtWidgets import QInputDialog
 
 from tests.mock import Serve, patch_yes_or_no_dialog
 from tests.utils import undoable
@@ -347,6 +348,70 @@ class TestSetMeasureNumber:
         """Assumes there a beat in the measure is selected"""
         with Serve(Get.FROM_USER_INT, (True, number)):
             commands.execute("timeline.beat.set_measure_number")
+
+    @staticmethod
+    def _get_dialog_kwargs():
+        """Runs the command with the dialog mocked and returns how it was called.
+
+        Serve discards the arguments the request is made with, so the dialog
+        itself has to be mocked to check what it is prefilled with.
+        """
+        with patch.object(QInputDialog, "getInt", return_value=(0, False)) as dialog:
+            commands.execute("timeline.beat.set_measure_number")
+        return dialog.call_args.kwargs
+
+    def test_dialog_initial_value_is_current_measure_number(self, beat_tlui):
+        beat_tlui.create_beat(0)
+        beat_tlui.select_element(beat_tlui[0])
+
+        assert self._get_dialog_kwargs()["value"] == 1
+
+    def test_dialog_initial_value_after_measure_number_was_changed(self, beat_tlui):
+        beat_tlui.timeline.beat_pattern = [3]
+        for i in range(12):
+            beat_tlui.create_beat(i / 10)
+
+        beat_tlui.select_element(beat_tlui[3])
+        self._set_measure_number()
+
+        assert self._get_dialog_kwargs()["value"] == DUMMY_MEASURE_NUMBER
+
+    def test_dialog_initial_value_when_beat_is_not_first_in_measure(self, beat_tlui):
+        beat_tlui.timeline.beat_pattern = [3]
+        for i in range(12):
+            beat_tlui.create_beat(i / 10)
+        beat_tlui.timeline.set_measure_number(1, 42)
+
+        beat_tlui.select_element(beat_tlui[4])
+
+        assert self._get_dialog_kwargs()["value"] == 42
+
+    def test_dialog_initial_value_is_earliest_selected_measure(self, beat_tlui):
+        beat_tlui.timeline.beat_pattern = [1]
+        for i in range(6):
+            beat_tlui.create_beat(i / 10)
+
+        beat_tlui.select_element(beat_tlui[4])
+        beat_tlui.select_element(beat_tlui[1])
+
+        assert self._get_dialog_kwargs()["value"] == 2
+
+    def test_accepting_initial_value_sets_all_selected_measures(self, beat_tlui):
+        beat_tlui.timeline.beat_pattern = [1]
+        for i in range(6):
+            beat_tlui.create_beat(i / 10)
+
+        beat_tlui.select_element(beat_tlui[1])
+        beat_tlui.select_element(beat_tlui[4])
+
+        with patch.object(
+            QInputDialog,
+            "getInt",
+            side_effect=lambda *_, **kwargs: (kwargs["value"], True),
+        ):
+            commands.execute("timeline.beat.set_measure_number")
+
+        assert beat_tlui.timeline.measure_numbers == [1, 2, 3, 4, 2, 3]
 
     def test_set_measure_number_single_measure(self, beat_tlui):
         beat_tlui.create_beat(0)

--- a/tilia/ui/timelines/beat/timeline.py
+++ b/tilia/ui/timelines/beat/timeline.py
@@ -112,16 +112,18 @@ class BeatTimelineUI(TimelineUI):
 
     @with_elements
     def on_set_measure_number(self, elements: list[BeatUI] | None = None):
+        measure_indices = self._get_measure_indices(elements)
         accepted, number = get(
             Get.FROM_USER_INT,
             "Change measure number",
             "Insert measure number",
+            value=self.timeline.measure_numbers[measure_indices[0]],
             minValue=0,
         )
         if not accepted:
             return False
 
-        for i in reversed(self._get_measure_indices(elements)):
+        for i in reversed(measure_indices):
             self.timeline.set_measure_number(i, number)
         return True
 


### PR DESCRIPTION
## Summary
- Prefills the \"Set measure number\" dialog with the measure number of the first selected beat, instead of always defaulting to 0.

## Test plan
- [ ] Right-click a beat, select \"Set measure number\" — dialog should open pre-filled with the current measure number for that beat.

Closes #471