### PR TITLE
fix(score): rebuild viewer beat positions when a score is re-imported

### DIFF
--- a/tests/ui/timelines/score/test_score_timeline_ui.py
+++ b/tests/ui/timelines/score/test_score_timeline_ui.py
@@ -11,7 +11,7 @@ from tests.mock import (
     patch_yes_or_no_dialog,
 )
 from tests.utils import get_blank_file_data, reloadable
-from tilia.errors import SCORE_STAFF_ID_ERROR
+from tilia.errors import SCORE_STAFF_ID_ERROR, SCORE_SVG_CREATE_ERROR
 from tilia.parsers.score.musicxml import notes_from_musicXML
 from tilia.requests import Get, Post, get, post
 from tilia.timelines.component_kinds import ComponentKind
@@ -314,3 +314,129 @@ def test_symbol_staff_collision(qtui, tmp_path):
     )
 
     assert staff_top_y_sans_symbols < staff_top_y_with_symbols
+
+
+MARKER_FONT_SIZE = "0.000009999999999999999px"
+
+
+def _svg_with_beat_markers(*markers: tuple[int, int, int, int]) -> str:
+    """Build an SVG carrying the near-invisible `measure␟division␟divisions`
+    text markers the score viewer reads beat positions from. Each marker is
+    (measure, division, divisions per measure, x).
+    """
+    elements = "".join(
+        f'<g class="vf-text">'
+        f'<text font-size="{MARKER_FONT_SIZE}" x="{x}" y="0">{m}␟{d}␟{divs}</text>'
+        f"</g>"
+        for m, d, divs, x in markers
+    )
+    return f'<svg width="1000" height="200">{elements}</svg>'
+
+
+SVG_WITHOUT_MARKERS = '<svg width="1000" height="200"/>'
+SVG_FIRST_SCORE = _svg_with_beat_markers((1, 0, 32, 100), (1, 16, 32, 150))
+SVG_SECOND_SCORE = _svg_with_beat_markers((1, 0, 32, 900), (1, 16, 32, 950))
+BEAT_X_FIRST_SCORE = {1.0: 100.0, 1.5: 150.0}
+BEAT_X_SECOND_SCORE = {1.0: 900.0, 1.5: 950.0}
+
+
+class TestViewerBeatPositions:
+    @staticmethod
+    def _import_score(tls, score_tlui, svg: str) -> None:
+        """Stand in for the musicXML import, which reaches the timeline as a
+        single `svg_data` write once the web engine has produced the SVG.
+        """
+        tls.set_timeline_data(score_tlui.id, "svg_data", svg)
+
+    @staticmethod
+    def _clear(score_tlui) -> None:
+        with Serve(Get.FROM_USER_YES_OR_NO, True):
+            commands.execute("timeline.clear", score_tlui)
+
+    def test_beat_positions_come_from_the_imported_score(self, score_tlui, tls):
+        self._import_score(tls, score_tlui, SVG_FIRST_SCORE)
+
+        assert score_tlui.get_data("viewer_beat_x") == BEAT_X_FIRST_SCORE
+        assert score_tlui.svg_view.beat_x_position == BEAT_X_FIRST_SCORE
+
+    def test_clear_drops_beat_positions(self, score_tlui, note, tls):
+        self._import_score(tls, score_tlui, SVG_FIRST_SCORE)
+
+        self._clear(score_tlui)
+
+        assert score_tlui.get_data("viewer_beat_x") == {}
+
+    def test_score_imported_after_clear_uses_its_own_beat_positions(
+        self, score_tlui, note, tls
+    ):
+        self._import_score(tls, score_tlui, SVG_FIRST_SCORE)
+        self._clear(score_tlui)
+
+        self._import_score(tls, score_tlui, SVG_SECOND_SCORE)
+
+        assert score_tlui.get_data("viewer_beat_x") == BEAT_X_SECOND_SCORE
+        assert score_tlui.svg_view.beat_x_position == BEAT_X_SECOND_SCORE
+
+    def test_score_imported_over_another_uses_its_own_beat_positions(
+        self, score_tlui, tls
+    ):
+        self._import_score(tls, score_tlui, SVG_FIRST_SCORE)
+
+        self._import_score(tls, score_tlui, SVG_SECOND_SCORE)
+
+        assert score_tlui.get_data("viewer_beat_x") == BEAT_X_SECOND_SCORE
+        assert score_tlui.svg_view.beat_x_position == BEAT_X_SECOND_SCORE
+
+    def test_beat_positions_survive_saving_and_reloading(
+        self, score_tlui, note, tls, tmp_path
+    ):
+        self._import_score(tls, score_tlui, SVG_FIRST_SCORE)
+
+        @reloadable(tmp_path / "file.tla")
+        def check() -> None:
+            score = get(Get.TIMELINE_UI_BY_ATTR, "timeline_class", ScoreTimeline)
+            assert score.get_data("viewer_beat_x") == BEAT_X_FIRST_SCORE
+
+    def test_score_saved_without_markers_falls_back_to_stored_positions(
+        self, score_tlui, tls, tilia_errors
+    ):
+        # Files saved before the markers were kept in `svg_data` hold a
+        # stripped SVG, so the mapping saved with them is the only source left.
+        tls.set_timeline_data(score_tlui.id, "viewer_beat_x", BEAT_X_FIRST_SCORE)
+
+        tls.set_timeline_data(score_tlui.id, "svg_data", SVG_WITHOUT_MARKERS)
+
+        assert score_tlui.svg_view.beat_x_position == BEAT_X_FIRST_SCORE
+        tilia_errors.assert_no_error()
+
+    def test_score_without_any_beat_positions_reports_an_error(
+        self, score_tlui, tls, tilia_errors
+    ):
+        self._import_score(tls, score_tlui, SVG_WITHOUT_MARKERS)
+
+        tilia_errors.assert_in_error_title(SCORE_SVG_CREATE_ERROR.title)
+
+    def test_undo_redo_across_clear_and_reimport(
+        self, score_tlui, note, tls, tilia_errors
+    ):
+        self._import_score(tls, score_tlui, SVG_FIRST_SCORE)
+        post(Post.APP_STATE_RECORD, "import first score")
+        self._clear(score_tlui)  # the clear command records the state itself
+        self._import_score(tls, score_tlui, SVG_SECOND_SCORE)
+        post(Post.APP_STATE_RECORD, "import second score")
+
+        commands.execute("edit.undo")
+        assert score_tlui.get_data("viewer_beat_x") == {}
+
+        commands.execute("edit.undo")
+        assert score_tlui.get_data("viewer_beat_x") == BEAT_X_FIRST_SCORE
+        assert score_tlui.svg_view.beat_x_position == BEAT_X_FIRST_SCORE
+
+        commands.execute("edit.redo")
+        assert score_tlui.get_data("viewer_beat_x") == {}
+
+        commands.execute("edit.redo")
+        assert score_tlui.get_data("viewer_beat_x") == BEAT_X_SECOND_SCORE
+        assert score_tlui.svg_view.beat_x_position == BEAT_X_SECOND_SCORE
+
+        tilia_errors.assert_no_error()

