### PR TITLE
Feat/player time edit

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -927,16 +927,16 @@ class TestFileNew:
         assert get(Get.MEDIA_DURATION) == 0
         assert not tilia.player.media_path
 
-    def test_player_toolbar_is_disabled(self, tilia, qtui):
+    def test_player_controls_disabled_on_new_file(self, tilia, qtui):
         with Serve(Get.FROM_USER_MEDIA_PATH, (True, EXAMPLE_MEDIA_PATH)):
             commands.execute("media.load.local")
 
-        assert qtui.player_toolbar.isEnabled()
+        assert qtui.player_toolbar.play_toggle_action.isEnabled()
 
         with Serve(Get.FROM_USER_SHOULD_SAVE_CHANGES, (True, False)):
             commands.execute("file.new")
 
-        assert not qtui.player_toolbar.isEnabled()
+        assert not qtui.player_toolbar.play_toggle_action.isEnabled()
 
     def test_all_windows_are_closed(self, tilia, qtui):
         for kind in WindowKind:

--- a/tests/ui/test_player_toolbar.py
+++ b/tests/ui/test_player_toolbar.py
@@ -1,0 +1,292 @@
+from unittest.mock import patch
+
+import pytest
+from PySide6.QtCore import QEvent, Qt
+from PySide6.QtGui import QKeyEvent
+
+from tests.mock import PatchPost, Serve
+from tests.utils import save_tilia_to_tmp_path
+from tilia.media.player.base import MediaTimeChangeReason
+from tilia.requests import Get, Post, post
+from tilia.ui import commands
+from tilia.ui.format import format_media_time, parse_media_time
+from tilia.ui.player import PlayerStatus, PlayerToolbarElement
+
+
+class TestPlayToggle:
+    def test_trigger_posts_toggle_play_pause(self, qtui):
+        post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.PLAYER_ENABLED)
+        with patch.object(commands, "execute") as mock:
+            qtui.player_toolbar.play_toggle_action.trigger()
+        mock.assert_called_once_with("media.toggle_play", True)
+
+    def test_ui_update_checks(self, qtui):
+        post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.PLAYER_ENABLED)
+        post(Post.PLAYER_UI_UPDATE, PlayerToolbarElement.TOGGLE_PLAY_PAUSE, True)
+        assert qtui.player_toolbar.play_toggle_action.isChecked()
+
+    def test_ui_update_unchecks(self, qtui):
+        post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.PLAYER_ENABLED)
+        post(Post.PLAYER_UI_UPDATE, PlayerToolbarElement.TOGGLE_PLAY_PAUSE, True)
+        post(Post.PLAYER_UI_UPDATE, PlayerToolbarElement.TOGGLE_PLAY_PAUSE, False)
+        assert not qtui.player_toolbar.play_toggle_action.isChecked()
+
+    def test_ui_update_ignored_when_not_player_enabled(self, qtui):
+        post(Post.PLAYER_UI_UPDATE, PlayerToolbarElement.TOGGLE_PLAY_PAUSE, True)
+        assert not qtui.player_toolbar.play_toggle_action.isChecked()
+
+
+class TestLoopToggle:
+    def test_trigger_posts_toggle_loop(self, qtui):
+        post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.PLAYER_ENABLED)
+        with PatchPost("tilia.ui.player", Post.PLAYER_TOGGLE_LOOP) as mock:
+            qtui.player_toolbar.loop_toggle_action.trigger()
+        mock.assert_called_once()
+
+    def test_ui_update_checks(self, qtui):
+        post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.PLAYER_ENABLED)
+        post(Post.PLAYER_UI_UPDATE, PlayerToolbarElement.TOGGLE_LOOP, True)
+        assert qtui.player_toolbar.loop_toggle_action.isChecked()
+
+    def test_ui_update_unchecks(self, qtui):
+        post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.PLAYER_ENABLED)
+        post(Post.PLAYER_UI_UPDATE, PlayerToolbarElement.TOGGLE_LOOP, True)
+        post(Post.PLAYER_UI_UPDATE, PlayerToolbarElement.TOGGLE_LOOP, False)
+        assert not qtui.player_toolbar.loop_toggle_action.isChecked()
+
+
+class TestVolume:
+    def test_toggle_posts_volume_mute(self, qtui):
+        post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.PLAYER_ENABLED)
+        with patch.object(commands, "execute") as mock:
+            qtui.player_toolbar.volume_toggle_action.trigger()
+        mock.assert_called_once_with("media.volume.mute", True)
+
+    def test_toggle_disables_slider(self, qtui):
+        post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.PLAYER_ENABLED)
+        qtui.player_toolbar.volume_toggle_action.trigger()
+        assert not qtui.player_toolbar.volume_slider.isEnabled()
+
+    def test_untoggle_re_enables_slider(self, qtui):
+        post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.PLAYER_ENABLED)
+        qtui.player_toolbar.volume_toggle_action.trigger()
+        qtui.player_toolbar.volume_toggle_action.trigger()
+        assert qtui.player_toolbar.volume_slider.isEnabled()
+
+    def test_slider_posts_volume_change(self, qtui):
+        post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.PLAYER_ENABLED)
+        with patch.object(commands, "execute") as mock:
+            qtui.player_toolbar.volume_slider.setValue(50)
+        mock.assert_called_once_with("media.volume.change", 50)
+
+    def test_ui_update_sets_volume_silently(self, qtui):
+        post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.PLAYER_ENABLED)
+        with patch.object(commands, "execute") as mock:
+            post(Post.PLAYER_UI_UPDATE, PlayerToolbarElement.SLIDER_VOLUME, 50)
+        mock.assert_not_called()
+        assert qtui.player_toolbar.volume_slider.value() == 50
+
+    def test_ui_update_checks_volume_toggle(self, qtui):
+        post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.PLAYER_ENABLED)
+        post(Post.PLAYER_UI_UPDATE, PlayerToolbarElement.TOGGLE_VOLUME, True)
+        assert qtui.player_toolbar.volume_toggle_action.isChecked()
+
+
+class TestPlaybackRate:
+    def test_spinbox_posts_rate_change(self, qtui):
+        post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.PLAYER_ENABLED)
+        with patch.object(commands, "execute") as mock:
+            qtui.player_toolbar.playback_rate_spinbox.setValue(1.5)
+        mock.assert_called_once_with("media.playback_rate.try", pytest.approx(1.5))
+
+    def test_ui_update_sets_rate_silently(self, qtui):
+        post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.PLAYER_ENABLED)
+        with patch.object(commands, "execute") as mock:
+            post(Post.PLAYER_UI_UPDATE, PlayerToolbarElement.SPINBOX_PLAYBACK, 2.0)
+        mock.assert_not_called()
+        assert qtui.player_toolbar.playback_rate_spinbox.value() == pytest.approx(2.0)
+
+
+class TestParseMediaTime:
+    def test_plain_seconds(self):
+        assert parse_media_time("5") == pytest.approx(5.0)
+
+    def test_plain_seconds_with_decimal(self):
+        assert parse_media_time("5.5") == pytest.approx(5.5)
+
+    def test_mm_ss(self):
+        assert parse_media_time("1:30") == pytest.approx(90.0)
+
+    def test_mm_ss_with_decimal(self):
+        assert parse_media_time("1:30.5") == pytest.approx(90.5)
+
+    def test_hh_mm_ss(self):
+        assert parse_media_time("1:00:00") == pytest.approx(3600.0)
+
+    def test_hh_mm_ss_with_decimal(self):
+        assert parse_media_time("1:30:45.5") == pytest.approx(5445.5)
+
+    def test_empty_returns_none(self):
+        assert parse_media_time("") is None
+
+    def test_trailing_colon_returns_none(self):
+        assert parse_media_time("1:") is None
+
+    def test_colon_only_returns_none(self):
+        assert parse_media_time(":") is None
+
+
+class TestTimeEditEnabled:
+    @pytest.fixture(autouse=True)
+    def reset_to_no_media(self):
+        post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.NO_MEDIA)
+        post(Post.FILE_MEDIA_DURATION_CHANGED, 0.0)
+
+    def test_time_edit_disabled_when_no_media_and_no_duration(self, qtui):
+        assert not qtui.player_toolbar.time_edit.isEnabled()
+
+    def test_time_edit_enabled_when_duration_set_in_no_media_state(self, qtui):
+        post(Post.FILE_MEDIA_DURATION_CHANGED, 60.0)
+        assert qtui.player_toolbar.time_edit.isEnabled()
+
+    def test_time_edit_disabled_when_duration_cleared_in_no_media_state(self, qtui):
+        post(Post.FILE_MEDIA_DURATION_CHANGED, 60.0)
+        post(Post.FILE_MEDIA_DURATION_CHANGED, 0.0)
+        assert not qtui.player_toolbar.time_edit.isEnabled()
+
+    def test_time_edit_enabled_when_player_enabled(self, qtui):
+        post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.PLAYER_ENABLED)
+        assert qtui.player_toolbar.time_edit.isEnabled()
+
+    def test_time_edit_disabled_when_waiting_for_youtube(self, qtui):
+        post(Post.FILE_MEDIA_DURATION_CHANGED, 60.0)
+        post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.WAITING_FOR_YOUTUBE)
+        assert not qtui.player_toolbar.time_edit.isEnabled()
+
+
+class TestTimeEditInteraction:
+    def test_seek_posted_on_valid_input(self, qtui):
+        qtui.player_toolbar.duration = 100.0
+        qtui.player_toolbar.time_edit.setText("1:30")
+        with patch.object(commands, "execute") as mock:
+            qtui.player_toolbar.time_edit.returnPressed.emit()
+        mock.assert_called_once_with("media.seek", pytest.approx(90.0))
+
+    def test_seek_clamped_to_duration(self, qtui):
+        qtui.player_toolbar.duration = 60.0
+        qtui.player_toolbar.time_edit.setText("200")
+        with patch.object(commands, "execute") as mock:
+            qtui.player_toolbar.time_edit.returnPressed.emit()
+        mock.assert_called_once_with("media.seek", pytest.approx(60.0))
+
+    def test_no_seek_on_parse_failure(self, qtui):
+        qtui.player_toolbar.time_edit.setText("")
+        with patch.object(commands, "execute") as mock:
+            qtui.player_toolbar.time_edit.returnPressed.emit()
+        mock.assert_not_called()
+
+    def test_text_reverts_after_successful_commit(self, qtui):
+        qtui.player_toolbar.current_time_string = "01:30.0"
+        qtui.player_toolbar.duration = 100.0
+        qtui.player_toolbar.time_edit.setText("02:00")
+        with patch.object(commands, "execute"):
+            qtui.player_toolbar.time_edit.returnPressed.emit()
+        assert qtui.player_toolbar.time_edit.text() == "01:30.0"
+
+    def test_text_reverts_after_failed_commit(self, qtui):
+        qtui.player_toolbar.current_time_string = "01:30.0"
+        qtui.player_toolbar.time_edit.setText("")
+        qtui.player_toolbar.time_edit.returnPressed.emit()
+        assert qtui.player_toolbar.time_edit.text() == "01:30.0"
+
+    def test_escape_reverts_text(self, qtui):
+        qtui.player_toolbar.current_time_string = "01:30.0"
+        qtui.player_toolbar.time_edit.setText("02:00.0")
+        event = QKeyEvent(
+            QEvent.Type.KeyPress, Qt.Key.Key_Escape, Qt.KeyboardModifier.NoModifier
+        )
+        qtui.player_toolbar.eventFilter(qtui.player_toolbar.time_edit, event)
+        assert qtui.player_toolbar.time_edit.text() == "01:30.0"
+
+    def test_escape_does_not_seek(self, qtui):
+        qtui.player_toolbar.duration = 100.0
+        qtui.player_toolbar.time_edit.setText("1:30")
+        event = QKeyEvent(
+            QEvent.Type.KeyPress, Qt.Key.Key_Escape, Qt.KeyboardModifier.NoModifier
+        )
+        with patch.object(commands, "execute") as mock:
+            qtui.player_toolbar.eventFilter(qtui.player_toolbar.time_edit, event)
+        mock.assert_not_called()
+
+    def test_time_display_updates_on_time_changed(self, qtui):
+        post(Post.PLAYER_CURRENT_TIME_CHANGED, 90.0, MediaTimeChangeReason.PLAYBACK)
+        assert qtui.player_toolbar.time_edit.text() == format_media_time(90.0)
+
+    def test_time_display_not_updated_when_focused(self, qtui):
+        qtui.player_toolbar.time_edit.setText("typing...")
+        with patch.object(qtui.player_toolbar.time_edit, "hasFocus", return_value=True):
+            post(Post.PLAYER_CURRENT_TIME_CHANGED, 90.0, MediaTimeChangeReason.PLAYBACK)
+        assert qtui.player_toolbar.time_edit.text() == "typing..."
+
+    def test_seek_via_timeline_updates_time_edit(self, qtui, tilia_state):
+        tilia_state.duration = 120.0
+        tilia_state.current_time = 90.0
+        assert qtui.player_toolbar.time_edit.text() == format_media_time(90.0)
+
+
+class TestDisplayUpdates:
+    def test_duration_label_updated(self, qtui):
+        post(Post.FILE_MEDIA_DURATION_CHANGED, 180.0)
+        assert qtui.player_toolbar.duration_label.text() == format_media_time(180.0)
+
+    def test_time_resets_to_zero_on_stop(self, qtui):
+        post(Post.PLAYER_CURRENT_TIME_CHANGED, 90.0, MediaTimeChangeReason.PLAYBACK)
+        post(Post.PLAYER_STOPPED)
+        assert qtui.player_toolbar.time_edit.text() == format_media_time(0)
+
+    def test_play_toggle_unchecked_on_stop(self, qtui):
+        post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.PLAYER_ENABLED)
+        post(Post.PLAYER_UI_UPDATE, PlayerToolbarElement.TOGGLE_PLAY_PAUSE, True)
+        post(Post.PLAYER_STOPPED)
+        assert not qtui.player_toolbar.play_toggle_action.isChecked()
+
+
+class TestTimePersistence:
+    def test_pending_time_set_on_file_load(self, tilia, qtui, tmp_path):
+        with Serve(Get.MEDIA_CURRENT_TIME, 42.0):
+            file_path = save_tilia_to_tmp_path(tmp_path)
+        post(Post.APP_CLEAR)
+        commands.execute("file.open", path=file_path)
+        assert qtui.player_toolbar._pending_time == pytest.approx(42.0)
+
+    def test_seek_posted_when_duration_available(self, qtui):
+        qtui.player_toolbar._pending_time = 42.0
+        with patch.object(commands, "execute") as mock:
+            post(Post.FILE_MEDIA_DURATION_CHANGED, 100.0)
+        mock.assert_called_once_with("media.seek", pytest.approx(42.0))
+
+    def test_seek_clamped_to_duration(self, qtui):
+        qtui.player_toolbar._pending_time = 200.0
+        with patch.object(commands, "execute") as mock:
+            post(Post.FILE_MEDIA_DURATION_CHANGED, 100.0)
+        mock.assert_called_once_with("media.seek", pytest.approx(100.0))
+
+    def test_pending_time_cleared_after_seek(self, qtui):
+        qtui.player_toolbar._pending_time = 42.0
+        post(Post.FILE_MEDIA_DURATION_CHANGED, 100.0)
+        assert qtui.player_toolbar._pending_time is None
+
+    def test_no_seek_when_no_pending_time(self, qtui):
+        with patch.object(commands, "execute") as mock:
+            post(Post.FILE_MEDIA_DURATION_CHANGED, 100.0)
+        mock.assert_not_called()
+
+    def test_pending_time_not_applied_for_youtube(self, qtui):
+        qtui.player_toolbar._pending_time = 42.0
+        post(Post.PLAYER_UPDATE_CONTROLS, PlayerStatus.WAITING_FOR_YOUTUBE)
+        assert qtui.player_toolbar._pending_time is None
+
+    def test_pending_time_cleared_on_app_clear(self, qtui):
+        qtui.player_toolbar._pending_time = 42.0
+        post(Post.APP_CLEAR)
+        assert qtui.player_toolbar._pending_time is None

