### PR TITLE
fix: keep hierarchy paste-complete boundaries exact so grouping doesn't fail

### DIFF
--- a/tests/timelines/hierarchy/test_hierarchy_timeline.py
+++ b/tests/timelines/hierarchy/test_hierarchy_timeline.py
@@ -404,6 +404,35 @@ class TestHierarchyTimelineComponentManager:
         assert child2.parent == parent2
         assert child2.children == []
 
+    def test_genealogy_with_parent_start_drifted_past_child_start(self, hierarchy_tl):
+        # Files saved before paste-complete stopped drifting can hold a parent
+        # whose start sits a few ulps after its child's. The two were meant to
+        # coincide, so the child must still be adopted.
+        eps = 4e-14
+        parent, _ = hierarchy_tl.create_hierarchy(0.5 + eps, 1, 2)
+        child, _ = hierarchy_tl.create_hierarchy(0.5, 1, 1)
+
+        assert child.parent == parent
+        assert parent.children == [child]
+
+    def test_genealogy_with_parent_end_drifted_before_child_end(self, hierarchy_tl):
+        eps = 4e-14
+        parent, _ = hierarchy_tl.create_hierarchy(0, 1 - eps, 2)
+        child, _ = hierarchy_tl.create_hierarchy(0, 1, 1)
+
+        assert child.parent == parent
+        assert parent.children == [child]
+
+    def test_genealogy_ignores_candidate_that_is_genuinely_too_narrow(
+        self, hierarchy_tl
+    ):
+        # Guard against the tolerance being too coarse: a candidate that falls
+        # well short of the child is not its parent.
+        hierarchy_tl.create_hierarchy(0.5, 0.9, 2)
+        child, _ = hierarchy_tl.create_hierarchy(0.5, 1, 1)
+
+        assert child.parent is None
+
     def test_get_boundary_conflicts_empty_timeline(self, hierarchy_tl):
         assert not hierarchy_tl.get_boundary_conflicts()
 
@@ -495,6 +524,31 @@ class TestHierarchyTimelineComponentManager:
         assert len(conflicts) == 2
         assert {h1, h3} in conflicts
         assert {h2, h3} in conflicts
+
+    def test_get_boundary_conflicts_drifted_coincident_boundaries(self, hierarchy_tl):
+        # A neighbor whose end sits a few ulps past the next component's start
+        # was meant to be flush with it. That float noise is not a conflict.
+        eps = 1e-13
+        hierarchy_tl.create_hierarchy(0, 0.5 + eps, 2)
+        hierarchy_tl.create_hierarchy(0.5, 1, 2)
+
+        assert not hierarchy_tl.get_boundary_conflicts()
+
+    def test_get_boundary_conflicts_overlap_well_past_boundary_still_conflicts(
+        self, hierarchy_tl
+    ):
+        # Guard against the tolerance being too coarse.
+        h1, _ = hierarchy_tl.create_hierarchy(0, 0.6, 2)
+        h2, _ = hierarchy_tl.create_hierarchy(0.5, 1, 2)
+
+        assert set(hierarchy_tl.get_boundary_conflicts()[0]) == {h1, h2}
+
+    def test_get_boundary_conflicts_drifted_duplicate_on_same_level(self, hierarchy_tl):
+        eps = 1e-13
+        h1, _ = hierarchy_tl.create_hierarchy(0, 1, 1)
+        h2, _ = hierarchy_tl.create_hierarchy(eps, 1 + eps, 1)
+
+        assert set(hierarchy_tl.get_boundary_conflicts()[0]) == {h1, h2}
 
 
 class TestSplit:
@@ -720,6 +774,35 @@ class TestGroup:
         hierarchy_tl.create_hierarchy(start=0.0, end=0.2, level=2)
 
         success, _ = hierarchy_tl.component_manager.group([hrc1, hrc2])
