### PR TITLE
feat: make every timeline kind creatable from the CLI

### DIFF
--- a/docs/cli-tutorial.md
+++ b/docs/cli-tutorial.md
@@ -21,25 +21,36 @@ For any command, you can get detailed help and examples by typing a command foll
 
 ```bash
 >>> timelines add --help
-usage: main.py timelines add [-h] [--name NAME] [--height HEIGHT] [--beat-pattern BEAT_PATTERN [BEAT_PATTERN ...]] {hierarchy,hrc,marker,mrk,beat,bea,score,sco}
+usage: main.py timelines add [-h] [--name NAME] [--height HEIGHT] [--beat-pattern BEAT_PATTERN [BEAT_PATTERN ...]] [--row-height DEFAULT_ROW_HEIGHT] [--path PATH]
+                            {audiowave,aud,beat,bea,harmony,har,hierarchy,hrc,marker,mrk,pdf,range,rng,score,sco}
 
 positional arguments:
-  {hierarchy,hrc,marker,mrk,beat,bea,score,sco}
+  {audiowave,aud,beat,bea,harmony,har,hierarchy,hrc,marker,mrk,pdf,range,rng,score,sco}
                         Kind of timeline to add
 
 options:
   -h, --help            show this help message and exit
   --name NAME, -n NAME  Name of the new timeline
   --height HEIGHT, -e HEIGHT
-                        Height of the timeline
+                        Height of the timeline. Not valid for harmony timelines, whose height follows from their level height and visible level count.
   --beat-pattern BEAT_PATTERN [BEAT_PATTERN ...], -b BEAT_PATTERN [BEAT_PATTERN ...]
-                        Pattern as space-separated integers indicating beat count in a measure. Pattern will be repeated. Pattern '3 4', for instance, will alternate measures of 3 and 4 beats.
+                        Pattern as space-separated integers indicating beat count in a measure (beat timelines only). Pattern will be repeated. Pattern '3 4', for instance, will alternate measures
+                        of 3 and 4 beats. Defaults to [4].
+  --row-height DEFAULT_ROW_HEIGHT
+                        Per-timeline default row height (range timelines only). Defaults to the global setting.
+  --path PATH, -p PATH  Path to the PDF file (PDF timelines only). Required for those.
 
 Examples:
   timelines add beat --name "Measures" --beat-pattern 4
   timelines add hierarchy --name "Form"
   timelines add marker --name "Cadences"
+  timelines add harmony --name "Chords"
+  timelines add pdf --name "Score" --path score.pdf
 ```
+
+Every timeline kind can be created from the CLI, by full name or by
+abbreviation. Arguments that don't apply to the chosen kind are rejected
+rather than ignored, so `timelines add harmony --height 50` is an error.
 
 ---
 

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -5,6 +5,9 @@ EXAMPLE_MEDIA_PATH = str(
 ).replace("\\", "/")
 EXAMPLE_MEDIA_DURATION = 9.952
 EXAMPLE_MEDIA_SCALE_FACTOR = EXAMPLE_MEDIA_DURATION / 100
+EXAMPLE_PDF_PATH = str(
+    (Path(__file__).parent / "resources" / "example.pdf").resolve()
+).replace("\\", "/")
 EXAMPLE_MUSICXML_PATH = str(
     (Path(__file__).parent / "resources" / "example.musicxml").resolve()
 ).replace("\\", "/")

--- a/tests/ui/cli/timelines/test_cli_timelines_add.py
+++ b/tests/ui/cli/timelines/test_cli_timelines_add.py
@@ -1,10 +1,36 @@
 from tests.constants import EXAMPLE_MEDIA_PATH, EXAMPLE_PDF_PATH
 from tilia.timelines.audiowave.timeline import AudioWaveTimeline
+from tilia.timelines.base.timeline import Timeline
 from tilia.timelines.beat.timeline import BeatTimeline
 from tilia.timelines.harmony.timeline import HarmonyTimeline
 from tilia.timelines.hierarchy.timeline import HierarchyTimeline
 from tilia.timelines.marker.timeline import MarkerTimeline
 from tilia.timelines.pdf.timeline import PdfTimeline