--- a/tilia/file/file_manager.py
+++ b/tilia/file/file_manager.py
@@ -350,8 +350,16 @@ class FileManager:
             geometry, window_state = get(Get.WINDOW_GEOMETRY), get(Get.WINDOW_STATE)
             zoom = get(Get.CURRENT_ZOOM)
         except NoReplyToRequest:
+            # No UI is listening (e.g. CLI usage or tests without a full
+            # Qt UI set up), so there's nothing to persist here.
             geometry, window_state, zoom = None, None, None
-        settings.update_recent_files(path, geometry, window_state, zoom)
+        try:
+            current_time = get(Get.MEDIA_CURRENT_TIME)
+        except NoReplyToRequest:
+            current_time = None
+        settings.update_recent_files(
+            path, geometry, window_state, zoom, time=current_time
+        )
 
     def new(self):
         self._setup_file()

--- a/tilia/settings.py
+++ b/tilia/settings.py
@@ -176,7 +176,14 @@ class SettingsManager(QObject):
     def _get_key(group_name: str, setting: str, in_default: bool) -> str:
         return f"{'editable/' if in_default else ''}{group_name}/{setting}"
 
-    def update_recent_files(self, path, geometry, state, zoom: float | None = None):
+    def update_recent_files(
+        self,
+        path,
+        geometry,
+        state,
+        zoom: float | None = None,
+        time: float | None = None,
+    ):
         recent_files = self._settings.value("private/recent_files", [])
         if not isinstance(recent_files, list):
             recent_files = [recent_files]