+        assert not success
+
+    def test_neighbor_end_drifted_just_past_group_start_does_not_fail(
+        self, hierarchy_tl
+    ):
+        # Operations that rescale components (e.g. paste-complete) can leave a
+        # neighbor's end a few ulps past the group's start even though the two
+        # were meant to be coincident. This float noise must not be read as an
+        # overlap. Regression for grouping split units after paste-complete.
+        eps = 1e-13
+        hierarchy_tl.create_hierarchy(start=0.0, end=0.5 + eps, level=2)
+        hrc1, _ = hierarchy_tl.create_hierarchy(start=0.5, end=0.75, level=1)
+        hrc2, _ = hierarchy_tl.create_hierarchy(start=0.75, end=1.0, level=1)
+
+        success, reason = hierarchy_tl.component_manager.group([hrc1, hrc2])
+
+        assert success, reason
+        assert hrc1.parent == hrc2.parent
+        assert hrc1.parent.level == 2
+
+    def test_neighbor_end_well_inside_group_still_fails(self, hierarchy_tl):
+        # Guard against the tolerance being too coarse: a neighbor ending well
+        # inside the group is a genuine overlap and must still be rejected.
+        hierarchy_tl.create_hierarchy(start=0.0, end=0.6, level=2)
+        hrc1, _ = hierarchy_tl.create_hierarchy(start=0.5, end=0.75, level=1)
+        hrc2, _ = hierarchy_tl.create_hierarchy(start=0.75, end=1.0, level=1)
+
+        success, _ = hierarchy_tl.component_manager.group([hrc1, hrc2])
+
         assert not success
 
 

--- a/tests/ui/timelines/hierarchy/test_hierarchy_timeline_ui.py
+++ b/tests/ui/timelines/hierarchy/test_hierarchy_timeline_ui.py
@@ -17,6 +17,11 @@ def tlui(hierarchy_tlui):
     return hierarchy_tlui
 
 
+def get_hierarchy(tlui, start: float, level: int) -> Hierarchy:
+    """Look a hierarchy up by its data, for setups that aren't in sorted order."""
+    return next(c for c in tlui.timeline if c.start == start and c.level == level)
+
+
 def set_dummy_copy_attributes(hierarchy: Hierarchy) -> None:
     for attr in HierarchyUI.DEFAULT_COPY_ATTRIBUTES.values:
         if attr == "color":
@@ -470,6 +475,138 @@ class TestCopyPaste:
         component_state2 = tlui.timeline.components
 
         assert component_state1 == component_state2
