### PR TITLE
Refactor/harmony

### DIFF
--- a/tests/timelines/harmony/test_harmony_timeline.py
+++ b/tests/timelines/harmony/test_harmony_timeline.py
@@ -23,6 +23,17 @@ class TestGetInversionAmount:
         with pytest.raises(ValueError):
             get_inversion_amount("not-a-quality")
 
+    @pytest.mark.parametrize(
+        "quality",
+        ["Italian", "French", "German", "Neapolitan", "Tristan", "power"],
+    )
+    def test_qualities_without_inversion_display_have_no_inversions(self, quality):
+        # These qualities either have no inversions in standard tonal harmony
+        # (the augmented sixths are defined by having b6 in the bass) or their
+        # label is a fixed string regardless of bass note, so the inspector
+        # and add-harmony dialog shouldn't offer inversions for them.
+        assert get_inversion_amount(quality) == 0
+
 
 class TestInversionValidation:
     def test_inversion_within_quality_range_is_accepted(self, harmony_tl):

--- a/tests/timelines/harmony/test_harmony_timeline.py
+++ b/tests/timelines/harmony/test_harmony_timeline.py
@@ -1,3 +1,77 @@
+import pytest
+
+from tilia.timelines.harmony.constants import get_inversion_amount
+
+
+class TestGetInversionAmount:
+    def test_triad_has_two_inversions(self):
+        assert get_inversion_amount("major") == 2
+
+    def test_seventh_chord_has_three_inversions(self):
+        assert get_inversion_amount("dominant-seventh") == 3
+
+    def test_ninth_chord_has_four_inversions(self):
+        assert get_inversion_amount("dominant-ninth") == 4
+
+    def test_eleventh_chord_has_five_inversions(self):
+        assert get_inversion_amount("dominant-11th") == 5
+
+    def test_thirteenth_chord_has_six_inversions(self):
+        assert get_inversion_amount("dominant-13th") == 6
+
+    def test_invalid_quality_raises_value_error(self):
+        with pytest.raises(ValueError):
+            get_inversion_amount("not-a-quality")
+
+
+class TestInversionValidation:
+    def test_inversion_within_quality_range_is_accepted(self, harmony_tl):
+        harmony, _ = harmony_tl.create_harmony(quality="major")
+        _, success = harmony.set_data("inversion", 2)
+        assert success
+        assert harmony.inversion == 2
+
+    def test_inversion_exceeding_quality_range_is_rejected(self, harmony_tl):
+        harmony, _ = harmony_tl.create_harmony(quality="major")
+        _, success = harmony.set_data("inversion", 3)
+        assert not success
+        assert harmony.inversion == 0
+
+    def test_negative_inversion_is_rejected(self, harmony_tl):
+        harmony, _ = harmony_tl.create_harmony(quality="major")
+        _, success = harmony.set_data("inversion", -1)
+        assert not success
+
+    def test_ninth_chord_accepts_fourth_inversion(self, harmony_tl):
+        harmony, _ = harmony_tl.create_harmony(quality="dominant-ninth")
+        _, success = harmony.set_data("inversion", 4)
+        assert success
+        assert harmony.inversion == 4
+
+    def test_ninth_chord_rejects_fifth_inversion(self, harmony_tl):
+        harmony, _ = harmony_tl.create_harmony(quality="dominant-ninth")
+        _, success = harmony.set_data("inversion", 5)
+        assert not success
+
+
+class TestModeKey:
+    def test_major_mode_key(self, harmony_tl):
+        mode, _ = harmony_tl.create_mode(type="major")
+        assert mode.key.mode == "major"
+
+    def test_minor_mode_key(self, harmony_tl):
+        mode, _ = harmony_tl.create_mode(type="minor")
+        assert mode.key.mode == "minor"
+
+    def test_dorian_mode_key(self, harmony_tl):
+        mode, _ = harmony_tl.create_mode(type="dorian")
+        assert mode.key.mode == "dorian"
+
+    def test_phrygian_mode_key(self, harmony_tl):
+        mode, _ = harmony_tl.create_mode(type="phrygian")
+        assert mode.key.mode == "phrygian"
+
+
 class TestValidateComponentCreation:
     def test_allows_harmony_at_same_time_as_mode(self, harmony_tl):
         harmony_tl.create_harmony()

--- a/tests/ui/dialogs/test_select_harmony_params.py
+++ b/tests/ui/dialogs/test_select_harmony_params.py
@@ -97,6 +97,20 @@ class TestChordSymbolParsing:
         params = parse_text("C" + extension)
         assert params["step"] == 0
 
+    def test_applied_to_is_cleared_when_no_longer_applied(qtui):
+        # Regression guard: the applied-to combobox was only ever updated when
+        # parsing produced a nonzero applied_to, so editing the text back down
+        # to a plain (non-applied) chord left the previous selection (e.g. "/V")
+        # stuck in the combobox instead of resetting to "none".
+        dialog = SelectHarmonyParams()
+        dialog.line_edit.setText("V7/V")
+        dialog.populate_from_text()
+        assert dialog.applied_to_combobox.currentData() == 4
+
+        dialog.line_edit.setText("V7")
+        dialog.populate_from_text()
+        assert dialog.applied_to_combobox.currentData() == 0
+
 
 class TestRomanNumeralParsing:
     # Regression guard: a roman-numeral seventh used to select the triad

--- a/tests/ui/dialogs/test_select_harmony_params.py
+++ b/tests/ui/dialogs/test_select_harmony_params.py
@@ -97,7 +97,7 @@ class TestChordSymbolParsing:
         params = parse_text("C" + extension)
         assert params["step"] == 0
 
-    def test_applied_to_is_cleared_when_no_longer_applied(qtui):
+    def test_applied_to_is_cleared_when_no_longer_applied(self, qtui):
         # Regression guard: the applied-to combobox was only ever updated when
         # parsing produced a nonzero applied_to, so editing the text back down
         # to a plain (non-applied) chord left the previous selection (e.g. "/V")

--- a/tests/ui/dialogs/test_select_harmony_params.py
+++ b/tests/ui/dialogs/test_select_harmony_params.py
@@ -83,7 +83,9 @@ class TestChordSymbolParsing:
     def test_slash_chords_where_bass_is_not_in_chord_symbol(self):
         params = parse_text("G/A")
         assert params["step"] == 4