@@ -189,6 +196,8 @@ class SettingsManager(QObject):
         self._settings.setValue(f"private/recent_files/{path}/state", state)
         if zoom is not None:
             self._settings.setValue(f"private/recent_files/{path}/zoom", zoom)
+        if time is not None:
+            self._settings.setValue(f"private/recent_files/{path}/playback_time", time)
         self._apply_recent_files_changes()
 
     def get_file_geometry(self, path) -> tuple:
@@ -201,6 +210,11 @@ class SettingsManager(QObject):
         path = Path(path).as_posix()
         zoom = self._settings.value(f"private/recent_files/{path}/zoom", None)
         return float(zoom) if zoom is not None else None
+
+    def get_file_time(self, path) -> float | None:
+        path = Path(path).as_posix()
+        value = self._settings.value(f"private/recent_files/{path}/playback_time", None)
+        return float(value) if value is not None else None
 
     def remove_from_recent_files(self, path):
         recent_files = self._settings.value("private/recent_files", [])

--- a/tilia/ui/format.py
+++ b/tilia/ui/format.py
@@ -4,3 +4,17 @@ def format_media_time(audio_time: float | str) -> str:
     hours = str(minutes // 60) + ":" if minutes >= 60 else ""
     minutes = str(minutes % 60).zfill(2)
     return f"{hours}{minutes}:{seconds_and_fraction}"
+
+
+def parse_media_time(text: str) -> float | None:
+    """Parse 'HH:MM:SS.f', 'MM:SS.f', or 'SS.f' to seconds. Returns None on invalid input."""
+    parts = text.split(":")
+    try:
+        if len(parts) == 3:
+            return int(parts[0]) * 3600 + int(parts[1]) * 60 + float(parts[2])
+        elif len(parts) == 2:
+            return int(parts[0]) * 60 + float(parts[1])
+        else:
+            return float(parts[0])
+    except ValueError:
+        return None

--- a/tilia/ui/player.py
+++ b/tilia/ui/player.py
@@ -1,18 +1,26 @@
-from enum import Enum, auto
+from __future__ import annotations
 
-from PySide6.QtCore import QEvent, Qt
-from PySide6.QtGui import QAction, QIcon
+from enum import Enum, auto
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import QEvent, QRegularExpression, Qt
+from PySide6.QtGui import QAction, QIcon, QRegularExpressionValidator
+
+if TYPE_CHECKING:
+    from tilia.file.tilia_file import TiliaFile
 from PySide6.QtWidgets import (
     QDoubleSpinBox,
     QLabel,
+    QLineEdit,
     QSlider,
     QToolBar,
 )
 
 import tilia.errors
 from tilia.requests import Get, Post, get, listen, post, stop_listening_to_all
+from tilia.settings import settings
 from tilia.ui import commands
-from tilia.ui.format import format_media_time
+from tilia.ui.format import format_media_time, parse_media_time
 
 
 class PlayerToolbar(QToolBar):
@@ -25,7 +33,10 @@ class PlayerToolbar(QToolBar):
 
         self.current_time_string = format_media_time(0)
         self.duration_string = format_media_time(0)
+        self.duration = 0.0
         self.last_playback_rate = 1.0
+        self._status = PlayerStatus.NO_MEDIA
+        self._pending_time: float | None = None
 
         self._setup_controls()
 
@@ -41,6 +52,8 @@ class PlayerToolbar(QToolBar):
             (Post.PLAYER_STOPPED, self.on_stop),
             (Post.PLAYER_UPDATE_CONTROLS, self.on_update_controls),
             (Post.PLAYER_UI_UPDATE, self.on_ui_update_silent),
+            (Post.APP_FILE_LOADED, self._on_file_loaded),
+            (Post.APP_CLEAR, self._on_clear),
         }
 
         for post_, callback in LISTENS:
@@ -65,42 +78,82 @@ class PlayerToolbar(QToolBar):
 
     def on_player_current_time_changed(self, audio_time: float, *_) -> None:
         self.current_time_string = format_media_time(audio_time)
-        self.update_time_string()
+        self._update_time_edit()
 
     def on_stop(self) -> None:
         self.current_time_string = format_media_time(0)
-        self.update_time_string()
+        self._update_time_edit()
         self.on_ui_update_silent(PlayerToolbarElement.TOGGLE_PLAY_PAUSE, False)
 
     def on_media_duration_changed(self, duration: float, is_confirmation: bool = False):
+        self.duration = duration
         self.duration_string = format_media_time(duration)
-        self.update_time_string()
+        self._update_time_edit()
+        self.duration_label.setText(self.duration_string)
+        if self._status == PlayerStatus.NO_MEDIA:
+            self.time_edit.setEnabled(duration > 0)
+            self.duration_label.setEnabled(duration > 0)
+        if self._pending_time is not None and duration > 0:
+            commands.execute("media.seek", min(self._pending_time, duration))
+            self._pending_time = None
 
-    def update_time_string(self):
-        self.time_label.setText(f"{self.current_time_string}/{self.duration_string}")
+    def _on_file_loaded(self, file: TiliaFile) -> None:
+        self._pending_time = settings.get_file_time(file.file_path)
+
+    def _on_clear(self) -> None:
+        self._pending_time = None
+
+    def _update_time_edit(self) -> None:
+        if not self.time_edit.hasFocus():
+            self.time_edit.setText(self.current_time_string)
+
+    def _on_time_committed(self) -> None:
+        seconds = parse_media_time(self.time_edit.text())
+        if seconds is not None:
+            commands.execute("media.seek", max(0.0, min(seconds, self.duration)))
+        self.time_edit.setText(self.current_time_string)
+        self.time_edit.clearFocus()
+
+    def eventFilter(self, obj: object, event: QEvent) -> bool:
+        if obj is self.time_edit and event.type() == QEvent.Type.KeyPress:
+            if event.key() == Qt.Key.Key_Escape:
+                self.time_edit.setText(self.current_time_string)
+                self.time_edit.clearFocus()
+                return True
+        return super().eventFilter(obj, event)
+
+    def _set_player_controls_enabled(self, enabled: bool) -> None:
+        for widget in self.tooltipped_widgets:
+            widget.setEnabled(enabled)
+        self.duration_label.setEnabled(enabled)
 
     def on_update_controls(self, state):