+
+    def test_paste_complete_keeps_shared_boundaries_exact(self, tlui):
+        # Siblings sharing a boundary in the source must still share it exactly
+        # after being rescaled into the target. Scaling each component
+        # independently would leave the two a few ulps apart, which later
+        # operations read as an overlap.
+        commands.execute("timeline.hierarchy.add", start=40, end=45, level=3)
+        commands.execute("timeline.hierarchy.add", start=45, end=70, level=3)
+        commands.execute("timeline.hierarchy.add", start=40, end=70, level=4)
+        commands.execute("timeline.hierarchy.add", start=0, end=23.4, level=4)
+        root = get_hierarchy(tlui, 40, 4)
+        target = get_hierarchy(tlui, 0, 4)
+
+        tlui.select_element(tlui.get_element(root.id))
+        commands.execute("timeline.component.copy")
+        tlui.deselect_all_elements()
+        tlui.select_element(tlui.get_element(target.id))
+        commands.execute("timeline.component.paste_complete")
+
+        left, right = sorted(target.children)
+
+        assert left.end == right.start
+        # the subtree must also line up exactly with the target it was pasted into
+        assert left.start == target.start
+        assert right.end == target.end
+
+    def test_paste_complete_keeps_grandchild_boundaries_exact(self, tlui):
+        # Nesting compounds any per-component error, since each level would
+        # re-derive its scale factor from the already-rounded bounds of the
+        # level above. One map for the whole subtree avoids that.
+        commands.execute("timeline.hierarchy.add", start=40, end=45, level=1)
+        commands.execute("timeline.hierarchy.add", start=45, end=52.5, level=1)
+        commands.execute("timeline.hierarchy.add", start=40, end=52.5, level=2)
+        commands.execute("timeline.hierarchy.add", start=52.5, end=70, level=2)
+        commands.execute("timeline.hierarchy.add", start=40, end=70, level=3)
+        commands.execute("timeline.hierarchy.add", start=0, end=23.4, level=3)
+        root = get_hierarchy(tlui, 40, 3)
+        target = get_hierarchy(tlui, 0, 3)
+
+        tlui.select_element(tlui.get_element(root.id))
+        commands.execute("timeline.component.copy")
+        tlui.deselect_all_elements()
+        tlui.select_element(tlui.get_element(target.id))
+        commands.execute("timeline.component.paste_complete")
+
+        left_child, right_child = sorted(target.children)
+        grandchild_1, grandchild_2 = sorted(left_child.children)
+
+        assert grandchild_1.end == grandchild_2.start
+        # grandchildren must align exactly with their parent's bounds, and the
+        # children with each other
+        assert grandchild_1.start == left_child.start
+        assert grandchild_2.end == left_child.end == right_child.start
+
+    def test_paste_complete_into_same_timespan_is_exact(self, tlui):
+        # An identity rescale must not perturb any boundary.
+        commands.execute("timeline.hierarchy.add", start=40, end=45.55, level=1)
+        commands.execute("timeline.hierarchy.add", start=45.55, end=70, level=1)
+        commands.execute("timeline.hierarchy.add", start=40, end=70, level=2)
+        commands.execute("timeline.hierarchy.add", start=70, end=100, level=2)
+        root = get_hierarchy(tlui, 40, 2)
+        target = get_hierarchy(tlui, 70, 2)
+
+        tlui.select_element(tlui.get_element(root.id))
+        commands.execute("timeline.component.copy")
+        tlui.deselect_all_elements()
+        tlui.select_element(tlui.get_element(target.id))
+        commands.execute("timeline.component.paste_complete")
+
+        left, right = sorted(target.children)
+
+        assert left.start == 70
+        assert left.end == right.start == 75.55
+        assert right.end == 100
+
+    def test_group_split_child_of_pasted_hierarchy(self, tlui):
+        # End-to-end guard over a whole editing flow that runs on rescaled
+        # boundaries: paste a subtree into a shorter target, then create a
+        # child inside one of the pasted units, lower its level, split it and
+        # group the halves. Every step compares boundaries the paste produced,
+        # so any drift between a pasted unit and its neighbour surfaces here as
+        # a spurious overlap.
+        # Source subtree lives at [40, 70]; the two level-3 children share the
+        # boundary 45, pasted into the shorter target [0, 23.4].
+        commands.execute("timeline.hierarchy.add", start=40, end=45, level=3)
+        # the right child is left childless, so it is the one that gets split
+        commands.execute("timeline.hierarchy.add", start=45, end=70, level=3)
+        commands.execute("timeline.hierarchy.add", start=40, end=70, level=4)
+        commands.execute("timeline.hierarchy.add", start=0, end=23.4, level=4)
+        root = get_hierarchy(tlui, 40, 4)
+        target = get_hierarchy(tlui, 0, 4)
+
+        tlui.select_element(tlui.get_element(root.id))
+        commands.execute("timeline.component.copy")
+        tlui.deselect_all_elements()
+        tlui.select_element(tlui.get_element(target.id))
+        commands.execute("timeline.component.paste_complete")
+
+        # the pasted right child. Components with end <= 30 are the pasted
+        # target subtree; the source subtree lives at >= 40.
+        pasted_right_child = max(
+            (c for c in tlui.timeline if c.level == 3 and c.end <= 30),
+            key=lambda c: c.start,
+        )
+
+        tlui.deselect_all_elements()
+        tlui.select_element(tlui.get_element(pasted_right_child.id))
+        commands.execute("timeline.hierarchy.create_child")  # -> level 2 child
+
+        child = max(c for c in tlui.timeline if c.level == 2 and c.end <= 30)
+        tlui.deselect_all_elements()
+        tlui.select_element(tlui.get_element(child.id))
+        commands.execute("timeline.hierarchy.decrease_level")  # level 2 -> 1
+
+        commands.execute(
+            "timeline.hierarchy.split",
+            time=(pasted_right_child.start + pasted_right_child.end) / 2,
+        )
+
+        halves = sorted(
+            (c for c in tlui.timeline if c.level == 1 and c.end <= 30),
+            key=lambda c: c.start,
+        )
+        assert len(halves) == 2
+        tlui.deselect_all_elements()
+        for half in halves:
+            tlui.select_element(tlui.get_element(half.id))
+        commands.execute("timeline.hierarchy.group")
+
+        grouped = [c for c in tlui.timeline if c.level == 2 and c.end <= 30]
+        assert len(grouped) == 1
+        assert halves[0].parent == halves[1].parent == grouped[0]
 
 
 class TestCreateHierarchy:

--- a/tests/ui/timelines/hierarchy/test_hierarchy_timeline_ui.py
+++ b/tests/ui/timelines/hierarchy/test_hierarchy_timeline_ui.py
@@ -1,7 +1,10 @@
+from unittest.mock import patch
+
 import pytest
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor
 