+from tilia.timelines.slider.timeline import SliderTimeline
+from tilia.ui.cli.timelines.add import (
+    KIND_STR_TO_TIMELINE_CLASS,
+    TIMELINE_CLASS_TO_KWARGS_NAMES,
+)
+
+
+class TestTimelineAddCoverage:
+    """#476 was a kind reachable everywhere else in the app but missing from
+    the CLI's tables. These fail when the next kind is added and not wired up
+    here, rather than letting it go unnoticed again."""
+
+    def test_every_creatable_kind_can_be_added(self):
+        creatable = set(Timeline.subclasses()) - {SliderTimeline}
+
+        assert set(KIND_STR_TO_TIMELINE_CLASS.values()) == creatable
+
+    def test_every_creatable_kind_declares_its_kwargs(self):
+        creatable = set(Timeline.subclasses()) - {SliderTimeline}
+
+        assert set(TIMELINE_CLASS_TO_KWARGS_NAMES) == creatable
+
+    def test_slider_cannot_be_added(self):
+        # It is created with the file and can't be deleted.
+        assert SliderTimeline not in KIND_STR_TO_TIMELINE_CLASS.values()
 
 
 class TestTimelineAdd:

--- a/tests/ui/cli/timelines/test_cli_timelines_add.py
+++ b/tests/ui/cli/timelines/test_cli_timelines_add.py
@@ -1,7 +1,10 @@
-from tests.constants import EXAMPLE_MEDIA_PATH
+from tests.constants import EXAMPLE_MEDIA_PATH, EXAMPLE_PDF_PATH
+from tilia.timelines.audiowave.timeline import AudioWaveTimeline
 from tilia.timelines.beat.timeline import BeatTimeline
+from tilia.timelines.harmony.timeline import HarmonyTimeline
 from tilia.timelines.hierarchy.timeline import HierarchyTimeline
 from tilia.timelines.marker.timeline import MarkerTimeline
+from tilia.timelines.pdf.timeline import PdfTimeline
 
 
 class TestTimelineAdd:
@@ -66,6 +69,84 @@ class TestTimelineAdd:
 
         tl = tls.get_timelines()[0]
         assert tl.beat_pattern == [4]
+
+    def test_add_harmony_timeline(self, cli, tls):
+        cli.parse_and_run("timeline add har --name test")
+
+        tl = tls.get_timelines()[0]
+        assert isinstance(tl, HarmonyTimeline)
+        assert tl.name == "test"
+
+    def test_add_harmony_timeline_full_name(self, cli, tls):
+        cli.parse_and_run("timeline add harmony")
+
+        assert isinstance(tls.get_timelines()[0], HarmonyTimeline)
+
+    def test_add_audiowave_timeline(self, cli, tls, tilia_errors):
+        cli.parse_and_run("load-media " + EXAMPLE_MEDIA_PATH)
+        cli.parse_and_run("timeline add aud --name test")
+
+        tl = tls.get_timelines()[0]
+        assert isinstance(tl, AudioWaveTimeline)
+        assert tl.name == "test"
+        # An audiowave timeline is only useful once refresh() has read the
+        # media and filled it in. Without media, or without a server for
+        # Get.PLAYBACK_AREA_WIDTH, it comes out empty and hidden instead.
+        assert tl.get_data("is_visible")
+        assert len(tl) > 0
+        tilia_errors.assert_no_error()
+
+    def test_add_audiowave_timeline_full_name(self, cli, tls, tilia_errors):
+        cli.parse_and_run("load-media " + EXAMPLE_MEDIA_PATH)
+        cli.parse_and_run("timeline add audiowave")
+
+        assert isinstance(tls.get_timelines()[0], AudioWaveTimeline)
+        tilia_errors.assert_no_error()
+
+    def test_add_audiowave_timeline_without_media_fails(self, cli, tls, tilia_errors):
+        cli.parse_and_run("timeline add audiowave")
+
+        tilia_errors.assert_error()
+        assert not tls.get_timelines()[0].get_data("is_visible")
+
+    def test_add_pdf_timeline(self, cli, tls, tilia_errors):
+        cli.parse_and_run(f"timeline add pdf --name test --path {EXAMPLE_PDF_PATH}")
+
+        tl = tls.get_timelines()[0]
+        assert isinstance(tl, PdfTimeline)
+        assert tl.name == "test"
+        assert tl.get_data("is_pdf_valid")
+        tilia_errors.assert_no_error()
+
+    def test_add_pdf_timeline_without_path_fails(self, cli, tls, tilia_errors):
+        cli.parse_and_run("timeline add pdf --name test")
+
+        assert len(tls) == 0
+        tilia_errors.assert_error()
+        tilia_errors.assert_in_error_message("--path")
+        tilia_errors.assert_in_error_message("pdf")
+
+    def test_height_rejected_for_harmony_kind(self, cli, tls, tilia_errors):
+        cli.parse_and_run("timelines add harmony --name H --height 50")
+
+        assert len(tls) == 0
+        tilia_errors.assert_error()
+        tilia_errors.assert_in_error_message("--height")
+        tilia_errors.assert_in_error_message("harmony")
+
+    def test_height_applied_to_audiowave_kind(self, cli, tls):
+        cli.parse_and_run("load-media " + EXAMPLE_MEDIA_PATH)
+        cli.parse_and_run("timelines add audiowave --name A --height 123")
+
+        assert tls.get_timelines()[0].height == 123
+
+    def test_path_rejected_for_non_pdf_kind(self, cli, tls, tilia_errors):
+        cli.parse_and_run(f"timelines add marker --name M --path {EXAMPLE_PDF_PATH}")
+
+        assert len(tls) == 0
+        tilia_errors.assert_error()
+        tilia_errors.assert_in_error_message("--path")
+        tilia_errors.assert_in_error_message("marker")
 
     def test_row_height_rejected_for_non_range_kind(self, cli, tls, tilia_errors):
         cli.parse_and_run("timelines add marker --name M --row-height 50")