+        self._status = state
         match state:
             case PlayerStatus.NO_MEDIA:
                 for widget in self.tooltipped_widgets:
                     widget.setToolTip(
                         "<i>Player disabled.<br>Load file via '</i>File > Load Media File<i>' to start.</i>"
                     )
-                self.setEnabled(False)
+                self._set_player_controls_enabled(False)
+                self.time_edit.setEnabled(self.duration > 0)
             case PlayerStatus.PLAYER_ENABLED:
                 for widget, tooltip in self.tooltipped_widgets.items():
                     widget.setToolTip(tooltip)
+                self._set_player_controls_enabled(True)
+                self.time_edit.setEnabled(True)
                 self.reset()
-                self.setEnabled(True)
             case PlayerStatus.WAITING_FOR_YOUTUBE:
                 for widget in self.tooltipped_widgets:
                     widget.setToolTip(
                         "<i>Player disabled.<br>Click on YouTube video to enable player.</i>"
                     )
-                self.setEnabled(False)
+                self._set_player_controls_enabled(False)
+                self.time_edit.setEnabled(False)
+                self._pending_time = None
 
     def on_ui_update_silent(self, element_to_set, value):
-        if not self.isEnabled():
+        if self._status != PlayerStatus.PLAYER_ENABLED:
             return
         match element_to_set:
             case PlayerToolbarElement.TOGGLE_PLAY_PAUSE:
@@ -191,10 +244,27 @@ class PlayerToolbar(QToolBar):
         self.tooltipped_widgets[self.loop_toggle_action] = "Toggle Loop"
         self.addAction(self.loop_toggle_action)
 
+    _TIME_RE = QRegularExpressionValidator(
+        QRegularExpression(r"^\d*(?::\d*(?::\d*)?)?(?:\.\d*)?$")
+    )
+
     def add_time_label(self):
-        self.time_label = QLabel(f"{self.current_time_string}/{self.duration_string}")
-        self.time_label.setMargin(3)
-        self.addWidget(self.time_label)
+        self.time_edit = QLineEdit(self.current_time_string)
+        self.time_edit.setAlignment(Qt.AlignmentFlag.AlignRight)
+        self.time_edit.setFrame(False)
+        self.time_edit.setFixedWidth(65)
+        self.time_edit.setValidator(self._TIME_RE)
+        self.time_edit.returnPressed.connect(self._on_time_committed)
+        self.time_edit.installEventFilter(self)
+        self.addWidget(self.time_edit)
+
+        separator = QLabel("/")
+        separator.setMargin(1)
+        self.addWidget(separator)
+
+        self.duration_label = QLabel(self.duration_string)
+        self.duration_label.setMargin(3)
+        self.addWidget(self.duration_label)
 
     def add_volume_toggle(self):
         def on_volume_toggle(checked: bool) -> None:


### PR DESCRIPTION
**Player time display is now a seekable input; playback position restored on file open**

- The current-time label in the player toolbar is now a `QLineEdit`.
Type a time in `HH:MM:SS.f`, `MM:SS.f`, or plain-seconds format and press Enter to seek; the value is clamped to `[0, duration]`.
Pressing Escape reverts without seeking. 
The field is not updated while it has focus so in-progress edits survive playback ticks.
A `QRegularExpressionValidator` allows all intermediate states while typing.
 - Controls are now disabled individually rather than via `setEnabled()` on the whole toolbar, so `time_edit` and the duration label remain enabled in `NO_MEDIA` state when a duration is present (annotation-only files with no media loaded).
 - Current playback position is saved to QSettings on file save and restored as a pending seek on next open. YouTube files are excluded.
 - Adds `parse_media_time()` as the inverse of `format_media_time()`.

(somewhat resolves #378)