+import tilia.errors
 from tests.mock import Serve, patch_yes_or_no_dialog
 from tests.utils import get_command_names
 from tilia.requests import Get, Post, post
@@ -475,6 +478,51 @@ class TestCopyPaste:
         component_state2 = tlui.timeline.components
 
         assert component_state1 == component_state2
+
+    def test_paste_complete_reports_child_creation_failure(self, tlui):
+        commands.execute("timeline.hierarchy.add", start=40, end=45, level=1)
+        commands.execute("timeline.hierarchy.add", start=45, end=70, level=1)
+        commands.execute("timeline.hierarchy.add", start=40, end=70, level=2)
+        commands.execute("timeline.hierarchy.add", start=0, end=23.4, level=2)
+        root = get_hierarchy(tlui, 40, 2)
+        target = get_hierarchy(tlui, 0, 2)
+
+        tlui.select_element(tlui.get_element(root.id))
+        commands.execute("timeline.component.copy")
+        tlui.deselect_all_elements()
+        tlui.select_element(tlui.get_element(target.id))
+
+        with (
+            patch.object(
+                tlui.timeline, "create_component", return_value=(None, "no room")
+            ),
+            patch("tilia.errors.display") as display,
+        ):
+            commands.execute("timeline.component.paste_complete")
+
+        display.assert_called_once()
+        assert display.call_args.args[0] == tilia.errors.COMPONENTS_PASTE_ERROR
+        assert "no room" in display.call_args.args[1]
+        assert not target.children
+
+    def test_paste_complete_reports_no_error_when_children_are_created(self, tlui):
+        commands.execute("timeline.hierarchy.add", start=40, end=45, level=1)
+        commands.execute("timeline.hierarchy.add", start=45, end=70, level=1)
+        commands.execute("timeline.hierarchy.add", start=40, end=70, level=2)
+        commands.execute("timeline.hierarchy.add", start=0, end=23.4, level=2)
+        root = get_hierarchy(tlui, 40, 2)
+        target = get_hierarchy(tlui, 0, 2)
+
+        tlui.select_element(tlui.get_element(root.id))
+        commands.execute("timeline.component.copy")
+        tlui.deselect_all_elements()
+        tlui.select_element(tlui.get_element(target.id))
+
+        with patch("tilia.errors.display") as display:
+            commands.execute("timeline.component.paste_complete")
+
+        display.assert_not_called()
+        assert len(target.children) == 2
 
     def test_paste_complete_keeps_shared_boundaries_exact(self, tlui):
         # Siblings sharing a boundary in the source must still share it exactly

--- a/tilia/timelines/hierarchy/timeline.py
+++ b/tilia/timelines/hierarchy/timeline.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import itertools
+from math import isclose
 from typing import Any
 
 import tilia.errors
@@ -16,6 +17,31 @@ from tilia.timelines.component_kinds import ComponentKind
 from ...ui.format import format_media_time
 from ..base.timeline import Timeline, TimelineComponentManager, TimelineFlag
 from .components import Hierarchy
+
+# Hierarchy boundaries are compared with a tolerance rather than with exact
+# float operators. Rescaling operations no longer introduce drift — paste-complete
+# maps the whole subtree with a single affine map, and scaling for a media-duration
+# change applies one factor uniformly — so times meant to be coincident come out
+# coincident. The tolerance is a safeguard for legacy files: those saved before
+# that fix already contain boundaries a few ulps apart (~1e-13) where they should
+# coincide, and exact comparison reads that float noise as a real overlap. The
+# tolerance sits far above the noise and far below any meaningful musical interval,
+# so genuine overlaps are still detected.
+_TIME_ABS_TOL = 1e-9
+
+
+def _times_close(a: float, b: float) -> bool:
+    return isclose(a, b, abs_tol=_TIME_ABS_TOL)
+
+
+def _le(a: float, b: float) -> bool:
+    """``a <= b``, treating near-coincident times as equal."""
+    return a < b or _times_close(a, b)
+
+
+def _lt(a: float, b: float) -> bool:
+    """``a < b``, treating near-coincident times as equal (i.e. not less)."""
+    return a < b and not _times_close(a, b)
 
 
 class HierarchyTLComponentManager(TimelineComponentManager):
