### PR TITLE
test: isolate the settings store from the user's own and from other tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
+import copy
 import functools
+import os
 import sys
 from pathlib import Path
 from typing import Literal
@@ -8,7 +10,6 @@ from colorama import Fore, Style
 from PySide6.QtCore import QSettings
 from PySide6.QtWidgets import QApplication
 
-import tilia.constants as constants_module
 import tilia.log as logging_module
 import tilia.settings as settings_module
 import tilia.utils  # noqa: F401
@@ -204,12 +205,51 @@ def resources() -> Path:
     return Path(__file__).parent / "resources"
 
 
+@pytest.fixture(scope="session", autouse=True)
+def isolate_settings(tmp_path_factory):
+    """Point the settings manager at a throwaway store for the whole session.
+
+    Settings are backed by a real QSettings store, so anything a test writes
+    outlives it. Pointing the tests at a *named* store meant those values
+    leaked into later tests, into the other xdist workers and into subsequent
+    runs; and any test that ran before a module requesting the test store
+    wrote to the developer's own settings instead.
+
+    Autouse and session-scoped so that no test can reach the real store,
+    whichever fixtures it happens to request.
+    """
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    path = tmp_path_factory.mktemp("settings") / f"{worker}.ini"
+    settings_module.settings._settings = QSettings(
+        str(path), QSettings.Format.IniFormat
+    )
+    _reset_settings_to_default()
+    yield
+
+
+def _reset_settings_to_default():
+    settings_module.settings._settings.clear()
+    settings_module.settings._cache = {}
+    settings_module.settings._check_all_default_settings_present()
+
+
+@pytest.fixture(autouse=True)
+def restore_settings_after_test(isolate_settings):
+    """Undo any setting a test writes.
+
+    Tests are expected to set the values they depend on explicitly, which only
+    works if the next test does not inherit them.
+    """
+    before = copy.deepcopy(settings_module.settings._cache)
+    yield
+    settings_module.settings._cache = before
+    for group_name, group in before.items():
+        for name, value in group.items():
+            settings_module.settings._set(group_name, name, value)
+
+
 @pytest.fixture(scope="module")
 def use_test_settings(qapplication):
-    settings_module.settings._settings = QSettings(
-        constants_module.APP_NAME, "DesktopTests", None
-    )
-    settings_module.settings._check_all_default_settings_present()
     settings_module.settings.set("general", "prioritise_performance", True)
     yield
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -492,7 +492,10 @@ class TestFileSetup:
 
 def assert_open_failed(tilia, tilia_errors, opened_file_path, prev_file):
     tilia_errors.assert_error()
-    assert settings.get_recent_files()[0] != opened_file_path
+    # get_recent_files returns posix strings, so the path has to be converted
+    # before comparing; `!= opened_file_path` compared a str to a Path and was
+    # therefore always true.
+    assert Path(opened_file_path).as_posix() not in settings.get_recent_files()
     assert tilia.file_manager.file == prev_file
 
 

--- a/tests/test_settings_isolation.py
+++ b/tests/test_settings_isolation.py
@@ -1,0 +1,25 @@
+from tilia.settings import settings
+
+PERIODICITY = ("beat_timeline", "display_measure_periodicity")
+DEFAULT_PERIODICITY = 4
+
+
+class TestSettingsIsolation:
+    """Settings are backed by a real QSettings store, so anything a test writes
+    outlives it unless the suite isolates and restores the store. Without that,
+    a value set here leaks into later tests, into the other xdist workers and
+    into subsequent runs.
+    """
+
+    def test_settings_are_not_stored_in_the_users_own_store(self):
+        assert settings._settings.fileName().endswith(".ini")
+
+    def test_setting_starts_at_its_default(self):
+        assert settings.get(*PERIODICITY) == DEFAULT_PERIODICITY
+
+    def test_setting_can_be_changed(self):
+        settings.set(*PERIODICITY, 7)
+        assert settings.get(*PERIODICITY) == 7
+
+    def test_setting_changed_by_previous_test_was_restored(self):
+        assert settings.get(*PERIODICITY) == DEFAULT_PERIODICITY


### PR DESCRIPTION
## Summary

The suite pointed the settings manager at `QSettings(APP_NAME, "DesktopTests")` — a **real, named, persistent** store that is never cleared — and it did so from a *module-scoped* fixture (`use_test_settings`) that most tests never request. Two problems follow.

**1. Settings leak out of the test that set them.** Because the store is a real file, a `settings.set(...)` outlives the test. It leaks into later tests, into the other xdist workers (which share the file), and into every subsequent run. This is the cause of the intermittent `pytest -n auto` failures in `tests/test_app.py` and in `test_file_with_measures_to_force_display` that pass when run serially.

It is not theoretical — on my machine the store had kept:

- `editable.beat_timeline.display_measure_periodicity = 2`, where the default is `4`. Every run started with the wrong value.
- **14,722** `private.recent_files.*` entries pointing at long-deleted pytest tmpdirs, from runs going back many sessions (`pytest-4`, `pytest-73/popen-gw3`, `pytest-129`, …). 7.8 MB of accumulated state that every run read from.

**2. Tests wrote to the developer's own settings.** `tilia` and `tls` don't depend on `use_test_settings`, and the fixture never restores the previous store, so which store a test got depended on module order within the worker. Any test running before a module that requested the fixture used the **real** store — my own `com.tilia.Desktop Settings.plist` had accumulated **298 of its 1000 keys** as recent-file entries from test runs.

## The change

- The store is a throwaway `.ini` in the pytest tmp dir, one per xdist worker.
- Installed **session-scoped and autouse**, so no test can reach the real store whichever fixtures it requests.
- Every setting a test writes is restored afterwards, so tests can rely on defaults — which is what `CLAUDE.md` already tells contributors to expect ("set the values you depend on explicitly inside each test").
- `use_test_settings` keeps doing its other job (`prioritise_performance`).

`assert_open_failed` needed a fix to land this: it compared a `str` to a `Path`, so it was *always* true and had never asserted anything. It only surfaced now because it also indexed `get_recent_files()[0]`, and that list is legitimately empty once recent files stop leaking between tests. Corrected to compare like-for-like; it passes, so a failed open is correctly not recorded as recent.

## Test plan

- [x] `tests/test_settings_isolation.py` — pins both properties: the store is not the user's own, and a setting written by one test is restored before the next. 4 pass here; 2 of them fail on `dev`.
- [x] Leak across processes demonstrated directly: on `dev`, one process writes `display_measure_periodicity = 7` and a **separate** process then reads back `7` instead of the default `4`. With this change the second process reads `4`.
- [x] Full suite green under `pytest -n auto`, twice: 1834 passed, 13 skipped, 2 xfailed, 2 xpassed.
- [x] Previously-flaky selection (`tests/test_app.py` + `tests/ui/timelines/beat/`) run 5x under `-n auto`: 136 passed each time.
- [x] Neither plist is touched by a full run any more — both key counts unchanged (14813 / 1000), and the real store's size and mtime are byte-identical before and after.

## Note for maintainers

The two stale stores are now unused but still on disk. On macOS they can be dropped with:

```bash
defaults delete com.tilia.DesktopTests
```

The real store keeps its test-written recent-file entries; clearing those is a user-facing action, so I have left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)