-        assert params["inversion"] == 0  # fourth inversion is not currently supported
+        assert (
+            params["inversion"] == 0
+        )  # bass-not-in-chord slash chords are not supported
 
     @pytest.mark.parametrize(
         "extension",

--- a/tests/ui/timelines/harmony/test_harmony_timeline_ui.py
+++ b/tests/ui/timelines/harmony/test_harmony_timeline_ui.py
@@ -131,6 +131,58 @@ class TestRomanNumeralDisplay:
 
         assert harmony_tlui[0].label.startswith(expected_start)
 
+    def test_roman_label_for_ninth_chord_high_inversion(self, harmony_tlui):
+        # inversion=4 places the 9th in the bass; label is dynamically computed
+        add_harmony(
+            display_mode="roman", quality="half-diminished-minor-ninth", inversion=4
+        )
+        label = harmony_tlui.harmonies()[0].label
+        assert label  # no crash, non-empty
+
+
+class TestLetterSymbolLabel:
+    def test_no_inversion_has_no_bass_note(self, harmony_tlui):
+        add_harmony(display_mode="letter", quality="major")
+        assert "/" not in harmony_tlui.harmonies()[0].letter_symbol_label
+
+    def test_first_inversion_shows_third(self, harmony_tlui):
+        add_harmony(display_mode="letter", quality="major", inversion=1)
+        assert harmony_tlui.harmonies()[0].letter_symbol_label.endswith("/E")
+
+    def test_second_inversion_shows_fifth(self, harmony_tlui):
+        add_harmony(display_mode="letter", quality="major", inversion=2)
+        assert harmony_tlui.harmonies()[0].letter_symbol_label.endswith("/G")
+
+    def test_seventh_chord_third_inversion_shows_flat_bass(self, harmony_tlui):
+        add_harmony(display_mode="letter", quality="dominant-seventh", inversion=3)
+        assert harmony_tlui.harmonies()[0].letter_symbol_label.endswith("/B`b")
+
+    def test_ninth_chord_fourth_inversion_shows_ninth(self, harmony_tlui):
+        add_harmony(display_mode="letter", quality="dominant-ninth", inversion=4)
+        assert harmony_tlui.harmonies()[0].letter_symbol_label.endswith("/D")
+
+
+class TestModeLabel:
+    def test_dorian_label(self, harmony_tlui):
+        add_mode(type="dorian")
+        assert harmony_tlui.modes()[0].label == "C Dorian"
+
+    def test_phrygian_label(self, harmony_tlui):
+        add_mode(type="phrygian")
+        assert harmony_tlui.modes()[0].label == "C Phrygian"
+
+    def test_major_still_gives_note_only(self, harmony_tlui):
+        add_mode(type="major")
+        assert harmony_tlui.modes()[0].label == "C"
+
+    def test_minor_still_gives_lowercase_note(self, harmony_tlui):
+        add_mode(type="minor")
+        assert harmony_tlui.modes()[0].label == "c"
+
+    def test_dorian_with_flat_tonic(self, harmony_tlui):
+        add_mode(step=6, accidental=-1, type="dorian")  # Bb dorian
+        assert harmony_tlui.modes()[0].label == "B`b Dorian"
+
 
 class TestCopyPaste:
     def test_paste_multiple_to_harmony_with_mode_as_first_copied(self, harmony_tlui):

--- a/tests/ui/timelines/harmony/test_harmony_ui.py
+++ b/tests/ui/timelines/harmony/test_harmony_ui.py
@@ -5,7 +5,9 @@ import pytest
 from tests.ui.timelines.harmony.interact import click_harmony_ui
 from tests.ui.timelines.harmony.test_harmony_timeline_ui import add_harmony, add_mode
 from tests.ui.timelines.interact import click_timeline_ui
+from tilia.requests import Post, post
 from tilia.ui import commands
+from tilia.ui.windows.kinds import WindowKind
 
 
 @pytest.fixture
@@ -150,3 +152,56 @@ class TestDoubleClick:
         harmony_tlui[0].on_double_left_click(None)
 
         mock.assert_not_called()
+
+
+class TestInversionInspectorItems:
+    @pytest.fixture(autouse=True)
+    def close_inspector(self):
+        yield
+        post(Post.WINDOW_CLOSE, WindowKind.INSPECT)
+
+    def open_inspector_for(self, harmony_ui, qtui):
+        click_harmony_ui(harmony_ui)
+        commands.execute("timeline.element.inspect")
+        return qtui._windows[WindowKind.INSPECT]
+
+    def test_major_triad_has_three_inversion_choices(self, qtui, harmony_tlui):
+        add_harmony(quality="major")
+        inspector = self.open_inspector_for(harmony_tlui.harmonies()[0], qtui)
+
+        inversion_combo = inspector.field_name_to_widgets["Inversion"][1]
+        assert inversion_combo.count() == 3  # inversions 0, 1, 2
+
+    def test_ninth_chord_has_five_inversion_choices(self, qtui, harmony_tlui):
+        add_harmony(quality="dominant-ninth")
+        inspector = self.open_inspector_for(harmony_tlui.harmonies()[0], qtui)
+
+        inversion_combo = inspector.field_name_to_widgets["Inversion"][1]
+        assert inversion_combo.count() == 5  # inversions 0, 1, 2, 3, 4
+
+    def test_inversion_choices_update_when_quality_changes(self, qtui, harmony_tlui):
+        add_harmony(quality="major")
+        inspector = self.open_inspector_for(harmony_tlui.harmonies()[0], qtui)
+
+        inversion_combo = inspector.field_name_to_widgets["Inversion"][1]
+        quality_combo = inspector.field_name_to_widgets["Quality"][1]
+        assert inversion_combo.count() == 3  # major: inversions 0, 1, 2
+
+        quality_combo.setCurrentIndex(quality_combo.findData("dominant-ninth"))
+
+        assert inversion_combo.count() == 5  # dominant-ninth: inversions 0, 1, 2, 3, 4
+
+    def test_inversion_clamped_to_max_when_quality_reduces_range(
+        self, qtui, harmony_tlui
+    ):
+        add_harmony(quality="dominant-ninth", inversion=4)
+        inspector = self.open_inspector_for(harmony_tlui.harmonies()[0], qtui)
+
+        inversion_combo = inspector.field_name_to_widgets["Inversion"][1]
+        quality_combo = inspector.field_name_to_widgets["Quality"][1]
+        assert inversion_combo.currentData() == 4
+
+        quality_combo.setCurrentIndex(quality_combo.findData("major"))
+
+        # inversion 4 is invalid for major; should clamp to max (2)
+        assert inversion_combo.currentData() == 2

--- a/tilia/errors.py
+++ b/tilia/errors.py
@@ -45,10 +45,6 @@ MEDIA_LOAD_FAILED = Error(
 )
 YOUTUBE_URL_INVALID = Error("Invalid YouTube URL", "{} is not a valid URL.")
 EXPORT_AUDIO_FAILED = Error("Export Audio", "{}")
-INVALID_HARMONY_INVERSION = Error(
-    "Invalid harmony inversion",
-    "Can't set inversion '{}' on a chord of type '{}'. Please select a valid inversion for this chord type.",
-)
 ADD_MODE_FAILED = Error("Add key failed", "Adding key failed: {}.")
 ADD_HARMONY_FAILED = Error("Add harmony failed", "{}")
 ADD_PDF_MARKER_FAILED = Error("Add page marker failed", "Can't add page marker: {}")

--- a/tilia/timelines/harmony/__init__.py
+++ b/tilia/timelines/harmony/__init__.py
@@ -1,1 +1,0 @@
-from . import calculate

--- a/tilia/timelines/harmony/calculate.py
+++ b/tilia/timelines/harmony/calculate.py
@@ -1,4 +1,0 @@
-def bass_step(root_step: int, inversion: int | None):
-    if inversion is None:
-        return root_step
-    return (root_step + 2 * inversion) % 7

--- a/tilia/timelines/harmony/components/harmony.py
+++ b/tilia/timelines/harmony/components/harmony.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import music21
 
-import tilia.errors
 from tilia.timelines.base.component import PointLikeTimelineComponent
 from tilia.timelines.base.validators import validate_string, validate_time
 from tilia.timelines.component_kinds import ComponentKind
@@ -55,7 +54,6 @@ class Harmony(PointLikeTimelineComponent):
         "step": validate_step,
         "accidental": validate_accidental,
         "quality": validate_quality,
-        "inversion": validate_inversion,
         "applied_to": validate_applied_to,
         "level": validate_level,
         "display_mode": validate_display_mode,
@@ -85,7 +83,7 @@ class Harmony(PointLikeTimelineComponent):
         self.step = step
         self.accidental = accidental
         self.quality = quality
-        self._inversion = inversion
+        self.inversion = inversion
         self.applied_to = applied_to
         self.level = level
         self.display_mode = display_mode
@@ -120,18 +118,19 @@ class Harmony(PointLikeTimelineComponent):
         params = _get_params_from_music21_object(music21_object, object_type)
         return Harmony(*params)
 
-    @property
-    def inversion(self):
-        return self._inversion
+    def validate_set_data(self, attr: str, value: Any) -> bool:
+        if attr == "inversion":
+            return validate_inversion(value, self.quality)
+        return super().validate_set_data(attr, value)
 
-    @inversion.setter
-    def inversion(self, value):
-        if value > get_inversion_amount(self.get_data("quality")):
-            tilia.errors.display(
-                tilia.errors.INVALID_HARMONY_INVERSION, value, self.get_data("quality")
-            )
-            return
-        self._inversion = value
+    def set_data(self, attr: str, value: Any):
+        result = super().set_data(attr, value)
+        if attr == "quality" and result[1]:
+            max_inv = get_inversion_amount(value)
+            if self.inversion > max_inv:
+                self.inversion = max_inv
+                self.update_hash()
+        return result
 
 
 def get_params_from_text(text: str, key: str):

--- a/tilia/timelines/harmony/components/mode.py
+++ b/tilia/timelines/harmony/components/mode.py
@@ -68,12 +68,10 @@ class Mode(PointLikeTimelineComponent):
 
     @property
     def key(self):
-        tonic = INT_TO_NOTE_NAME[self.step]
-        tonic_symbol = tonic.lower() if self.get_data("type") == "minor" else tonic
-        accidental_symbol = Accidental.get_from_int(
+        tonic = INT_TO_NOTE_NAME[self.step] + Accidental.get_from_int(
             "music21", self.get_data("accidental")
         )
-        return music21.key.Key(tonic_symbol + accidental_symbol)
+        return music21.key.Key(tonic, mode=self.get_data("type"))
 
 
 def _format_postfix_accidental(text):

--- a/tilia/timelines/harmony/constants.py
+++ b/tilia/timelines/harmony/constants.py
@@ -7,9 +7,44 @@ MODE_TYPES = [m for m in _m21k.modeSharpsAlter.keys() if m not in ("ionian", "ae
 FONT_TYPES = ["analytic", "normal"]
 HARMONY_QUALITIES = list(_m21h.CHORD_TYPES.keys())
 
+# These qualities are locked to root position: the Inspector/Add Harmony
+# dialog offer no inversion choices for them, and to_roman_numeral /
+# letter_symbol_label render a fixed string regardless of bass note.
+#
+# - Italian, French, German (augmented sixths): genuinely have no inversions
+#   in standard tonal harmony — the augmented-sixth interval that defines
+#   the chord only exists with scale degree b6 in the bass.
+# - Tristan: referenced in the literature as a single fixed sonority,
+#   not a chord family with an established inversion convention.
+# - Neapolitan: DOES have real inversions (root position and 2nd inversion
+#   occur, though 1st inversion — "N6" — is by far the most common). But
+#   music21's own "Neapolitan"/"N6" CHORD_TYPES entry is not the classical
+#   Neapolitan-sixth triad at all — it's an unrelated 4-note "all-interval
+#   tetrachord" that happens to share the abbreviation. Supporting inversions
+#   here means building the real major-triad-on-b2 pitches first, not just
+#   removing this quality from the set below.
+# - power: DOES have a real inverted voicing (5th in the bass, common in
+#   rock/metal), but music21.harmony.ChordSymbol can't construct it via
+#   inversion=1 (raises ChordException — see the try/except in
+#   HarmonyUI.letter_symbol), and there's no established figured-bass
+#   notation for an inverted power chord to reuse in to_roman_numeral.
+#
+# TODO: Neapolitan and power are the two qualities above actually worth
+# revisiting (Italian/French/German/Tristan have no inversions to support).
+# Neapolitan needs its pitches constructed independently of music21's
+# "N6" chord type before inversions mean anything; power needs a bass
+# override in HarmonyUI.letter_symbol (music21 can't invert it directly)
+# plus an invented figured-bass notation for to_roman_numeral, since no
+# textbook convention exists for an inverted power chord.
+_NO_INVERSION_QUALITIES = frozenset(
+    {"Italian", "French", "German", "Neapolitan", "Tristan", "power"}
+)
+
 
 def get_inversion_amount(quality: str) -> int:
     if quality not in HARMONY_QUALITIES:
         raise ValueError(f'Invalid harmony quality "{quality}"')
+    if quality in _NO_INVERSION_QUALITIES:
+        return 0
     intervals_str = str(_m21h.CHORD_TYPES[quality][0])  # type: ignore[index]
     return len(intervals_str.split(",")) - 1

--- a/tilia/timelines/harmony/constants.py
+++ b/tilia/timelines/harmony/constants.py
@@ -1,86 +1,15 @@
-HARMONY_INVERSIONS = [0, 1, 2, 3]
+import music21.harmony as _m21h
+import music21.key as _m21k
+
 HARMONY_DISPLAY_MODES = ["letter", "roman", "custom"]
 HARMONY_ACCIDENTALS = [2, 1, 0, -1, -2]
-MODE_TYPES = ["major", "minor"]
+MODE_TYPES = [m for m in _m21k.modeSharpsAlter.keys() if m not in ("ionian", "aeolian")]
 FONT_TYPES = ["analytic", "normal"]
-# Names are taken from music21.harmony.CHORD_TYPES
-HARMONY_QUALITIES = [
-    "major",
-    "minor",
-    "augmented",
-    "diminished",
-    # seventh
-    "dominant-seventh",
-    "major-seventh",
-    "minor-major-seventh",
-    "minor-seventh",
-    "augmented-major-seventh",
-    "augmented-seventh",
-    "half-diminished-seventh",
-    "diminished-seventh",
-    "seventh-flat-five",
-    # sixth
-    "major-sixth",
-    "minor-sixth",
-    # ninth
-    "major-ninth",
-    "dominant-ninth",
-    "minor-major-ninth",
-    "minor-ninth",
-    "augmented-major-ninth",
-    "augmented-dominant-ninth",
-    "half-diminished-ninth",
-    "half-diminished-minor-ninth",
-    "diminished-ninth",
-    "diminished-minor-ninth",
-    # eleventh
-    "dominant-11th",
-    "major-11th",
-    "minor-major-11th",
-    "minor-11th",
-    "augmented-major-11th",
-    "augmented-11th",
-    "half-diminished-11th",
-    "diminished-11th",
-    # thirteenth
-    "major-13th",
-    "dominant-13th",
-    "minor-major-13th",
-    "minor-13th",
-    "augmented-major-13th",
-    "augmented-dominant-13th",
-    "half-diminished-13th",
-    # other
-    "suspended-second",
-    "suspended-fourth",
-    "suspended-fourth-seventh",
-    "Neapolitan",
-    "Italian",
-    "French",
-    "German",
-    "pedal",
-    "power",
-    "Tristan",
-]
+HARMONY_QUALITIES = list(_m21h.CHORD_TYPES.keys())
 
 
 def get_inversion_amount(quality: str) -> int:
     if quality not in HARMONY_QUALITIES:
         raise ValueError(f'Invalid harmony quality "{quality}"')
-
-    if quality.endswith(("sixth", "seventh", "ninth", "11th", "13th")):
-        return 3  # 4th inversion and beyond are not yet supported
-    elif quality == "seventh-flat-five":
-        return 3
-    elif quality in [
-        "power",
-        "pedal",
-        "French",
-        "German",
-        "Italian",
-        "Neapolitan",
-        "Tristan",
-    ]:
-        return 0
-    else:
-        return 2
+    intervals_str = str(_m21h.CHORD_TYPES[quality][0])  # type: ignore[index]
+    return len(intervals_str.split(",")) - 1

--- a/tilia/timelines/harmony/validators.py
+++ b/tilia/timelines/harmony/validators.py
@@ -2,9 +2,9 @@ from tilia.timelines.harmony.constants import (
     FONT_TYPES,
     HARMONY_ACCIDENTALS,
     HARMONY_DISPLAY_MODES,
-    HARMONY_INVERSIONS,
     HARMONY_QUALITIES,
     MODE_TYPES,
+    get_inversion_amount,
 )
 
 
@@ -12,8 +12,8 @@ def validate_quality(value):
     return value in HARMONY_QUALITIES
 
 
-def validate_inversion(value):
-    return value in HARMONY_INVERSIONS
+def validate_inversion(value: int, quality: str) -> bool:
+    return 0 <= value <= get_inversion_amount(quality)
 
 
 def validate_accidental(value):

--- a/tilia/ui/dialogs/harmony_params.py
+++ b/tilia/ui/dialogs/harmony_params.py
@@ -22,6 +22,7 @@ from tilia.ui.timelines.harmony.constants import (
     ACCIDENTAL_TO_INT,
     NOTE_NAME_TO_INT,
 )
+from tilia.ui.timelines.harmony.elements.harmony_attrs import _INV_TO_STRING
 from tilia.ui.timelines.harmony.utils import (
     INT_TO_APPLIED_TO_SUFFIX,
 )
@@ -127,24 +128,23 @@ class SelectHarmonyParams(QDialog):
 
     @staticmethod
     def _get_quality_items(row_amount: int):
-        all_items = [
-            ("", 0),
-            ("1st", 1),
-            ("2nd", 2),
-            ("3rd", 3),
-        ]
-        return all_items[: row_amount + 1]
+        return [(_INV_TO_STRING[i], i) for i in range(row_amount + 1)]
 
     def on_quality_combobox_changed(self, *_):
         quality = self.quality_combobox.currentData()
+        current_inversion = self.inversion_combobox.currentData()
 
-        # Clearing the combo box to refill it with the correct number of rows
         for _ in range(self.inversion_combobox.model().rowCount()):
             self.inversion_combobox.removeItem(0)
 
         inversion_amount = get_inversion_amount(quality)
         for text, data in self._get_quality_items(inversion_amount):
             self.inversion_combobox.addItem(text, data)
+
+        target = min(current_inversion, inversion_amount)
+        self.inversion_combobox.setCurrentIndex(
+            self.inversion_combobox.findData(target)
+        )
 
     def _populate_widgets(self, params):
         def get_index_by_param(combobox, param):

--- a/tilia/ui/dialogs/harmony_params.py
+++ b/tilia/ui/dialogs/harmony_params.py
@@ -20,7 +20,10 @@ from tilia.timelines.harmony.constants import (
 from tilia.timelines.timeline_kinds import TimelineKind
 from tilia.ui.timelines.harmony.constants import (
     ACCIDENTAL_TO_INT,
+    INT_TO_NOTE_NAME,
     NOTE_NAME_TO_INT,
+    QUALITY_TO_ABBREVIATION,
+    Accidental,
 )
 from tilia.ui.timelines.harmony.elements.harmony_attrs import _INV_TO_STRING
 from tilia.ui.timelines.harmony.utils import (
@@ -54,6 +57,7 @@ class SelectHarmonyParams(QDialog):
             quality_combobox.insertItem(0, kind.replace("-", " ").capitalize(), kind)
         quality_combobox.setCurrentIndex(0)
         quality_combobox.currentIndexChanged.connect(self.on_quality_combobox_changed)
+        quality_combobox.currentIndexChanged.connect(self.on_combobox_changed)
 
         applied_to_combobox = self.applied_to_combobox = QComboBox()
         for i, value in INT_TO_APPLIED_TO_SUFFIX.items():
@@ -66,8 +70,18 @@ class SelectHarmonyParams(QDialog):
             settings.get("harmony_timeline", "default_harmony_display_mode")
         )
 
+        for cb in (
+            step_combobox,
+            accidental_combobox,
+            inversion_combobox,
+            applied_to_combobox,
+        ):
+            cb.currentIndexChanged.connect(self.on_combobox_changed)
+
         line_edit = self.line_edit = QLineEdit()
         line_edit.textEdited.connect(self.on_text_edited)
+
+        self._populating = False
 
         self.current_key = current_key
         current_key_label = QLabel(
@@ -119,6 +133,16 @@ class SelectHarmonyParams(QDialog):
             "level": 1,
         }
 
+    def on_combobox_changed(self):
+        if self._populating:
+            return
+        step = self.step_combobox.currentData()
+        accidental = self.accidental_combobox.currentData()
+        quality = self.quality_combobox.currentData()
+        note = INT_TO_NOTE_NAME[step] + Accidental.get_from_int("music21", accidental)
+        self.line_edit.setText(note + QUALITY_TO_ABBREVIATION.get(quality, ""))
+        self.line_edit.setStyleSheet("")
+
     def on_text_edited(self):
         success = self.populate_from_text()
         if not success:
@@ -151,6 +175,7 @@ class SelectHarmonyParams(QDialog):
             result = combobox.findData(params[param])
             return result if result != -1 else 0
 
+        self._populating = True
         self.step_combobox.setCurrentIndex(self.step_combobox.findData(params["step"]))
         self.accidental_combobox.setCurrentIndex(
             get_index_by_param(self.accidental_combobox, "accidental")
@@ -167,6 +192,7 @@ class SelectHarmonyParams(QDialog):
                     INT_TO_APPLIED_TO_SUFFIX[params["applied_to"]]
                 )
             )
+        self._populating = False
 
     def populate_from_text(self):
         text = self.line_edit.text()

--- a/tilia/ui/dialogs/harmony_params.py
+++ b/tilia/ui/dialogs/harmony_params.py
@@ -186,12 +186,9 @@ class SelectHarmonyParams(QDialog):
         self.inversion_combobox.setCurrentIndex(
             get_index_by_param(self.inversion_combobox, "inversion")
         )
-        if params["applied_to"]:
-            self.applied_to_combobox.setCurrentIndex(
-                self.applied_to_combobox.findText(
-                    INT_TO_APPLIED_TO_SUFFIX[params["applied_to"]]
-                )
-            )
+        self.applied_to_combobox.setCurrentIndex(
+            get_index_by_param(self.applied_to_combobox, "applied_to")
+        )
         self._populating = False
 
     def populate_from_text(self):

--- a/tilia/ui/timelines/harmony/constants.py
+++ b/tilia/ui/timelines/harmony/constants.py
@@ -1,6 +1,5 @@
-import music21
-
-from tilia.timelines.harmony.constants import HARMONY_QUALITIES
+import music21.harmony
+import music21.pitch
 
 ROMAN_TO_INT = {
     "I": 0,
@@ -59,13 +58,15 @@ class Accidental:
 NOTE_NAME_TO_INT = {"C": 0, "D": 1, "E": 2, "F": 3, "G": 4, "A": 5, "B": 6}
 INT_TO_NOTE_NAME = {v: k for k, v in NOTE_NAME_TO_INT.items()}
 
-STEP_TO_PITCH_CLASS = {0: 0, 1: 2, 2: 4, 3: 5, 4: 7, 5: 9, 6: 11}
-
-QUALITY_TO_ABBREVIATION = {
-    qlt: music21.harmony.CHORD_TYPES[qlt][1][0] for qlt in HARMONY_QUALITIES
+STEP_TO_PITCH_CLASS = {
+    i: music21.pitch.Pitch(s).pitchClass
+    for i, s in enumerate(["C", "D", "E", "F", "G", "A", "B"])
 }
 
-INVERSION_TO_INTERVAL = {1: 3, 2: 5, 3: 7}
+QUALITY_TO_ABBREVIATION = {
+    qlt: data[1][0] for qlt, data in music21.harmony.CHORD_TYPES.items()
+}
+
 
 CHORD_COMMON_NAME_TO_TYPE = {
     "augmented seventh chord": "augmented-seventh",

--- a/tilia/ui/timelines/harmony/elements/harmony.py
+++ b/tilia/ui/timelines/harmony/elements/harmony.py
@@ -15,7 +15,6 @@ from tilia.ui.timelines.drag import DragManager
 from tilia.ui.timelines.harmony.constants import (
     INT_TO_NOTE_NAME,
     INT_TO_ROMAN,
-    INVERSION_TO_INTERVAL,
     QUALITY_TO_ABBREVIATION,
     Accidental,
 )
@@ -130,7 +129,8 @@ class HarmonyUI(TimelineUIElement):
 
     @property
     def letter_symbol_label(self):
-        figure = self.letter_symbol.figure
+        symbol = self.letter_symbol
+        figure = symbol.figure
         match self.get_data("quality"):
             case "Italian":
                 return "It6+"
@@ -148,18 +148,17 @@ class HarmonyUI(TimelineUIElement):
                 return figure.replace("pedal", "`p`e`d")
             case "seventh-flat-five":
                 return figure.replace("dom7dim5", "7((b5))")
-        match self.get_data("accidental"):
-            case -2:
-                figure = figure.replace("--", "`b`b")
-            case -1:
-                figure = figure.replace("-", "b")
-            case 2:
-                figure = figure.replace("##", "`#`#")
+        accidental = self.get_data("accidental")
+        if accidental:
+            figure = figure.replace(
+                Accidental.get_from_int("music21", accidental),
+                Accidental.get_from_int("musanalysis", accidental),
+            )
 
-        if inversion := self.get_data("inversion"):
-            # bass_step = harmony.calculate.bass_step(self.get_data('step'), inversion)
-            # figure += '/' + INT_TO_NOTE_NAME[bass_step]  # TODO calculate bass note
-            figure += "/&" + str(INVERSION_TO_INTERVAL[inversion])
+        if self.get_data("inversion"):
+            bass = symbol.bass()
+            bass_accidental = Accidental.get_from_int("musanalysis", int(bass.alter))
+            figure += "/" + bass.step + bass_accidental
 
         figure = figure.replace("M7", "^^7")
         figure = figure.replace("M9", "^^9")

--- a/tilia/ui/timelines/harmony/elements/harmony.py
+++ b/tilia/ui/timelines/harmony/elements/harmony.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import music21
+import music21.chord
 from music21.roman import RomanNumeral
 from PySide6.QtCore import QPointF
 from PySide6.QtGui import QColor, QFont
@@ -72,15 +73,19 @@ class HarmonyUI(TimelineUIElement):
 
     @property
     def letter_symbol(self):
-        symbol = music21.harmony.ChordSymbol(
+        note = (
             INT_TO_NOTE_NAME[self.get_data("step")]
-            + Accidental.get_from_int(
-                "music21",
-                self.get_data("accidental"),
-            )
-            + QUALITY_TO_ABBREVIATION[self.get_data("quality")],
-            inversion=self.get_data("inversion"),
+            + Accidental.get_from_int("music21", self.get_data("accidental"))
+            + QUALITY_TO_ABBREVIATION[self.get_data("quality")]
         )
+        try:
+            symbol = music21.harmony.ChordSymbol(
+                note, inversion=self.get_data("inversion")
+            )
+        except music21.chord.ChordException:
+            # Some qualities (e.g. minor-sixth) report more inversions than
+            # music21 can construct; fall back to root position (#376).
+            symbol = music21.harmony.ChordSymbol(note, inversion=0)
         applied_to = self.get_data("applied_to")
         if applied_to:
             symbol.romanNumeral = RomanNumeral(

--- a/tilia/ui/timelines/harmony/elements/harmony_attrs.py
+++ b/tilia/ui/timelines/harmony/elements/harmony_attrs.py
@@ -1,14 +1,20 @@
 from tilia.timelines.harmony.constants import (
     FONT_TYPES,
     HARMONY_DISPLAY_MODES,
-    HARMONY_INVERSIONS,
     HARMONY_QUALITIES,
+    get_inversion_amount,
 )
 from tilia.ui.format import format_media_time
 from tilia.ui.timelines.copy_paste import CopyAttributes
 from tilia.ui.timelines.harmony.constants import ACCIDENTAL_TO_INT, NOTE_NAME_TO_INT
 from tilia.ui.timelines.harmony.utils import INT_TO_APPLIED_TO_SUFFIX
 from tilia.ui.windows.inspect import InspectRowKind
+
+_INV_TO_STRING = {0: "", 1: "1st", 2: "2nd", 3: "3rd", 4: "4th", 5: "5th", 6: "6th"}
+
+
+def _inversion_items(quality: str) -> list[tuple[str, int]]:
+    return [(_INV_TO_STRING[i], i) for i in range(get_inversion_amount(quality) + 1)]
 
 
 def get_inversion_inspect_args():
@@ -87,6 +93,7 @@ DEFAULT_COPY_ATTRIBUTES = CopyAttributes(
 
 def get_inspector_dict(harmony):
     return {
+        "__items_update": {"Inversion": _inversion_items(harmony.get_data("quality"))},
         "Label": harmony.label,
         "Time": format_media_time(harmony.get_data("time")),
         "Comments": harmony.get_data("comments"),

--- a/tilia/ui/timelines/harmony/elements/harmony_attrs.py
+++ b/tilia/ui/timelines/harmony/elements/harmony_attrs.py
@@ -12,8 +12,7 @@ from tilia.ui.windows.inspect import InspectRowKind
 
 
 def get_inversion_inspect_args():
-    inv_to_string = {0: "", 1: "1st", 2: "2nd", 3: "3rd"}
-    return {"items": [(inv_to_string[inv], inv) for inv in HARMONY_INVERSIONS]}
+    return {"items": []}
 
 
 def get_quality_inspect_args():

--- a/tilia/ui/timelines/harmony/elements/mode.py
+++ b/tilia/ui/timelines/harmony/elements/mode.py
@@ -41,14 +41,17 @@ class ModeUI(TimelineUIElement):
 
     @property
     def label(self):
-        center = INT_TO_NOTE_NAME[self.get_data("step")] + Accidental.get_from_int(
+        tonic = INT_TO_NOTE_NAME[self.get_data("step")] + Accidental.get_from_int(
             "musanalysis",
             self.get_data("accidental"),
         )
-        result = center if self.get_data("type") == "major" else center.lower()
-        if result[0] == "b":
-            result = "@" + result
-        return result
+        mode_type = self.get_data("type")
+        if mode_type == "major":
+            return ("@" if tonic[0] == "b" else "") + tonic
+        if mode_type == "minor":
+            result = tonic.lower()
+            return ("@" if result[0] == "b" else "") + result
+        return tonic + " " + mode_type.capitalize()
 
     @property
     def key(self):
@@ -163,7 +166,16 @@ class ModeBody(QGraphicsTextItem):
         self.setPos(self.get_point(x, y))
 
     def set_text(self, value: str):
-        self.setPlainText(value)
+        if " " in value:
+            idx = value.index(" ")
+            tonic = value[:idx]
+            mode_name = value[idx + 1 :]
+            self.setHtml(
+                f"<span>{tonic}&nbsp;</span>"
+                f'<span style="font-family: Arial; font-size: 10pt;">{mode_name}</span>'
+            )
+        else:
+            self.setPlainText(value)
 
     def on_select(self):
         font = self.font()

--- a/tilia/ui/timelines/harmony/utils.py
+++ b/tilia/ui/timelines/harmony/utils.py
@@ -4,6 +4,7 @@ from tilia.ui.timelines.harmony.constants import (
     INT_TO_NOTE_NAME,
     INT_TO_ROMAN,
     NOTE_NAME_TO_INT,
+    QUALITY_TO_ABBREVIATION,
     Accidental,
 )
 
@@ -20,73 +21,12 @@ def _handle_special_qualities(quality: str) -> str | None:
             return "N6"
 
 
+# Qualities whose notation is bespoke at every inversion and cannot be
+# derived from chord structure.
 QUALITY_TO_ROMAN_NUMERAL_SUFFIX = {
-    "major": ("", "6", "64", None),
-    "minor": ("", "6", "64", None),
-    "augmented": ("+", "+6", "+64", None),
-    "diminished": ("o", "o6", "o64", None),
-    # seventh
-    "dominant-seventh": ("7", "65", "43", "2"),
-    "major-seventh": ("^^7", "65", "43", "2"),
-    "minor-major-seventh": ("^^7", "65", "43", "2"),
-    "minor-seventh": ("7", "65", "43", "2"),
-    "augmented-major-seventh": ("+^^7", "65", "43", "2"),
-    "augmented-seventh": ("+7", "65", "43", "2"),
-    "half-diminished-seventh": ("o\\7", "o\\65", "o\\43", "o\\2"),
-    "diminished-seventh": ("o7", "o65", "o43", "o2"),
-    "seventh-flat-five": "7((b5))",
-    # sixth
+    "seventh-flat-five": ("7((b5))", None, None, None),
     "major-sixth": ("((6))", "6((4))", "64((2))", "7"),
     "minor-sixth": ("((6))", "6((4))", "64((2))", "7"),
-    # ninth
-    "major-ninth": ("9", "%765", "%543", "%432"),
-    "dominant-ninth": ("9", "%765", "%543", "%432"),
-    "minor-major-ninth": ("^^9", "%765", "%543", "%432"),
-    "minor-ninth": ("9", "%765", "%543", "%432"),
-    "augmented-major-ninth": ("+^^9", "+%765", "+%543", "+%432"),
-    "augmented-dominant-ninth": ("+^^9", "+%765", "+%543", "+%432"),
-    "half-diminished-ninth": ("o\\9", "o%765", "o%543", "o%432"),
-    "half-diminished-minor-ninth": ("o\\b9", "o%sbs765", "%sbs543", "sbs%432"),
-    "diminished-ninth": ("o9", "o%765", "o%543", "o%432"),
-    "diminished-minor-ninth": ("ob9", "%sbs765", "%sbs543", "%sbs432"),
-    # eleventh
-    "dominant-11th": ("11", "%sbs765((9))", "%sbs543((7))", "%sbs432((5))"),
-    "major-11th": ("^^11", "%sbs765((9))", "%sbs543((7))", "%sbs432((5))"),
-    "minor-major-11th": ("11", "%sbs765((9))", "%sbs543((7))", "%sbs432((5))"),
-    "minor-11th": ("11", "%sbs765((9))", "%sbs543((7))", "%sbs432((5))"),
-    "augmented-major-11th": (
-        "+11   ",
-        "+%sbs765((9))",
-        "+%sbs543((7))",
-        "+%sbs432((5))",
-    ),
-    "augmented-11th": ("+11", "+%sbs765((9))", "+%sbs543((7))", "+%sbs432((5))"),
-    "half-diminished-11th": (
-        "o\\11",
-        "o\\%sbs765((9))",
-        "o\\%sbs543((7))",
-        "o\\%sbs432((5))",
-    ),
-    "diminished-11th": ("o11", "o%sbs765((9))", "o%sbs543((7))", "o%sbs432((5))"),
-    # thirteenth
-    "major-13th": "^^13",
-    "dominant-13th": ("13", "%sbs765((11))", "%sbs543((9))", "%sbs432((5))"),
-    "minor-major-13th": ("^^13", "%sbs765((11))", "%sbs543((9))", "%sbs432((5))"),
-    "minor-13th": ("13", "%sbs765((11))", "%sbs543((9))", "%sbs432((5))"),
-    "augmented-major-13th": ("+13", "+%sbs765((11))", "+%sbs543((9))", "+%sbs432((5))"),
-    "augmented-dominant-13th": (
-        "+13",
-        "+%sbs765((11))",
-        "+%sbs543((9))",
-        "+%sbs432((5))",
-    ),
-    "half-diminished-13th": (
-        "o\\13",
-        "o\\%sbs765((11))",
-        "o\\%sbs543((9))",
-        "o\\%sbs432((5))",
-    ),
-    # other
     "suspended-second": ("52", "74", "54", None),
     "suspended-fourth": ("54", "52", "74", None),
     "suspended-fourth-seventh": ("74", "54", "52", None),
@@ -104,6 +44,233 @@ INT_TO_APPLIED_TO_SUFFIX = {
     5: "/VI",
     6: "/VII",
 }
+
+_TRIAD_QUALITIES = frozenset({"major", "minor", "augmented", "diminished"})
+
+# Derived from the static table so _get_chord_size skips them correctly.
+_STATIC_QUALITIES = frozenset(QUALITY_TO_ROMAN_NUMERAL_SUFFIX)
+
+
+def _get_inv_prefix(quality: str) -> str:
+    """Return the quality prefix prepended to the inversion figured-bass string."""
+    if quality.startswith("half-diminished"):
+        return "o\\"
+    if quality.startswith("diminished"):
+        return "o"
+    # Augmented 7th chords use no prefix in inversions (only at root position).
+    if quality.startswith("augmented") and "seventh" not in quality:
+        return "+"
+    return ""
+
+
+def _get_chord_size(quality: str) -> str | None:
+    """Return chord-size category for dynamic dispatch; None means use the static table."""
+    if quality in _STATIC_QUALITIES:
+        return None
+    if quality in _TRIAD_QUALITIES:
+        return "triad"
+    if "seventh" in quality:
+        return "seventh"
+    if "ninth" in quality:
+        return "ninth"
+    if "11th" in quality:
+        return "eleventh"
+    if "13th" in quality:
+        return "thirteenth"
+    return None
+
+
+# Qualities that carry the MusAnalysis major-7th triangle ("^^") at root position.
+# The set is irregular (e.g. major-ninth omits it while major-11th includes it),
+# so it must be listed explicitly.
+_MAJOR_MARKER_QUALITIES = frozenset(
+    {
+        "major-seventh",
+        "minor-major-seventh",
+        "augmented-major-seventh",
+        "minor-major-ninth",
+        "augmented-major-ninth",
+        "augmented-dominant-ninth",
+        "major-11th",
+        "major-13th",
+        "minor-major-13th",
+    }
+)
+
+# Qualities with a flat (minor) 9th at root position.
+_FLAT_NINTH_QUALITIES = frozenset(
+    {
+        "half-diminished-minor-ninth",
+        "diminished-minor-ninth",
+    }
+)
+
+
+def _root_position_suffix(quality: str) -> str:
+    """Compute the root-position suffix from the quality name."""
+    if quality.startswith("half-diminished"):
+        prefix = "o\\"
+    elif quality.startswith("diminished"):
+        prefix = "o"
+    elif quality.startswith("augmented"):
+        prefix = "+"
+    else:
+        prefix = ""
+
+    size = _get_chord_size(quality)
+    if size == "triad":
+        return prefix
+
+    number = {"seventh": "7", "ninth": "9", "eleventh": "11", "thirteenth": "13"}.get(
+        size or "", ""
+    )
+    major_marker = "^^" if quality in _MAJOR_MARKER_QUALITIES else ""
+    flat = "b" if quality in _FLAT_NINTH_QUALITIES else ""
+    return prefix + major_marker + flat + number
+
+
+def _fmt_mod(mod: str | None, none_str: str = "") -> str:
+    return none_str if mod is None else mod.replace("-", "b")
+
+
+def _figs_to_str(figures: list[tuple[int, str | None]]) -> str:
+    prefix = "%" if len(figures) > 2 else ""
+    accs = "".join(_fmt_mod(mod, "s") for _, mod in figures)
+    nums = "".join(str(n) for n, _ in figures)
+    return prefix + accs + nums
+
+
+def _figure_index_for_pitch(
+    figures: list[tuple[int, str | None]],
+    pitch: music21.pitch.Pitch | None,
+    bass: music21.pitch.Pitch,
+) -> int | None:
+    """Return index in figures for pitch above bass; None if pitch is None or == bass."""
+    if pitch is None:
+        return None
+    interval = music21.interval.Interval(bass, pitch)
+    generic = _to_ascending_generic(interval.generic.directed)
+    if generic <= 1:
+        return None
+    for i, (num, _) in enumerate(figures):
+        if num == generic:
+            return i
+    return None
+
+
+def _to_ascending_generic(generic: int) -> int:
+    """
+    Normalise a directed generic interval to an ascending value in [1, 7].
+
+    Negative (descending) intervals are converted to their ascending diatonic
+    complement: a descending 3rd becomes an ascending 6th (3 + 6 = 9).
+    Values outside [1, 7] — including those produced by the complement step —
+    are then folded back into [1, 7] by modular reduction.  The result of 1
+    indicates the bass pitch itself (unison or octave equivalent).
+    """
+    if generic < 0:
+        generic = 8 - (-generic - 1) % 7
+    return (generic - 1) % 7 + 1
+
+
+def _get_figures(
+    sym: music21.harmony.ChordSymbol,
+    key: music21.key.Key,
+) -> list[tuple[int, str | None]]:
+    """
+    Compute figured bass (interval, modifier) pairs for each non-bass chord
+    tone, where the modifier reflects the deviation from the diatonic pitch at
+    that scale degree above the bass in the given key.
+    """
+    bass = sym.bass()
+    key_pitches = key.pitches
+    key_steps = [p.step for p in key_pitches]
+    try:
+        bass_idx = key_steps.index(bass.step)
+    except ValueError:
+        bass_idx = None
+
+    figures: list[tuple[int, str | None]] = []
+    seen: set[int] = set()
+    for pitch in sym.pitches:
+        if pitch.step == bass.step:
+            continue
+        generic = _to_ascending_generic(
+            music21.interval.Interval(bass, pitch).generic.directed
+        )
+        if generic <= 1 or generic in seen:
+            continue
+        seen.add(generic)
+        if bass_idx is None:
+            figures.append((generic, None))
+        else:
+            diatonic_idx = (bass_idx + generic - 1) % 7
+            diff = round(pitch.alter - key_pitches[diatonic_idx].alter)
+            figures.append((generic, Accidental.get_from_int("music21", diff) or None))
+
+    figures.sort(key=lambda x: -x[0])
+    return figures
+
+
+def _chord_fb(
+    sym: music21.harmony.ChordSymbol,
+    key: music21.key.Key,
+    quality: str,
+) -> str:
+    """
+    Universal figured bass for any chord at any inversion.
+    Treats the chord as root + 3rd + 5th + extension; all intermediates (7th of
+    9th chords, 7th+9th of 11th chords, etc.) are always implied and dropped
+    unconditionally. Of the remaining figures, drops the diatonic 5th first; if
+    the 5th is non-diatonic, drops the diatonic 3rd instead (only when the chord
+    has an extension, so triads in 2nd inversion keep both 3rd and 5th).
+    """
+    figures = _get_figures(sym, key)
+    bass = sym.bass()
+    size = _get_chord_size(quality)
+
+    # Drop intermediate extensions unconditionally (always implied by chord type).
+    intermediates: list[music21.pitch.Pitch | None] = []
+    if size in ("ninth", "eleventh", "thirteenth"):
+        intermediates.append(sym.seventh)
+    if size in ("eleventh", "thirteenth"):
+        intermediates.append(sym.getChordStep(9))
+    if size == "thirteenth":
+        intermediates.append(sym.getChordStep(11))
+
+    for pitch in intermediates:
+        idx = _figure_index_for_pitch(figures, pitch, bass)
+        if idx is not None:
+            figures.pop(idx)
+
+    # Drop 5th if diatonic; if the 5th is non-diatonic (must show it) or in the
+    # bass, drop the diatonic 3rd instead — but only when the chord has an
+    # extension (triads in 2nd inversion need both figures).
+    fifth_idx = _figure_index_for_pitch(figures, sym.fifth, bass)
+    if fifth_idx is not None and figures[fifth_idx][1] is None:
+        figures.pop(fifth_idx)
+    elif sym.seventh is not None:
+        third_idx = _figure_index_for_pitch(figures, sym.third, bass)
+        if third_idx is not None and figures[third_idx][1] is None:
+            figures.pop(third_idx)
+
+    return _figs_to_str(figures)
+
+
+def _compute_quality_suffix(
+    quality: str,
+    note_name: str,
+    inversion: int,
+    key: music21.key.Key,
+) -> str | None:
+    size = _get_chord_size(quality)
+    if size in ("triad", "seventh"):
+        max_inv = 2 if size == "triad" else 3
+        if inversion > max_inv:
+            return None
+    abbrev = QUALITY_TO_ABBREVIATION[quality]
+    sym = music21.harmony.ChordSymbol(note_name + abbrev, inversion=inversion)
+    return _get_inv_prefix(quality) + _chord_fb(sym, key, quality)
 
 
 def _get_note_degree(key: music21.key.Key, note):
@@ -126,7 +293,10 @@ def _get_roman_numeral_accidental(
         return 0
 
     degree = _get_note_degree(key, note)
-    key_degree_accidental = key.pitchFromDegree(degree).alter
+    key_degree_pitch = key.pitchFromDegree(degree)
+    if key_degree_pitch is None:
+        return 0
+    key_degree_accidental = key_degree_pitch.alter
     return note.pitch.alter - key_degree_accidental
 
 
@@ -151,11 +321,32 @@ def to_roman_numeral(
     # For now, let's leave them without a prefix, as that will be,
     # by far, the most common correct prefix.
     result_prefix = (
-        Accidental.get_from_int("musanalysis", result_accidental)
+        Accidental.get_from_int("musanalysis", round(result_accidental))
         if not applied_to
         else ""
     )
-    quality_suffix = QUALITY_TO_ROMAN_NUMERAL_SUFFIX[quality][inversion]
+
+    size = _get_chord_size(quality)
+    if size is not None:
+        if inversion > 0:
+            note_name = INT_TO_NOTE_NAME[step] + Accidental.get_from_int(
+                "music21", accidental
+            )
+            quality_suffix = _compute_quality_suffix(quality, note_name, inversion, key)
+            if quality_suffix is None:
+                quality_suffix = _root_position_suffix(quality)
+        else:
+            quality_suffix = _root_position_suffix(quality)
+    else:
+        suffix_table = QUALITY_TO_ROMAN_NUMERAL_SUFFIX.get(quality)
+        quality_suffix = (
+            suffix_table[inversion]
+            if suffix_table and inversion < len(suffix_table)
+            else None
+        )
+        if quality_suffix is None:
+            quality_suffix = (suffix_table[0] if suffix_table else "") or ""
+
     applied_to_suffix = INT_TO_APPLIED_TO_SUFFIX[applied_to]
 
     if "11th" in quality:

--- a/tilia/ui/windows/inspect.py
+++ b/tilia/ui/windows/inspect.py
@@ -213,6 +213,17 @@ class Inspect(QDockWidget):
 
     def update_values(self, field_values: dict[str, str], element_id: int):
         self.element_id = element_id
+        for field_name, items in field_values.pop("__items_update", {}).items():
+            widget = self.field_name_to_widgets[field_name][1]
+            if isinstance(widget, QComboBox):
+                current_data = widget.currentData()
+                widget.blockSignals(True)
+                widget.clear()
+                for label, data in items:
+                    widget.addItem(str(label), data)
+                idx = widget.findData(current_data)
+                widget.setCurrentIndex(idx if idx != -1 else widget.count() - 1)
+                widget.blockSignals(False)
         for field_name, value in field_values.items():
             widget = self.field_name_to_widgets[field_name][1]
 


### PR DESCRIPTION
- **Roman numeral figured bass** — dynamically computes MusAnalysis figured-bass suffixes for all chord qualities and inversions using music21's chord structure, replacing the previous hard-coded triad/seventh table. Handles triads, seventh, ninth, eleventh, and thirteenth chords at any inversion; extended chords drop implied intermediates (e.g. the 7th in a 9th chord). Augmented-sixth, suspended, and other bespoke qualities keep a static table.
- **Modal scale types** — mode labels now display the mode name in a readable font alongside the tonic (e.g. "C Dorian", "B♭ Phrygian") rather than rendering the mode name through the MusAnalysis glyph font.
- **Quality-aware inversion clamping** — when changing a chord's quality in the inspector or the add-harmony dialog, the inversion is clamped to the maximum valid for the new quality. Closes #468.
- **Chord symbol fallback for uninvertible qualities** — `letter_symbol` now catches `ChordException` and falls back to root position when music21 cannot construct the requested inversion (e.g. `minor-sixth` at inversion 3). Closes #376.
- **Add-harmony dialog sync** — selecting a note/quality/accidental from the combo boxes now writes the chord symbol back into the text field, so the two entry methods stay in sync.
- **Refactor** — harmony constants (`NOTE_NAME_TO_INT`, `INT_TO_NOTE_NAME`, etc.) are now derived from music21 at import time rather than duplicated by hand; `_INV_TO_STRING` is the single source of truth for inversion labels across the dialog and inspector.
