### PR TITLE
fix: adding a beat could wipe a beat timeline after "Set amount in measure"

### DIFF
--- a/tests/timelines/beat/test_beat_timeline.py
+++ b/tests/timelines/beat/test_beat_timeline.py
@@ -1,5 +1,6 @@
 import pytest
 
+from tilia.timelines.beat.timeline import BeatTimeline
 from tilia.ui import commands
 
 
@@ -436,3 +437,27 @@ class TestBeatTimeline:
 
         assert len(tilia.timelines[0]) == 11
         assert tilia.timelines[0][-1].get_data("time") == 10
+
+
+class TestGetExtensionFromBeatPattern:
+    def test_starting_measure_emptier_than_beat_pattern(self):
+        extension = BeatTimeline.get_extension_from_beat_pattern(
+            [4], 3, beats_on_starting_measure=2
+        )
+        assert extension == [2, 1]
+
+    def test_starting_measure_as_full_as_beat_pattern(self):
+        extension = BeatTimeline.get_extension_from_beat_pattern(
+            [4], 3, beats_on_starting_measure=4
+        )
+        assert extension == [3]
+
+    def test_starting_measure_fuller_than_beat_pattern(self):
+        """ "Set amount in measure" can put more beats in a measure than the
+        beat pattern prescribes for it. There is nothing left to fill in that
+        case, so the extension has to start a new measure.
+        """
+        extension = BeatTimeline.get_extension_from_beat_pattern(
+            [4], 3, beats_on_starting_measure=5
+        )
+        assert extension == [3]

--- a/tests/ui/timelines/beat/test_beat_timeline_ui.py
+++ b/tests/ui/timelines/beat/test_beat_timeline_ui.py
@@ -509,6 +509,29 @@ class TestSetBeatAmountInMeasure:
 
         assert [get_displayed_measure_number(b) for b in beat_tlui] == ["1", "", "2"]
 
+    def test_add_beat_when_last_measure_is_fuller_than_beat_pattern(self, beat_tlui):
+        beat_tlui.timeline.beat_pattern = [4]
+        for i in range(24):
+            beat_tlui.create_beat(i / 10)
+
+        # give a middle measure one beat more than the beat pattern prescribes
+        beat_tlui.select_element(beat_tlui[16])
+        with Serve(Get.FROM_USER_INT, (True, 5)):
+            commands.execute("timeline.beat.set_amount_in_measure")
+
+        # then make that measure the last one
+        beat_tlui.deselect_all_elements()
+        for element in list(beat_tlui)[-3:]:
+            beat_tlui.select_element(element)
+        commands.execute("timeline.component.delete")
+        assert beat_tlui.timeline.beats_in_measure == [4, 4, 4, 4, 5]
+
+        commands.execute("media.seek", 3.0)
+        commands.execute("timeline.beat.add")
+
+        assert len(beat_tlui) == 22
+        assert beat_tlui.timeline.beats_in_measure == [4, 4, 4, 4, 5, 1]
+
 
 class TestFillWithBeats:
     @pytest.fixture(autouse=True)

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -417,13 +417,13 @@ class BeatTimeline(Timeline):
                 diff = beats - beats_on_starting_measure
                 extension = [min(diff, amount)]
                 remaining_beats = amount - diff
-            elif beats_on_starting_measure == beats:
+            else:
+                # A measure may hold more beats than the beat pattern
+                # prescribes for it, as "Set amount in measure" sets an
+                # arbitrary amount. There is nothing left to fill in that
+                # case, so the extension starts a new measure.
                 extension = []
                 remaining_beats = amount
-            else:
-                raise ValueError(
-                    "More beats on starting measure than found in the iterator"
-                )
         else:
             extension = []
             remaining_beats = amount
@@ -472,7 +472,7 @@ class BeatTimeline(Timeline):
 
         bp_index = (self.measure_count % len(self.beat_pattern)) - 1
         is_last_measure_complete = (
-            self._beats_in_measure[-1] == self.beat_pattern[bp_index]
+            self._beats_in_measure[-1] >= self.beat_pattern[bp_index]
         )
 
         if is_last_measure_complete:


### PR DESCRIPTION
## Summary

"Set amount in measure" puts an arbitrary number of beats in a measure — that is the point of the feature. So `beats_in_measure[-1]` can legitimately hold **more** beats than the beat pattern prescribes for that slot.

`get_extension_from_beat_pattern` treated that as impossible and raised:

```
ValueError: More beats on starting measure than found in the iterator
```

and `extend_beats_in_measure` only recognised an *exactly* full measure as complete, so it would have grown the over-full measure further rather than starting a new one.

**The data loss.** Adding a beat in that state raises out of `recalculate_measures`. `TimelineUIs.on_timeline_command` recovers by restoring the snapshot it took before the command — but restoring re-runs `recalculate_measures`, hits the same exception, and aborts *after* clearing the timeline. The user gets an error dialog and an **empty beat timeline**; every beat is gone.

Both places now treat a measure at or over its prescribed size as full, so the extension starts a new measure.

## Reproducing on `dev`

1. Beat timeline with beat pattern `4`, add 24 beats → `beats_in_measure == [4, 4, 4, 4, 4, 4]`
2. Select a beat in the 5th measure, "Set amount in measure" → `5` → `[4, 4, 4, 4, 5, 3]`
3. Delete the last 3 beats, so the over-full measure becomes the last one → `[4, 4, 4, 4, 5]`
4. Add a beat → "Command failed" dialog, and the timeline is left with **0 beats**

With this change step 4 gives `[4, 4, 4, 4, 5, 1]` and all 22 beats are present.

## Test plan

- [x] `test_add_beat_when_last_measure_is_fuller_than_beat_pattern` — end-to-end through the commands, walks the steps above; raises on `dev`
- [x] `test_starting_measure_fuller_than_beat_pattern` — the previously-raising case; `get_extension_from_beat_pattern` was otherwise untested, so the two neighbouring cases (emptier / exactly as full) are pinned alongside it
- [x] Beat suites green, and the rest of the suite unaffected (the 3 `tests/test_app.py` failures under `pytest -n auto` reproduce on `dev` without this change and pass serially)
- [x] Randomised fuzz over the beat commands (25 seeds x 200 steps of set/reset measure number, set beats in measure, add, delete, distribute): 12 of 25 seeds hit the crash on `dev`, 0 of 25 with this change

Found by fuzzing while reviewing #480; independent of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)