@@ -40,7 +66,9 @@ class HierarchyTLComponentManager(TimelineComponentManager):
         candidates = {
             h
             for h in self
-            if h.start <= child.start and h.end >= child.end and h.level > child.level
+            if _le(h.start, child.start)
+            and _le(child.end, h.end)
+            and h.level > child.level
         }
         if not candidates:
             return None
@@ -51,8 +79,8 @@ class HierarchyTLComponentManager(TimelineComponentManager):
             return {
                 h
                 for h in hierarchy_iter
-                if above.start <= h.start
-                and above.end >= h.end
+                if _le(above.start, h.start)
+                and _le(h.end, above.end)
                 and above.level > h.level
             }
 
@@ -73,26 +101,31 @@ class HierarchyTLComponentManager(TimelineComponentManager):
 
         conflicts = []
 
+        def starts_or_ends_strictly_inside(outer: Hierarchy, inner: Hierarchy) -> bool:
+            return (_lt(outer.start, inner.start) and _lt(inner.start, outer.end)) or (
+                _lt(outer.start, inner.end) and _lt(inner.end, outer.end)
+            )
+
         for hrc1, hrc2 in itertools.combinations(self._components, 2):
-            if hrc1.start < hrc2.start < hrc1.end or hrc1.start < hrc2.end < hrc1.end:
+            if starts_or_ends_strictly_inside(hrc1, hrc2):
                 # hrc2 starts or ends inside hrc1
                 if hrc2.level >= hrc1.level:
                     # if it is on the same level or higher, there's a conflict
                     conflicts.append((hrc1, hrc2))
-                elif not hrc1.start > hrc2.start and hrc1.end < hrc2.end:
+                elif not _lt(hrc2.start, hrc1.start) and _lt(hrc1.end, hrc2.end):
                     # if it doesn't start AND end inside, there's a conflict
                     conflicts.append((hrc1, hrc2))
 
             # repeat swapping hr1 and hrc2
-            if hrc2.start < hrc1.start < hrc2.end or hrc2.start < hrc1.end < hrc2.end:
+            if starts_or_ends_strictly_inside(hrc2, hrc1):
                 if hrc1.level >= hrc2.level:
                     conflicts.append((hrc2, hrc1))
-                elif not hrc2.start > hrc1.start and hrc2.end < hrc1.end:
+                elif not _lt(hrc1.start, hrc2.start) and _lt(hrc2.end, hrc1.end):
                     conflicts.append((hrc2, hrc1))
 
             if (
-                hrc1.start == hrc2.start
-                and hrc1.end == hrc2.end
+                _times_close(hrc1.start, hrc2.start)
+                and _times_close(hrc1.end, hrc2.end)
                 and hrc1.level == hrc2.level
             ):
                 # if hierarchies have same times and level, there's a conflict
@@ -136,10 +169,14 @@ class HierarchyTLComponentManager(TimelineComponentManager):
             ]
 
             for unit_to_check in units_to_check:
-                start_inside_group = start <= unit_to_check.start < end
-                ends_inside_group = start < unit_to_check.end <= end
-                comprehends_group = (
-                    unit_to_check.start <= start and end <= unit_to_check.end
+                start_inside_group = _le(start, unit_to_check.start) and _lt(
+                    unit_to_check.start, end
+                )
+                ends_inside_group = _lt(start, unit_to_check.end) and _le(
+                    unit_to_check.end, end
+                )
+                comprehends_group = _le(unit_to_check.start, start) and _le(
+                    end, unit_to_check.end
                 )
 
                 if (
@@ -169,10 +206,10 @@ class HierarchyTLComponentManager(TimelineComponentManager):
             """Raises False if there is a unit in grouping level that spans
             or exceeds the interval between 'start_time' and 'end_time'."""
             if any(
-                [
-                    u.start <= start < u.end or u.start < end <= u.end
-                    for u in [u for u in self.timeline if u.level == grouping_level]
-                ]
+                (_le(u.start, start) and _lt(start, u.end))
+                or (_lt(u.start, end) and _le(end, u.end))
+                for u in self.timeline
+                if u.level == grouping_level
             ):
                 return (
                     False,

--- a/tilia/ui/timelines/hierarchy/timeline.py
+++ b/tilia/ui/timelines/hierarchy/timeline.py
@@ -2,10 +2,10 @@ from typing import Callable
 
 import tilia.ui.strings
 import tilia.ui.timelines.copy_paste
-from tilia.log import logger
 from tilia.requests import Get, Post, get, listen, post
 from tilia.settings import settings
 from tilia.timelines.component_kinds import ComponentKind
+from tilia.timelines.hierarchy.components import Hierarchy
 from tilia.timelines.hierarchy.timeline import HierarchyTimeline
 from tilia.ui import commands
 from tilia.ui.menus import HierarchyMenu
@@ -217,8 +217,8 @@ class HierarchyTimelineUI(TimelineUI):
         self,
         child_pastedata_: dict,
         map_time: Callable[[float], float],
-    ):
-        component, _ = self.timeline.create_component(
+    ) -> tuple[Hierarchy | None, str | None]:
+        return self.timeline.create_component(
             kind=ComponentKind.HIERARCHY,
             start=map_time(child_pastedata_["context"]["start"]),
             end=map_time(child_pastedata_["context"]["end"]),
@@ -226,41 +226,47 @@ class HierarchyTimelineUI(TimelineUI):
             **child_pastedata_["values"],
         )
 
-        return component
+    def paste_with_children_into_element(
+        self, paste_data: dict, element: HierarchyUI
+    ) -> list[str]:
+        """Paste the copied subtree into ``element``, rescaled to its timespan.
 
-    def paste_with_children_into_element(self, paste_data: dict, element: HierarchyUI):
+        Returns the reasons any descendant could not be created. Pasting is
+        best-effort: a child that fails is skipped along with its own subtree,
+        and the remaining siblings are still pasted.
+        """
         map_time = self._get_paste_time_map(
             paste_data["context"]["start"],
             paste_data["context"]["end"],
             element.tl_component.start,
             element.tl_component.end,
         )
-        self._paste_subtree_into_element(paste_data, element, map_time)
+        return self._paste_subtree_into_element(paste_data, element, map_time)
 
     def _paste_subtree_into_element(
         self,
         paste_data: dict,
         element: HierarchyUI,
         map_time: Callable[[float], float],
-    ) -> None:
+    ) -> list[str]:
         tilia.ui.timelines.copy_paste.paste_into_element(element, paste_data)
 
+        fail_reasons = []
         for child_paste_data in paste_data.get("children", []):
-            child_component = self._create_child_from_paste_data(
+            child_component, fail_reason = self._create_child_from_paste_data(
                 child_paste_data, map_time
             )
 
             if child_component is None:
-                logger.error(
-                    "Could not paste hierarchy child into "
-                    f"'{element.tl_component}': component creation failed."
-                )
+                fail_reasons.append(fail_reason)
                 continue
 
             if child_paste_data.get("children", None):
-                self._paste_subtree_into_element(
+                fail_reasons += self._paste_subtree_into_element(
                     child_paste_data, self.get_component_ui(child_component), map_time
                 )
+
+        return fail_reasons
 
     def get_copy_data_from_hierarchy_ui(self, hierarchy_ui: HierarchyUI):
         ui_data = get_copy_data_from_element(
@@ -328,6 +334,7 @@ class HierarchyTimelineUI(TimelineUI):
             return False
 
         data = copied_components[0]
+        fail_reasons = []
         for element in self.selected_elements:
             success, reason = _validate_paste_complete_level(element, data)
             if not success:
@@ -337,7 +344,11 @@ class HierarchyTimelineUI(TimelineUI):
             while children := element.get_data("children"):
                 self.timeline.delete_components(children)
 
-            self.paste_with_children_into_element(data, element)
+            fail_reasons += self.paste_with_children_into_element(data, element)
+
+        if fail_reasons:
+            _display_paste_complete_error("\n".join(fail_reasons))
+            return False
 
         return True
 

--- a/tilia/ui/timelines/hierarchy/timeline.py
+++ b/tilia/ui/timelines/hierarchy/timeline.py
@@ -1,5 +1,8 @@
+from typing import Callable
+
 import tilia.ui.strings
 import tilia.ui.timelines.copy_paste
+from tilia.log import logger
 from tilia.requests import Get, Post, get, listen, post
 from tilia.settings import settings
 from tilia.timelines.component_kinds import ComponentKind
@@ -181,35 +184,44 @@ class HierarchyTimelineUI(TimelineUI):
             paste_into_element(element, paste_data[0])
             self.select_element(element)
 
+    @staticmethod
+    def _get_paste_time_map(
+        source_start: float,
+        source_end: float,
+        target_start: float,
+        target_end: float,
+    ) -> Callable[[float], float]:
+        """Return the affine map from the copied subtree's timespan to the target's.
+
+        The whole subtree shares one map, so a time that appears in several
+        copied components — as one's end and the next one's start — maps to the
+        same float in all of them and coincident boundaries stay coincident.
+        Deriving a scale factor separately per nesting level, or anchoring
+        starts and ends to different reference points, lets those boundaries
+        drift apart by a few ulps, which later reads as an overlap.
+        """
+        scale_factor = (target_end - target_start) / (source_end - source_start)
+
+        def map_time(time: float) -> float:
+            # Anchor the endpoints exactly: scaling them arithmetically can
+            # land a ulp off, misaligning the subtree with the target.
+            if time == source_start:
+                return target_start
+            if time == source_end:
+                return target_end
+            return (time - source_start) * scale_factor + target_start
+
+        return map_time
+
     def _create_child_from_paste_data(
         self,
-        new_parent: HierarchyUI,
-        prev_parent_start: float,
-        prev_parent_end: float,
         child_pastedata_: dict,
+        map_time: Callable[[float], float],
     ):
-
-        new_parent_length = new_parent.tl_component.end - new_parent.tl_component.start
-
-        prev_parent_length = prev_parent_end - prev_parent_start
-        scale_factor = new_parent_length / prev_parent_length
-
-        relative_child_start = child_pastedata_["context"]["start"] - prev_parent_start
-
-        new_child_start = (
-            relative_child_start * scale_factor
-        ) + new_parent.tl_component.start
-
-        relative_child_end = child_pastedata_["context"]["end"] - prev_parent_end
-
-        new_child_end = (
-            relative_child_end * scale_factor
-        ) + new_parent.tl_component.end
-
         component, _ = self.timeline.create_component(
             kind=ComponentKind.HIERARCHY,
-            start=new_child_start,
-            end=new_child_end,
+            start=map_time(child_pastedata_["context"]["start"]),
+            end=map_time(child_pastedata_["context"]["end"]),
             level=child_pastedata_["context"]["level"],
             **child_pastedata_["values"],
         )
@@ -217,24 +229,38 @@ class HierarchyTimelineUI(TimelineUI):
         return component
 
     def paste_with_children_into_element(self, paste_data: dict, element: HierarchyUI):
+        map_time = self._get_paste_time_map(
+            paste_data["context"]["start"],
+            paste_data["context"]["end"],
+            element.tl_component.start,
+            element.tl_component.end,
+        )
+        self._paste_subtree_into_element(paste_data, element, map_time)
+
+    def _paste_subtree_into_element(
+        self,
+        paste_data: dict,
+        element: HierarchyUI,
+        map_time: Callable[[float], float],
+    ) -> None:
         tilia.ui.timelines.copy_paste.paste_into_element(element, paste_data)
 
-        if "children" in paste_data:
-            children_of_element = []
-            for child_paste_data in paste_data["children"]:
-                child_component = self._create_child_from_paste_data(
-                    element,
-                    paste_data["context"]["start"],
-                    paste_data["context"]["end"],
-                    child_paste_data,
+        for child_paste_data in paste_data.get("children", []):
+            child_component = self._create_child_from_paste_data(
+                child_paste_data, map_time
+            )
+
+            if child_component is None:
+                logger.error(
+                    "Could not paste hierarchy child into "
+                    f"'{element.tl_component}': component creation failed."
                 )
+                continue
 
-                if child_paste_data.get("children", None):
-                    self.paste_with_children_into_element(
-                        child_paste_data, self.get_component_ui(child_component)
-                    )
-
-                children_of_element.append(child_component)
+            if child_paste_data.get("children", None):
+                self._paste_subtree_into_element(
+                    child_paste_data, self.get_component_ui(child_component), map_time
+                )
 
     def get_copy_data_from_hierarchy_ui(self, hierarchy_ui: HierarchyUI):
         ui_data = get_copy_data_from_element(


### PR DESCRIPTION
Grouping components derived from a pasted hierarchy subtree failed with
`Grouping failed: Grouping component would overlap with existing component.`

Closes #396.

## Reproducing

Reported against a real file. In a hierarchy timeline:

1. Copy the top-level hierarchy of one timeline.
2. Paste it into a single hierarchy of another with **Paste complete**.
3. Create a child in one of the pasted components.
4. Decrease that child's level.
5. Split the child in two.
6. Try to group the two halves.

Expected the halves to be grouped; got the overlap error instead.

## Cause

`_create_child_from_paste_data` rescaled each copied component with arithmetic
that differed between its start and its end: the start was taken relative to the
source parent's **start**, the end relative to the source parent's **end**. A time
appearing in two components — as one's end and the next one's start — therefore
went through different operations and came out a few ulps apart. Nesting
compounded this, since every level re-derived its scale factor from the
already-rounded bounds of the level above.

In the reported file the pasted `Modulation` component starts at
`134.18723783376336` while its left-hand neighbours end at `134.1872378337634` —
4e-14 further right, so arithmetically *inside* the group span. Since the
grouping validators compare boundaries with exact float operators, that
sub-ulp gap read as a real overlap.

## Fix

Three commits, one per concern:

**`fix: keep hierarchy paste-complete boundaries exact`** — build a single affine
map at the root of the paste and apply it to the absolute times of the whole
subtree, so the same time maps to the same float everywhere it occurs. This is
mathematically identical to the old per-level nesting (composing affine maps
over nested intervals yields the root map) but without the intermediate
rounding. Endpoints are anchored exactly so the pasted subtree lines up flush
with the target.

**`fix: tolerate float drift when comparing hierarchy boundaries`** — compare
boundaries with a 1 ns tolerance instead of exact operators. Needed
independently of the above: files saved before this fix already contain the
drifted values, and exact comparison is fragile for any rescaling operation.
1 ns sits far above the float noise (~1e-13) and far below any meaningful
musical interval, so genuine overlaps are still rejected.

The tolerance is applied to *every* boundary comparison that runs over stored
geometry, not just the two grouping validators, so the helpers cannot disagree
about whether the same timeline is valid:

- `get_parent` / `get_children` — a parent whose start sits a few ulps after its
  child's start was not found, silently orphaning the child. Everything
  depending on the parent link then misbehaves: delete cascade, level changes,
  copy-with-children, and the `has_same_parent` check inside grouping itself.
- `get_boundary_conflicts` — reported the very grouping unit the validators had
  just accepted as conflicting with its drifted neighbour.

Each comparison keeps its original strictness; only the equality test changes.

Checked `scale_segmentlike` (media-duration changes) for the same class of bug —
it applies `t * factor` uniformly to starts and ends, so shared boundaries stay
identical. Paste-complete was the only offender.

**`fix: report paste-complete child creation failures to the user`** — a child of
the pasted subtree that could not be created was skipped with only a log line,
so the user saw a silently incomplete paste. It now goes through the same
`COMPONENTS_PASTE_ERROR` dialog as the other paste-complete failures. Pasting
stays best-effort — a failed child is skipped along with its own subtree and the
remaining siblings are still pasted — so the reasons are collected across the
whole operation and reported once at the end rather than one dialog per failure.

Also folded into the paste commit: the unused `children_of_element` accumulator
is gone, and a failed `create_component` no longer flows into
`get_component_ui(None)`.

## Tests

Each new test was confirmed to fail without the corresponding fix and pass with it.

- Three tests asserting exact float equality of shared boundaries after
  paste-complete — for siblings, for grandchildren (where the old error
  compounded), and for an identity rescale. Two of them fail on `dev` with the
  visible drift `3.8999999999999995` vs `3.9000000000000004`.
- An end-to-end test walking the whole reported flow through commands
  (paste-complete → create_child → decrease_level → split → group), which fails
  on `dev` with the exact reported error message.
- Two backend tests for the grouping tolerance: one where a neighbour's end sits
  a few ulps inside the group span (must succeed), one where it sits well inside
  (must still be rejected).
- Three more for genealogy and conflict detection: a parent whose start drifted
  past its child's start, one whose end drifted before its child's end, and
  coincident-but-drifted boundaries that must not be reported as conflicting.
- Guard tests against the tolerance being too coarse: a genuinely too-narrow
  parent is still not adopted, an overlap well past a boundary is still
  reported, and a drifted duplicate on the same level is still a conflict.
- Two tests for the paste-complete failure dialog: it fires with the creation
  failure's reason, and it stays silent when every child is created.

Every commit is green on its own. Full suite: 1844 passed, 13 skipped.
`pre-commit` (black + ruff) clean.