--- a/tests/ui/windows/test_svg_viewer.py
+++ b/tests/ui/windows/test_svg_viewer.py
@@ -14,10 +14,10 @@ def _make_svg(*texts):
     return root
 
 
-class TestStripBeatXMarkers:
+class TestGetBeatXPos:
     def test_removes_three_part_marker_with_zero_font(self):
         root = _make_svg(("0.000009999999999999999px", "1␟0␟32"))
-        SvgViewer._strip_beat_x_markers(root)
+        SvgViewer._get_beat_x_pos(root)
         assert root.findall(".//g[@class='vf-text']") == []
 
     def test_removes_all_markers_from_fixture_shape(self):
@@ -30,19 +30,19 @@ class TestStripBeatXMarkers:
                 for b in range(8)
             ]
         )
-        SvgViewer._strip_beat_x_markers(root)
+        SvgViewer._get_beat_x_pos(root)
         assert root.findall(".//g[@class='vf-text']") == []
 
     def test_keeps_text_with_normal_font_size(self):
         root = _make_svg(("15px", "regular text"))
-        SvgViewer._strip_beat_x_markers(root)
+        SvgViewer._get_beat_x_pos(root)
         assert len(root.findall(".//g[@class='vf-text']")) == 1
 
     def test_bumps_font_size_for_tiny_non_marker_text(self):
         # Tiny font size but text is NOT a 3-part marker → bump to 15px,
         # keep the element so it renders at a sane size.
         root = _make_svg(("0.5px", "annotation"))
