### PR TITLE
fix: file dialogs hid directories and accepted non-existent paths

### DIFF
--- a/tests/ui/dialogs/test_file_dialogs.py
+++ b/tests/ui/dialogs/test_file_dialogs.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+from PySide6.QtCore import QDir
 from PySide6.QtWidgets import QFileDialog
 
 from tilia.ui.dialogs import file as file_dialogs
@@ -14,19 +15,45 @@ OPEN_DIALOG_BUILDERS = {
     "media": lambda: file_dialogs.ask_for_media_file(),
 }
 
+DIALOG_BUILDERS = OPEN_DIALOG_BUILDERS | {
+    "save": lambda: file_dialogs.ask_for_path_to_save(
+        "Save as", "TiLiA files (*.tla)", "file.tla"
+    ),
+}
+
 
 def build_dialog(builder):
     """Runs a dialog-creating function, returning the dialog instead of executing it."""
-    captured = []
-
-    def capture(dialog):
-        captured.append(dialog)
-        return False, None
-
-    with patch.object(file_dialogs, "_get_return_from_file_dialog", capture):
+    with patch.object(
+        file_dialogs, "_get_return_from_file_dialog", return_value=(False, None)
+    ) as get_return:
         builder()
 
-    return captured[0]
+    return get_return.call_args.args[0]
+
+
+DEFAULT_FILTER = (
+    QDir.Filter.Dirs
+    | QDir.Filter.Files
+    | QDir.Filter.Drives
+    | QDir.Filter.AllDirs
+    | QDir.Filter.NoDot
+    | QDir.Filter.NoDotDot
+)
+
+
+class TestDirectoriesAreListed:
+    @pytest.mark.parametrize("name", DIALOG_BUILDERS)
+    def test_dialog_keeps_default_filter(self, name, qtui):
+        # QFileDialog.setFilter replaces Qt's default filter instead of adding
+        # to it, so no dialog may call it. Dropping AllDirs hides every folder
+        # and leaves the user unable to navigate; dropping NoDot/NoDotDot lists
+        # "." and ".." as entries. Which of the two you get depends on call
+        # order, because setFileMode() re-derives the filter and puts AllDirs
+        # and Drives back. See issue #565.
+        dialog = build_dialog(DIALOG_BUILDERS[name])
+
+        assert dialog.filter() == DEFAULT_FILTER
 
 
 class TestOpenDialogsRequireExistingFile:

--- a/tests/ui/dialogs/test_file_dialogs.py
+++ b/tests/ui/dialogs/test_file_dialogs.py
@@ -1,0 +1,41 @@
+from unittest.mock import patch
+
+import pytest
+from PySide6.QtWidgets import QFileDialog
+
+from tilia.ui.dialogs import file as file_dialogs
+
+OPEN_DIALOG_BUILDERS = {
+    "open tilia file": lambda: file_dialogs.ask_for_tilia_file_to_open(),
+    "open file": lambda: file_dialogs.ask_for_file_to_open(
+        "Import", "CSV files (*.csv)"
+    ),
+    "pdf": lambda: file_dialogs.ask_for_pdf_file(),
+    "media": lambda: file_dialogs.ask_for_media_file(),
+}
+
+
+def build_dialog(builder):
+    """Runs a dialog-creating function, returning the dialog instead of executing it."""
+    captured = []
+
+    def capture(dialog):
+        captured.append(dialog)
+        return False, None
+
+    with patch.object(file_dialogs, "_get_return_from_file_dialog", capture):
+        builder()
+
+    return captured[0]
+
+
+class TestOpenDialogsRequireExistingFile:
+    @pytest.mark.parametrize("name", OPEN_DIALOG_BUILDERS)
+    def test_open_dialog_only_accepts_existing_file(self, name, qtui):
+        # QFileDialog defaults to FileMode.AnyFile, which accepts a filename the
+        # user typed that does not exist on disk. Every dialog that opens an
+        # existing file must opt into FileMode.ExistingFile, or
+        # _get_return_from_file_dialog hands the caller a bogus path as success.
+        dialog = build_dialog(OPEN_DIALOG_BUILDERS[name])
+
+        assert dialog.fileMode() == QFileDialog.FileMode.ExistingFile