--- a/tilia/errors.py
+++ b/tilia/errors.py
@@ -95,6 +95,10 @@ CLI_ADD_TIMELINE_ARG_NOT_APPLICABLE = Error(
     "Invalid argument",
     "'{}' is not valid for timeline kind '{}'.",
 )
+CLI_ADD_TIMELINE_ARG_REQUIRED = Error(
+    "Missing argument",
+    "'{}' is required for timeline kind '{}'.",
+)
 OPEN_FILE_NOT_FOUND = Error("File not found", "File '{}' not found.")
 OPEN_FILE_INVALID_TLA = Error(
     "Invalid file type", "File '{}' is not a valid .tla file. {}"

--- a/tilia/ui/cli/timelines/add.py
+++ b/tilia/ui/cli/timelines/add.py
@@ -2,10 +2,13 @@ import argparse
 
 import tilia.errors
 from tilia.requests import Get, get
+from tilia.timelines.audiowave.timeline import AudioWaveTimeline
 from tilia.timelines.base.timeline import Timeline
 from tilia.timelines.beat.timeline import BeatTimeline
+from tilia.timelines.harmony.timeline import HarmonyTimeline
 from tilia.timelines.hierarchy.timeline import HierarchyTimeline
 from tilia.timelines.marker.timeline import MarkerTimeline
+from tilia.timelines.pdf.timeline import PdfTimeline
 from tilia.timelines.range.timeline import RangeTimeline
 from tilia.timelines.score.timeline import ScoreTimeline
 from tilia.ui.cli.io import output
@@ -13,12 +16,17 @@ from tilia.ui.cli.io import output
 # Every kind the user can create, with its abbreviation. SliderTimeline is
 # deliberately absent: it comes with the file and can't be deleted.
 KIND_STR_TO_TIMELINE_CLASS: dict[str, type[Timeline]] = {
+    "audiowave": AudioWaveTimeline,
+    "aud": AudioWaveTimeline,
     "beat": BeatTimeline,
     "bea": BeatTimeline,
+    "harmony": HarmonyTimeline,
+    "har": HarmonyTimeline,
     "hierarchy": HierarchyTimeline,
     "hrc": HierarchyTimeline,
     "marker": MarkerTimeline,
     "mrk": MarkerTimeline,
+    "pdf": PdfTimeline,
     "range": RangeTimeline,
     "rng": RangeTimeline,
     "score": ScoreTimeline,
@@ -29,12 +37,20 @@ KIND_STR_TO_TIMELINE_CLASS: dict[str, type[Timeline]] = {
 # table: an optional argument the user passed that isn't listed for their
 # kind is rejected rather than silently dropped.
 TIMELINE_CLASS_TO_KWARGS_NAMES: dict[type[Timeline], list[str]] = {
+    AudioWaveTimeline: ["name", "height"],
     BeatTimeline: ["name", "height", "beat_pattern"],
+    # HarmonyTimeline takes no height: it derives one from level_height and
+    # visible_level_count, and raises TypeError if handed one as well.
+    HarmonyTimeline: ["name"],
     HierarchyTimeline: ["name", "height"],
     MarkerTimeline: ["name", "height"],
+    PdfTimeline: ["name", "height", "path"],
     RangeTimeline: ["name", "height", "default_row_height"],
     ScoreTimeline: ["name", "height"],
 }
+
+# Kwargs a kind can't be constructed without.
+REQUIRED_KWARGS: dict[type[Timeline], list[str]] = {PdfTimeline: ["path"]}
 
 # Optional argument attribute -> the flag to name in error messages.
 # "name" is absent because every kind accepts it.
@@ -42,6 +58,7 @@ OPTIONAL_ARG_TO_FLAG = {
     "beat_pattern": "--beat-pattern",
     "default_row_height": "--row-height",
     "height": "--height",
+    "path": "--path",
 }
 
 
@@ -55,6 +72,8 @@ Examples:
   timelines add beat --name "Measures" --beat-pattern 4
   timelines add hierarchy --name "Form"
   timelines add marker --name "Cadences"
+  timelines add harmony --name "Chords"
+  timelines add pdf --name "Score" --path score.pdf
 """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -67,7 +86,12 @@ Examples:
         "--name", "-n", type=str, default="", help="Name of the new timeline"
     )
     add_subp.add_argument(
-        "--height", "-e", type=int, default=None, help="Height of the timeline"
+        "--height",
+        "-e",
+        type=int,
+        default=None,
+        help="Height of the timeline. Not valid for harmony timelines, whose "
+        "height follows from their level height and visible level count.",
     )
     add_subp.add_argument(
         "--beat-pattern",
@@ -86,6 +110,13 @@ Examples:
         default=None,
         help="Per-timeline default row height (range timelines only). "
         "Defaults to the global setting.",
+    )
+    add_subp.add_argument(
+        "--path",
+        "-p",
+        type=str,
+        default=None,
+        help="Path to the PDF file (PDF timelines only). Required for those.",
     )
     add_subp.set_defaults(func=add)
 
@@ -111,6 +142,15 @@ def add(namespace: argparse.Namespace):
         if getattr(namespace, attr) is not None and attr not in accepted_kwargs:
             tilia.errors.display(
                 tilia.errors.CLI_ADD_TIMELINE_ARG_NOT_APPLICABLE, flag, kind
+            )
+            return
+
+    for attr in REQUIRED_KWARGS.get(tl_type, []):
+        if getattr(namespace, attr) is None:
+            tilia.errors.display(
+                tilia.errors.CLI_ADD_TIMELINE_ARG_REQUIRED,
+                OPTIONAL_ARG_TO_FLAG[attr],
+                kind,
             )
             return
 

--- a/tilia/ui/cli/timelines/add.py
+++ b/tilia/ui/cli/timelines/add.py
@@ -10,6 +10,40 @@ from tilia.timelines.range.timeline import RangeTimeline
 from tilia.timelines.score.timeline import ScoreTimeline
 from tilia.ui.cli.io import output
 
+# Every kind the user can create, with its abbreviation. SliderTimeline is
+# deliberately absent: it comes with the file and can't be deleted.
+KIND_STR_TO_TIMELINE_CLASS: dict[str, type[Timeline]] = {
+    "beat": BeatTimeline,
+    "bea": BeatTimeline,
+    "hierarchy": HierarchyTimeline,
+    "hrc": HierarchyTimeline,
+    "marker": MarkerTimeline,
+    "mrk": MarkerTimeline,
+    "range": RangeTimeline,
+    "rng": RangeTimeline,
+    "score": ScoreTimeline,
+    "sco": ScoreTimeline,
+}
+
+# The creation kwargs each kind accepts. This doubles as the validation
+# table: an optional argument the user passed that isn't listed for their
+# kind is rejected rather than silently dropped.
+TIMELINE_CLASS_TO_KWARGS_NAMES: dict[type[Timeline], list[str]] = {
+    BeatTimeline: ["name", "height", "beat_pattern"],
+    HierarchyTimeline: ["name", "height"],
+    MarkerTimeline: ["name", "height"],
+    RangeTimeline: ["name", "height", "default_row_height"],
+    ScoreTimeline: ["name", "height"],
+}
+
+# Optional argument attribute -> the flag to name in error messages.
+# "name" is absent because every kind accepts it.
+OPTIONAL_ARG_TO_FLAG = {
+    "beat_pattern": "--beat-pattern",
+    "default_row_height": "--row-height",
+    "height": "--height",
+}
+
 
 def setup_parser(subparser):
     add_subp = subparser.add_parser(
@@ -26,18 +60,7 @@ Examples:
     )
     add_subp.add_argument(
         "kind",
-        choices=[
-            "hierarchy",
-            "hrc",
-            "marker",
-            "mrk",
-            "beat",
-            "bea",
-            "score",
-            "sco",
-            "range",
-            "rng",
-        ],
+        choices=list(KIND_STR_TO_TIMELINE_CLASS),
         help="Kind of timeline to add",
     )
     add_subp.add_argument(
@@ -67,52 +90,25 @@ Examples:
     add_subp.set_defaults(func=add)
 
 
-TLKIND_TO_KWARGS_NAMES = {
-    BeatTimeline: ["name", "height", "beat_pattern"],
-    HierarchyTimeline: ["name", "height"],
-    MarkerTimeline: ["name", "height"],
-    RangeTimeline: ["name", "height", "default_row_height"],
-    ScoreTimeline: ["name", "height"],
-}
-
-# arg attr -> (timeline kind it's valid for, flag name for the error message)
-KIND_SPECIFIC_ARGS = {
-    "beat_pattern": (BeatTimeline, "--beat-pattern"),
-    "default_row_height": (RangeTimeline, "--row-height"),
-}
-
-
 def get_kwargs_by_timeline_type(namespace: argparse.Namespace, kind: type[Timeline]):
     kwargs = {}
-    for attr in TLKIND_TO_KWARGS_NAMES[kind]:
+    for attr in TIMELINE_CLASS_TO_KWARGS_NAMES[kind]:
         kwargs[attr] = getattr(namespace, attr)
     return kwargs
 
 
 def add(namespace: argparse.Namespace):
-    KIND_STR_TO_TLKIND = {
-        "hierarchy": HierarchyTimeline,
-        "hrc": HierarchyTimeline,
-        "marker": MarkerTimeline,
-        "mrk": MarkerTimeline,
-        "beat": BeatTimeline,
-        "bea": BeatTimeline,
-        "score": ScoreTimeline,
-        "sco": ScoreTimeline,
-        "range": RangeTimeline,
-        "rng": RangeTimeline,
-    }
-
     if not get(Get.MEDIA_DURATION):
         tilia.errors.display(tilia.errors.CLI_CREATE_TIMELINE_WITHOUT_DURATION)
         return
     kind = namespace.kind
     name = namespace.name
 
-    tl_type = KIND_STR_TO_TLKIND[kind]
+    tl_type = KIND_STR_TO_TIMELINE_CLASS[kind]
+    accepted_kwargs = TIMELINE_CLASS_TO_KWARGS_NAMES[tl_type]
 
-    for attr, (expected_kind, flag) in KIND_SPECIFIC_ARGS.items():
-        if getattr(namespace, attr) is not None and tl_type is not expected_kind:
+    for attr, flag in OPTIONAL_ARG_TO_FLAG.items():
+        if getattr(namespace, attr) is not None and attr not in accepted_kwargs:
             tilia.errors.display(
                 tilia.errors.CLI_ADD_TIMELINE_ARG_NOT_APPLICABLE, flag, kind
             )

--- a/tilia/ui/cli/ui.py
+++ b/tilia/ui/cli/ui.py
@@ -27,6 +27,7 @@ from tilia.ui.cli import (
 )
 from tilia.ui.cli.io import ask_yes_or_no, error, tabulate
 from tilia.ui.cli.player import CLIVideoPlayer, CLIYoutubePlayer
+from tilia.ui.timelines.constants import PLAYBACK_AREA_WIDTH
 
 
 class CLI:
@@ -45,6 +46,12 @@ class CLI:
 
         SERVES = {
             (Get.PLAYER_CLASS, self.get_player_class),
+            # AudioWaveTimeline.refresh() caps its amplitude divisions at the
+            # playback area width. Only QtUI serves this, so without it
+            # `timelines add audiowave` dies on NoReplyToRequest. Report the
+            # same default QtUI starts at, so a timeline built here has the
+            # resolution it would have had in the GUI.
+            (Get.PLAYBACK_AREA_WIDTH, lambda: PLAYBACK_AREA_WIDTH),
             (Get.FROM_USER_YES_OR_NO, on_ask_yes_or_no),
             (Get.FROM_USER_SHOULD_SAVE_CHANGES, on_ask_should_save_changes),
             (Get.FROM_USER_RETRY_MEDIA_PATH, on_ask_retry_media_file),


### PR DESCRIPTION
## Summary

Makes every timeline kind the app can create reachable from `timelines add`, and fixes the reason the audiowave kind couldn't have worked there.

Supersedes #483, which added `harmony` and `audiowave` against a base that has since moved on ~209 commits (the `TimelineKind` enum it was written against no longer exists). This is a fresh implementation on `dev`.

Closes #476.

## What changed

**`audiowave` was broken before it was exposed.** `Timelines.create_timeline` calls `AudioWaveTimeline.refresh()` for new audiowave timelines, and `refresh()` caps its amplitude divisions at `Get.PLAYBACK_AREA_WIDTH` — a request only `QtUI` ever served. Adding one from the CLI therefore raised `NoReplyToRequest`, which `CLI.run` catches and reports as a raw Python traceback under "CLI error", leaving a timeline with no components behind. With no media loaded it instead failed earlier and produced a hidden, empty timeline. There was no input for which the command worked.

The CLI now serves that request with the same default `QtUI` starts at, so an audiowave timeline built headless has the resolution it would have had in the GUI.

**New kinds.** `harmony`/`har`, `audiowave`/`aud`, and `pdf`. `slider` stays out on purpose — it comes with the file and can't be deleted. With those, all eight creatable kinds are available.

**PDF takes `--path`.** The GUI collects the file through a dialog with no CLI equivalent, so the path comes from a flag instead, and the kind is rejected up front when it's missing rather than letting `PdfTimeline` fail on a required positional.

**`--height` is now checked rather than dropped.** Harmony computes its height from `level_height` and `visible_level_count`, and passing one raises `TypeError` inside `HarmonyTimeline.__init__` — so the flag is rejected with a message. Audiowave is an ordinary `Timeline` in this respect, so `--height` applies to it normally.

**One kind table instead of three.** `choices` and `KIND_STR_TO_TLKIND` were the same key set written twice, with `KIND_SPECIFIC_ARGS` a third hand-written arg-to-kind mapping alongside them. `choices` is now derived from the kind table, and optional arguments are validated against the per-kind kwargs table, so a kind that gains or loses a kwarg gets the right validation for free. That commit is behaviour-preserving and the pre-existing tests cover it.

## On #476 specifically

The issue wasn't a logic error but a bookkeeping one: a kind reachable everywhere else in the app was simply missing from one list, and nothing noticed. Adding the missing kinds fixes today's symptom; the last commit compares the CLI's tables against `Timeline.subclasses()` so the next kind added to the app fails there until it's wired up.

## Test plan

- [x] `pytest` — full suite
- [x] Real CLI, not just tests: `load-media example.mp3` then `timelines add audiowave/harmony/pdf` all create cleanly, no traceback
- [x] The audiowave tests fail without the `Get.PLAYBACK_AREA_WIDTH` fix (`assert 0 > 0`, then `assert_no_error`) — they're real regression guards, not name-and-type assertions that a hidden empty timeline would also satisfy
- [x] The coverage test fails when a kind is removed from the table
- [x] `pre-commit run` on all changed files

## Not in scope

Nothing stops a user creating N audiowave timelines, each re-decoding the same media. That's identical in the GUI, so it's a pre-existing question about `create_timeline` rather than something this change introduces. Happy to open it separately if it's worth a guard.
