### PR TITLE
Fixed width for time label

### DIFF
--- a/tilia/ui/player.py
+++ b/tilia/ui/player.py
@@ -1,7 +1,7 @@
 from enum import Enum, auto
 
 from PySide6.QtCore import QEvent, Qt
-from PySide6.QtGui import QAction, QIcon
+from PySide6.QtGui import QAction, QFontMetrics, QIcon
 from PySide6.QtWidgets import (
     QDoubleSpinBox,
     QLabel,
@@ -193,7 +193,17 @@ class PlayerToolbar(QToolBar):
 
     def add_time_label(self):
         self.time_label = QLabel(f"{self.current_time_string}/{self.duration_string}")
-        self.time_label.setMargin(3)
+
+        self.time_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        max_time_str = self.duration_string
+        metrics = QFontMetrics(self.time_label.font())
+        calculated_width = (
+            (metrics.horizontalAdvance(max_time_str) * 2)
+            + 20  # fix the width of the time label to be the largest size needed (twice the duration string length) plus a margin of 20px
+        )
+
+        self.time_label.setFixedWidth(calculated_width)
         self.addWidget(self.time_label)
 
     def add_volume_toggle(self):


### PR DESCRIPTION
## Summary

Creates a fixed width for the time label based on the total time duration string (plus a buffer width).
Previously, as the current time string was updated, the entire player bar would shift slightly. This creates a fixed width so the other icons don't move.

## Test plan

Load a file and press play.

## Before:


https://github.com/user-attachments/assets/5f8c8a99-6711-4d65-8262-41d403840cd9



## After


https://github.com/user-attachments/assets/98682bc4-0529-450f-bed6-a9eeebbad94f