--- a/tilia/ui/dialogs/file.py
+++ b/tilia/ui/dialogs/file.py
@@ -94,6 +94,7 @@ def ask_for_path_to_export(
 def ask_for_pdf_file() -> tuple[bool, str | None]:
     dialog = QFileDialog()
     dialog.setWindowTitle("Choose PDF")
+    dialog.setFileMode(QFileDialog.FileMode.ExistingFile)
     dialog.setFilter(QtCore.QDir.Filter.Files)
     dialog.setNameFilter("PDF files (*.pdf)")
 
@@ -135,6 +136,7 @@ def ask_for_media_file() -> tuple[bool, str | None]:
 
     dialog = QFileDialog()
     dialog.setWindowTitle("Load media")
+    dialog.setFileMode(QFileDialog.FileMode.ExistingFile)
     dialog.setFilter(QtCore.QDir.Filter.Files)
     dialog.setNameFilters(
         [

--- a/tilia/ui/dialogs/file.py
+++ b/tilia/ui/dialogs/file.py
@@ -1,8 +1,6 @@
 from pathlib import Path
 from typing import Sequence
 
-from PySide6 import QtCore
-from PySide6.QtCore import QDir
 from PySide6.QtWidgets import QFileDialog
 
 import tilia.ui.dialogs.basic
@@ -30,7 +28,6 @@ def ask_for_tilia_file_to_open() -> tuple[bool, str | None]:
     dialog = QFileDialog()
     dialog.setWindowTitle(f"Open {APP_NAME} files")
     dialog.setFileMode(QFileDialog.FileMode.ExistingFile)
-    dialog.setFilter(QDir.Filter.Files)
     dialog.setNameFilters([APP_FILE_FILTER, "All files (*)"])
     return _get_return_from_file_dialog(dialog)
 
@@ -40,7 +37,6 @@ def ask_for_file_to_open(
 ) -> tuple[bool, str | None]:
     dialog = QFileDialog()
     dialog.setWindowTitle(title)
-    dialog.setFilter(QDir.Filter.Files)
     dialog.setFileMode(QFileDialog.FileMode.ExistingFile)
     if isinstance(name_filters, str):
         name_filters = [name_filters]
@@ -95,7 +91,6 @@ def ask_for_pdf_file() -> tuple[bool, str | None]:
     dialog = QFileDialog()
     dialog.setWindowTitle("Choose PDF")
     dialog.setFileMode(QFileDialog.FileMode.ExistingFile)
-    dialog.setFilter(QtCore.QDir.Filter.Files)
     dialog.setNameFilter("PDF files (*.pdf)")
 
     return _get_return_from_file_dialog(dialog)
@@ -137,7 +132,6 @@ def ask_for_media_file() -> tuple[bool, str | None]:
     dialog = QFileDialog()
     dialog.setWindowTitle("Load media")
     dialog.setFileMode(QFileDialog.FileMode.ExistingFile)
-    dialog.setFilter(QtCore.QDir.Filter.Files)
     dialog.setNameFilters(
         [
             f"All supported media files ({all_filetypes})",


### PR DESCRIPTION
Two related defects in `tilia/ui/dialogs/file.py`, both invisible on Windows and macOS because Qt delegates to the native dialog there. They only surface when Qt's own widget dialog is used — the common case on Linux when no platform-theme plugin (`libqxdgdesktopportal.so`, plasma-integration, etc.) is available to the bundled Qt.

## 1. `setFilter` discarded Qt's default filter

Closes #565.

`QFileDialog.setFilter()` *replaces* the filter rather than adding to it. Qt's default is `Dirs | Files | Drives | AllDirs | NoDot | NoDotDot`, so `setFilter(QDir.Filter.Files)` left the model with files only — no folders listed, and typing a directory path was ignored because it did not resolve within the filtered model.

`ask_for_path_to_save()` never called `setFilter`, which is why Save-as was unaffected on the same system.

One correction to the issue text: the effect was not uniform across the four call sites, because `setFileMode()` re-derives the filter and puts `AllDirs` and `Drives` back. What each dialog ended up with depended on call order:

| function | order | resulting filter | symptom |
| --- | --- | --- | --- |
| `ask_for_tilia_file_to_open` | `setFileMode` → `setFilter` | `Files` | no folders, navigation blocked |
| `ask_for_file_to_open` (imports) | `setFilter` → `setFileMode` | `Dirs\|Files\|Drives\|AllDirs` | folders listed, but `.` and `..` shown as entries |
| `ask_for_pdf_file` | `setFilter` only | `Files` | no folders, navigation blocked |
| `ask_for_media_file` | `setFilter` only | `Files` | no folders, navigation blocked |

So the import dialogs were never blocked outright, as #565 claims — they leaked `.` and `..` instead. All four are fixed by the same removal.

Restricting the *selection* to files is already handled by `FileMode.ExistingFile`; the filter call only ever restricted the *listing*.

## 2. PDF and media dialogs accepted non-existent paths

`ask_for_pdf_file()` and `ask_for_media_file()` never called `setFileMode()`, so they used the `FileMode.AnyFile` default. A filename the user typed that does not exist on disk was accepted, and `_get_return_from_file_dialog` returned it to the caller as success. Both now set `FileMode.ExistingFile`, like the other open dialogs in the module.

The `ask_retry_media_file()` / `ask_retry_pdf_file()` prompts are unaffected: they are reached from `_setup_file_media()` and `_handle_invalid_pdf()` when a `.tla` file's stored path no longer resolves, which never goes through a file dialog.

## Tests

New `tests/ui/dialogs/test_file_dialogs.py`. The existing helpers patch `QFileDialog.exec` and `selectedFiles` wholesale, so dialog *configuration* was never exercised; these tests patch `_get_return_from_file_dialog` instead and assert against the constructed dialog.

- `TestDirectoriesAreListed` — every dialog keeps Qt's full default filter. Compares against the whole flag set rather than probing for `AllDirs`, so it catches both symptoms in the table above. Includes the save dialog as a control.
- `TestOpenDialogsRequireExistingFile` — every dialog that opens an existing file sets `FileMode.ExistingFile`.

Checked against `main`: 6 of the 9 fail without these changes, and the save-dialog control stays green. Full suite `1261 passed, 12 skipped, 2 xfailed, 2 xpassed`.