-        SvgViewer._strip_beat_x_markers(root)
+        SvgViewer._get_beat_x_pos(root)
         kept = root.findall(".//g[@class='vf-text']")
         assert len(kept) == 1
         assert kept[0][0].attrib["font-size"] == "15px"
@@ -51,19 +51,19 @@ class TestStripBeatXMarkers:
         root = etree.Element("svg")
         g = etree.SubElement(root, "g", attrib={"class": "vf-text"})
         etree.SubElement(g, "text").text = "anything"  # no font-size attr
-        SvgViewer._strip_beat_x_markers(root)
+        SvgViewer._get_beat_x_pos(root)
         # Should not raise; element kept since we can't tell what to do.
         assert len(root.findall(".//g[@class='vf-text']")) == 1
 
     def test_handles_unparseable_font_size(self):
         root = _make_svg(("not-a-number", "anything"))
-        SvgViewer._strip_beat_x_markers(root)
+        SvgViewer._get_beat_x_pos(root)
         assert len(root.findall(".//g[@class='vf-text']")) == 1
 
     def test_handles_empty_g_wrapper(self):
         root = etree.Element("svg")
         etree.SubElement(root, "g", attrib={"class": "vf-text"})  # no children
-        SvgViewer._strip_beat_x_markers(root)  # should not raise
+        SvgViewer._get_beat_x_pos(root)  # should not raise
 
     def test_mixed_content_keeps_only_real_glyphs(self):
         root = _make_svg(
@@ -72,7 +72,7 @@ class TestStripBeatXMarkers:
             ("0.5px", "annotation"),  # tiny non-marker, kept w/ 15px
             ("0.000009999999999999999px", "5␟4␟32"),  # marker, removed
         )
-        SvgViewer._strip_beat_x_markers(root)
+        SvgViewer._get_beat_x_pos(root)
         kept = root.findall(".//g[@class='vf-text']")
         assert len(kept) == 2
         kept_texts = sorted(g[0].text for g in kept)

--- a/tilia/timelines/score/timeline.py
+++ b/tilia/timelines/score/timeline.py
@@ -108,11 +108,15 @@ class ScoreTimeline(Timeline):
 
     @viewer_beat_x.setter
     def viewer_beat_x(self, x_pos: dict[float, float] | None = None):
-        if x_pos:
-            self._viewer_beat_x = x_pos
+        self._viewer_beat_x = x_pos or {}
 
-    def save_svg_data(self, svg_data):
-        self._svg_data = svg_data
+    def clear(self):
+        # `svg_data` and `viewer_beat_x` describe the score being removed, so
+        # they have to go together. Keeping either one would make a score
+        # imported afterwards render against the previous score's data.
+        self.svg_data = ""
+        self.viewer_beat_x = {}
+        super().clear()
 
     @property
     def staff_count(self):

