### PR TITLE
feat: add harmony and audiowave timeline kinds to CLI add command

### DIFF
--- a/tests/ui/cli/timelines/test_cli_timelines_add.py
+++ b/tests/ui/cli/timelines/test_cli_timelines_add.py
@@ -59,3 +59,27 @@ class TestTimelineAdd:
 
         tl = tls.get_timelines()[0]
         assert tl.beat_pattern == [4]
+
+    def test_add_harmony_timeline(self, cli, tls):
+        cli.parse_and_run("timeline add har --name test")
+
+        tl = tls.get_timelines()[0]
+        assert tl.KIND == TimelineKind.HARMONY_TIMELINE
+        assert tl.name == "test"
+
+    def test_add_harmony_timeline_full_name(self, cli, tls):
+        cli.parse_and_run("timeline add harmony")
+
+        assert tls.get_timelines()[0].KIND == TimelineKind.HARMONY_TIMELINE
+
+    def test_add_audiowave_timeline(self, cli, tls):
+        cli.parse_and_run("timeline add aud --name test")
+
+        tl = tls.get_timelines()[0]
+        assert tl.KIND == TimelineKind.AUDIOWAVE_TIMELINE
+        assert tl.name == "test"
+
+    def test_add_audiowave_timeline_full_name(self, cli, tls):
+        cli.parse_and_run("timeline add audiowave")
+
+        assert tls.get_timelines()[0].KIND == TimelineKind.AUDIOWAVE_TIMELINE

--- a/tilia/ui/cli/timelines/add.py
+++ b/tilia/ui/cli/timelines/add.py
@@ -21,7 +21,20 @@ Examples:
     )
     add_subp.add_argument(
         "kind",
-        choices=["hierarchy", "hrc", "marker", "mrk", "beat", "bea", "score", "sco"],
+        choices=[
+            "hierarchy",
+            "hrc",
+            "marker",
+            "mrk",
+            "beat",
+            "bea",
+            "score",
+            "sco",
+            "harmony",
+            "har",
+            "audiowave",
+            "aud",
+        ],
         help="Kind of timeline to add",
     )
     add_subp.add_argument(
@@ -50,6 +63,10 @@ KIND_STR_TO_TLKIND = {
     "bea": TlKind.BEAT_TIMELINE,
     "score": TlKind.SCORE_TIMELINE,
     "sco": TlKind.SCORE_TIMELINE,
+    "harmony": TlKind.HARMONY_TIMELINE,
+    "har": TlKind.HARMONY_TIMELINE,
+    "audiowave": TlKind.AUDIOWAVE_TIMELINE,
+    "aud": TlKind.AUDIOWAVE_TIMELINE,
 }
 
 TLKIND_TO_KWARGS_NAMES = {
@@ -57,6 +74,8 @@ TLKIND_TO_KWARGS_NAMES = {
     TlKind.HIERARCHY_TIMELINE: ["name", "height"],
     TlKind.MARKER_TIMELINE: ["name", "height"],
     TlKind.SCORE_TIMELINE: ["name", "height"],
+    TlKind.HARMONY_TIMELINE: ["name"],
+    TlKind.AUDIOWAVE_TIMELINE: ["name"],
 }
 
 


### PR DESCRIPTION
## Summary
- Adds `harmony` / `har` and `audiowave` / `aud` as valid kind arguments to `timelines add`.
- Harmony timelines omit the `--height` kwarg (their height is computed from level count and level height internally).
- Audiowave timelines similarly omit `--height`.
- Tests added for both new kinds and their abbreviations.

## Test plan
- [ ] `tilia timelines add harmony --name "Chords"` creates a harmony timeline.
- [ ] `tilia timelines add har` works as shorthand.
- [ ] `tilia timelines add audiowave --name "Wave"` creates an audiowave timeline.
- [ ] `tilia timelines add aud` works as shorthand.

Closes #476