### PR TITLE
fix: keep measures_to_force_display a valid set of in-range indices

### DIFF
--- a/tests/timelines/beat/test_beat_timeline.py
+++ b/tests/timelines/beat/test_beat_timeline.py
@@ -254,6 +254,20 @@ class TestBeatTimeline:
         assert beat_tl.measure_numbers == [1, 2, 10, 11, 5, 6]
         assert beat_tl.measures_to_force_display == [4, 2]
 
+    def test_set_measure_number_twice_forces_display_once(self, beat_tl):
+        beat_tl.measure_numbers = [1, 2, 3, 4]
+        beat_tl.set_measure_number(1, 10)
+        beat_tl.set_measure_number(1, 10)
+        assert beat_tl.measures_to_force_display == [1]
+
+    def test_reset_measure_number_unforces_display_after_repeated_sets(self, beat_tl):
+        beat_tl.measure_numbers = [1, 2, 3, 4]
+        beat_tl.set_measure_number(1, 10)
+        beat_tl.set_measure_number(1, 20)
+        beat_tl.set_measure_number(1, 30)
+        beat_tl.reset_measure_number(1)
+        assert beat_tl.measures_to_force_display == []
+
     def test_reset_measure_number_first_measure(self, beat_tl):
         beat_tl.measure_numbers = [1, 2, 3, 4]
         beat_tl.set_measure_number(0, 10)

--- a/tests/timelines/beat/test_beat_timeline.py
+++ b/tests/timelines/beat/test_beat_timeline.py
@@ -268,6 +268,23 @@ class TestBeatTimeline:
         beat_tl.reset_measure_number(1)
         assert beat_tl.measures_to_force_display == []
 
+    def test_reduce_measure_numbers_drops_forced_display_out_of_range(self, beat_tl):
+        beat_tl.set_data("beat_pattern", [1])
+        for i in range(5):
+            beat_tl.create_beat(time=i + 1)
+        beat_tl.recalculate_measures()
+
+        # forcing a later measure first leaves the list unsorted
+        beat_tl.set_measure_number(4, 40)
+        beat_tl.set_measure_number(1, 10)
+        assert beat_tl.measures_to_force_display == [4, 1]
+
+        beat_tl.delete_components([beat_tl[2], beat_tl[3], beat_tl[4]])
+        beat_tl.recalculate_measures()
+
+        assert beat_tl.measure_count == 2
+        assert beat_tl.measures_to_force_display == [1]
+
     def test_reset_measure_number_first_measure(self, beat_tl):
         beat_tl.measure_numbers = [1, 2, 3, 4]
         beat_tl.set_measure_number(0, 10)

--- a/tests/ui/timelines/beat/test_beat_timeline_ui.py
+++ b/tests/ui/timelines/beat/test_beat_timeline_ui.py
@@ -422,6 +422,21 @@ class TestSetMeasureNumber:
         commands.execute("edit.redo")
         assert beat_tlui.timeline.measure_numbers[0] == 1
 
+    def test_reset_measure_number_hides_label_set_more_than_once(self, beat_tlui):
+        settings.set("beat_timeline", "display_measure_periodicity", 4)
+        beat_tlui.timeline.beat_pattern = [1]
+        for i in range(4):
+            beat_tlui.create_beat(i)
+
+        beat_tlui.select_element(beat_tlui[1])
+        self._set_measure_number()
+        self._set_measure_number()
+        assert get_displayed_measure_number(beat_tlui[1]) == str(DUMMY_MEASURE_NUMBER)
+
+        commands.execute("timeline.beat.reset_measure_number")
+
+        assert get_displayed_measure_number(beat_tlui[1]) == ""
+
     def test_measure_zero_number_is_not_displayed(self, beat_tlui):
         settings.set("beat_timeline", "display_measure_periodicity", 2)
         beat_tlui.timeline.beat_pattern = [1]

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -617,7 +617,8 @@ class BeatTimeline(Timeline):
 
     def force_display_measure_number(self, measure_index: int) -> None:
         self.clear_cached_metric_positions()
-        self.measures_to_force_display.append(measure_index)
+        if measure_index not in self.measures_to_force_display:
+            self.measures_to_force_display.append(measure_index)
 
     def unforce_display_measure_number(self, measure_index: int) -> None:
         self.clear_cached_metric_positions()

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -508,12 +508,11 @@ class BeatTimeline(Timeline):
         if not extra_measure_count:
             return
         self.measure_numbers = self.measure_numbers[:-extra_measure_count]
-        if self.measures_to_force_display:
-            while (
-                self.measures_to_force_display
-                and self.measures_to_force_display[-1] >= self.measure_count
-            ):
-                self.measures_to_force_display.pop(-1)
+        # measures_to_force_display is not sorted, so every index has to be
+        # checked, not just the ones at the end of the list.
+        self.measures_to_force_display = [
+            i for i in self.measures_to_force_display if i < self.measure_count
+        ]
 
     def update_beats_that_start_measures(self):
         # noinspection PyAttributeOutsideInit


### PR DESCRIPTION
## Summary

Two independent bugs in how `BeatTimeline` maintains `measures_to_force_display`. The list is treated everywhere as a set of in-range measure indices, but nothing enforced either property.

**1. The same measure could be forced twice.** `force_display_measure_number` appended unconditionally, so setting a measure number to a value it already had left a second entry. `unforce_display_measure_number` removes a *single* occurrence, so one "Reset measure number" was no longer enough to hide the label again — and the duplicates were written to the `.tla` file.

Easy to hit by accident, since the number is applied to every selected measure: re-confirming a number for one measure re-forces all of them.

**2. Out-of-range indices survived pruning.** `reduce_measure_numbers` popped from the *tail* of the list while the last index was out of range. But the list is appended to in the order the user edits measures and is never sorted, so an out-of-range index sitting before an in-range one was left behind. Those stale indices are saved to the file and resurface as spuriously displayed measure numbers once the timeline grows back.

Found while reviewing #480, but independent of it — opened off `dev` rather than folded into that branch.

## Test plan

- [x] `test_set_measure_number_twice_forces_display_once` — backend, fails on `dev` with `[1, 1] == [1]`
- [x] `test_reset_measure_number_unforces_display_after_repeated_sets` — backend, fails on `dev` with `[1, 1] == []`
- [x] `test_reduce_measure_numbers_drops_forced_display_out_of_range` — backend, fails on `dev` with `[4, 1] == [1]`
- [x] `test_reset_measure_number_hides_label_set_more_than_once` — end-to-end through the commands; fails on `dev` with `'2' == ''`, i.e. the label stays visible after Reset
- [x] Full suite green (1834 passed, 13 skipped, 2 xfailed, 2 xpassed)
- [x] Randomised fuzz over the beat commands (25 seeds x 200 steps of set/reset measure number, set beats in measure, add, delete, distribute) checking the two invariants: 138 violations before, 0 after

## Manual check

1. Beat timeline, several measures, "Measure number periodicity" set so a middle measure is normally hidden.
2. Right-click a beat in that measure, "Set measure number", give it a number — the label appears.
3. Repeat step 2 with the same number.
4. "Reset measure number" — before this change the label stayed visible; it should now disappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)