--- a/tilia/ui/timelines/score/timeline.py
+++ b/tilia/ui/timelines/score/timeline.py
@@ -59,7 +59,7 @@ class ScoreTimelineUI(TimelineUI):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.UPDATE_TRIGGERS = self.UPDATE_TRIGGERS + ["svg_data"]
+        self.UPDATE_TRIGGERS = self.UPDATE_TRIGGERS + ["svg_data", "viewer_beat_x"]
         listen(
             self,
             Post.SETTINGS_UPDATED,
@@ -472,10 +472,30 @@ class ScoreTimelineUI(TimelineUI):
             self.measure_tracker.show()
 
     def update_svg_data(self) -> None:
+        self._reload_svg_view()
+
+    def update_viewer_beat_x(self) -> None:
+        self._reload_svg_view()
+
+    def _reload_svg_view(self) -> None:
+        # `svg_data` and `viewer_beat_x` are restored one attribute at a time,
+        # so the viewer may be reloaded while only half of the pair has been
+        # applied. Reloading on both means whichever arrives second leaves the
+        # viewer consistent.
+        if not self.timeline.svg_data:
+            self.reset_svg()
+            return
         self.svg_view.load_svg_data(self.timeline.svg_data)
 
     def reset_svg(self):
-        self.svg_view.deleteLater()
+        try:
+            viewer = get(Get.SCORE_VIEWER, self.id)
+        except NoReplyToRequest:
+            # Nothing to reset. Going through `self.svg_view` here would build
+            # a viewer — re-registering its toolbar commands — only to destroy
+            # it again.
+            return
+        viewer.deleteLater()
 
     def on_left_click(self, item, modifier, double, x, y):
         if item != self.measure_tracker:

--- a/tilia/ui/windows/svg_viewer.py
+++ b/tilia/ui/windows/svg_viewer.py
@@ -147,29 +147,27 @@ class SvgViewer(ViewDockWidget):
 
     def load_svg_data(self, data: str) -> None:
         self.score_root = etree.fromstring(data, None)
-        if not (x_pos := self.timeline.get_data("viewer_beat_x")):
-            beat_x_pos, success = self.timeline.set_data(
-                "viewer_beat_x", self._get_beat_x_pos(self.score_root)
+        # Reading the markers removes them, which is also what keeps them out
+        # of the render: Qt emits a font warning per marker per paint
+        # (issue #513), which both floods the log and tanks frame rate.
+        # The stripped SVG is deliberately not written back to the timeline:
+        # `svg_data` keeps its markers so that the mapping below can always be
+        # rebuilt from it, which is what makes a re-imported score use its own
+        # beat positions instead of the previous score's.
+        beat_x_pos = self._get_beat_x_pos(self.score_root)
+        if not beat_x_pos:
+            # SVGs saved before the markers were kept have none left to read,
+            # so the mapping stored alongside them is all there is to go on.
+            beat_x_pos = self.timeline.get_data("viewer_beat_x")
+        if not beat_x_pos:
+            tilia.errors.display(
+                tilia.errors.SCORE_SVG_CREATE_ERROR,
+                "File not properly set up. Beat positions not found.",
             )
-            if not success:
-                tilia.errors.display(
-                    tilia.errors.SCORE_SVG_CREATE_ERROR,
-                    "File not properly set up. Beat positions not found.",
-                )
-                return
-            else:
-                self.beat_x_position = {
-                    float(beat): float(x) for beat, x in beat_x_pos.items()
-                }
-        else:
-            # `_get_beat_x_pos` strips data-marker elements as a side effect.
-            # When viewer_beat_x is already cached we skip it, so the markers
-            # can survive into the rendered SVG. Qt emits a font warning per
-            # marker per paint (issue #513), which both floods the log and
-            # tanks frame rate — strip them here too.
-            self._strip_beat_x_markers(self.score_root)
-            self.beat_x_position = {float(beat): float(x) for beat, x in x_pos.items()}
-        self.timeline.save_svg_data(str(etree.tostring(self.score_root), "utf-8"))
+            return
+
+        self.timeline.set_data("viewer_beat_x", beat_x_pos)
+        self.beat_x_position = {float(beat): float(x) for beat, x in beat_x_pos.items()}
 
         self.setParent(get(Get.MAIN_WINDOW))
         self.score_renderer.load(bytearray(etree.tostring(self.score_root)))

--- a/tilia/ui/windows/svg_viewer.py
+++ b/tilia/ui/windows/svg_viewer.py
@@ -217,17 +217,14 @@ class SvgViewer(ViewDockWidget):
             yield e, parts
 
     @staticmethod
-    def _strip_beat_x_markers(root: etree._Element) -> None:
-        """Remove the data-marker text elements that `_get_beat_x_pos`
-        strips on first load. Used when reloading an already-processed SVG.
+    def _get_beat_x_pos(root: etree._Element) -> dict[float, float]:
+        """Build the beat-to-x mapping from the data markers, removing each
+        marker from ``root`` as it is read. Returns an empty mapping for an
+        SVG whose markers were already stripped.
         """
-        for e, _ in SvgViewer._extract_beat_position_markers(root):
-            e.getparent().remove(e)
-
-    def _get_beat_x_pos(self, root: etree._Element) -> dict[float, float]:
         x_stamps = {}
         measure_divs = {}
-        for e, parts in self._extract_beat_position_markers(root):
+        for e, parts in SvgViewer._extract_beat_position_markers(root):
             e.getparent().remove(e)
 
             measure, beat_div, max_div = map(int, parts)


### PR DESCRIPTION
## The bug

`SvgViewer.load_svg_data` only computed the beat-to-x mapping when `viewer_beat_x` was falsy, and nothing ever cleared it. Importing a second musicXML into a score timeline that already had one kept the **first** score's mapping.

Reproduced by loading an SVG whose markers sit at x=100/150 and then one at x=900/950: `timeline.viewer_beat_x` and `viewer.beat_x_position` still read `{1.0: 100.0, 1.5: 150.0}`. Everything downstream is then wrong for the new score — `scroll_to_time`, `_get_closest_time`, the measure tracker, and every stavenote's `seek_x`.

## The fix

**The mapping is rebuilt from the SVG on every load.** That needs the data markers to still be there, so `load_svg_data` no longer writes the stripped SVG back over `svg_data`. Stripping is cheap and now runs on every load anyway; a stored mapping is still honoured as a fallback, for files saved before this change.

Two things made the pair awkward to decouple, and both are handled:

1. **The `viewer_beat_x` setter ignored falsy values**, so `set_data("viewer_beat_x", {})` was a silent no-op and the mapping could not be cleared through the normal path. It assigns `x_pos or {}` now, and `ScoreTimeline.clear()` discards both halves together — keeping either one alone would leave the timeline describing a score that is no longer there, and would make an undo overwrite the value it just restored.

2. **`_restore_timeline_state` restores SERIALIZABLE attributes one at a time**, `svg_data` before `viewer_beat_x`, so the viewer reloads while only half of the pair has been applied. `viewer_beat_x` joins `UPDATE_TRIGGERS` and both updaters go through `_reload_svg_view`, so whichever attribute arrives second leaves the viewer consistent. An empty `svg_data` closes the viewer instead of being handed to `etree.fromstring`. `SERIALIZABLE` is untouched — the per-timeline `hash` built from it goes into the `.tla` file.

Plus one small related change: `reset_svg` no longer reaches the viewer through the `svg_view` property, which would build one — re-registering its toolbar commands against a throwaway widget — only to destroy it again.

The second commit removes `_strip_beat_x_markers`, which has no callers left now that every load goes through `_get_beat_x_pos`, and moves its tests over.

## Tests

Eight new tests in `TestViewerBeatPositions`: clearing drops the mapping; a score imported after a clear uses its own beat positions; the same for a score imported over another without a clear; undo/redo across both transitions displays no error and leaves the viewer consistent; saving and reloading preserves the positions; a marker-less SVG falls back to the stored mapping; and an SVG with no source at all reports `SCORE_SVG_CREATE_ERROR`. Four of them fail on `dev`.

Full suite green (1835 passed). The `tests/test_app.py` failures under `-n auto` are the pre-existing xdist flake — all 90 pass serially.

## Notes for the reviewer

- **`svg_data` now keeps its markers**, so `.tla` files get bigger. Files written before this change still load, through the stored-mapping fallback.
- **`SCORE_SVG_CREATE_ERROR` was unreachable on `dev`**: `validate_pre_validated` always returns `True`, so the `success` flag that guarded it was always true. This PR makes the error genuinely reachable — when neither markers nor a stored mapping are available — and covers it with a test.
- **Overlaps with `fix/472-score-clear-svg-viewer`**, which also discards `svg_data` on clear and closes the viewer. That branch sits on a different base where `svg_view` returns `None` rather than lazily building a viewer, so the two will conflict in the same three places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)