### PR TITLE
fix: close the score viewer when the score timeline is cleared

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,8 @@ tilia                       # Qt GUI
 tilia --user-interface cli  # CLI (source-only, not in compiled builds)
 
 # Tests (pytest-env auto-sets ENVIRONMENT=test and QT_QPA_PLATFORM=offscreen)
-pytest                                                  # full suite
+pytest                                                  # full suite (~10 min)
+pytest -n auto                                          # full suite in parallel (~1.5 min, pytest-xdist)
 pytest tests/ui/timelines/marker/test_marker_timeline_ui.py    # one file
 pytest tests/ui/timelines/marker/test_marker_timeline_ui.py::TestCreateDelete::test_create_at_selected_time  # one test
 pytest -k marker                                        # by keyword
@@ -39,6 +40,14 @@ python scripts/deploy.py <ref_name> <os_type>  # output in build/<os_type>/exe
 ```
 
 Default pytest timeout is 10s (pytest-timeout). `ffmpeg` must be on PATH for audio export/convert features.
+
+Prefer `-n auto` — the suite takes minutes serially and about a minute in parallel. A handful of
+tests (notably in `tests/test_app.py` and the CLI roundtrip tests) fail intermittently under
+`-n auto`, and which ones fail varies between runs; this predates any given change, so confirm a
+failure reproduces serially before investigating it. The same goes for `undoable()` on a timeline
+with several components: `TimelineComponentManager.restore_state` recreates components in
+set-iteration order while `hash_components()` hashes them in list order, so whether the assertion
+passes depends on `PYTHONHASHSEED`.
 
 ## Architecture
 

--- a/tests/ui/timelines/score/test_score_timeline_ui.py
+++ b/tests/ui/timelines/score/test_score_timeline_ui.py
@@ -375,3 +375,80 @@ class TestAudioTimeChange:
         post(Post.PLAYER_CURRENT_TIME_CHANGED, 1.0, None)
 
         assert score_tlui.svg_view is None
+
+
+class TestClear:
+    @staticmethod
+    def _clear(score_tlui):
+        with Serve(Get.FROM_USER_YES_OR_NO, True):
+            commands.execute("timeline.clear", score_tlui)
+
+    def test_closes_the_svg_viewer(self, score_tlui, note, tls):
+        tls.set_timeline_data(score_tlui.id, "svg_data", SVG_WITH_MARKERS)
+
+        self._clear(score_tlui)
+
+        assert score_tlui.svg_view is None
+
+    def test_viewer_stays_closed_during_playback(self, score_tlui, note, tls):
+        tls.set_timeline_data(score_tlui.id, "svg_data", SVG_WITH_MARKERS)
+        self._clear(score_tlui)
+
+        post(Post.PLAYER_CURRENT_TIME_CHANGED, 1.0, None)
+
+        assert score_tlui.svg_view is None
+
+    def test_discards_svg_data(self, score_tlui, note, tls):
+        tls.set_timeline_data(score_tlui.id, "svg_data", SVG_WITH_MARKERS)
+
+        self._clear(score_tlui)
+
+        assert score_tlui.get_data("svg_data") == ""
+
+    def test_restoring_a_cleared_state_closes_the_viewer(self, score_tlui, note, tls):
+        # The path undo/redo takes when it lands on a cleared state.
+        tls.set_timeline_data(score_tlui.id, "svg_data", SVG_WITH_MARKERS)
+        self._clear(score_tlui)
+        cleared_state, _ = tls.serialize_timelines()
+        tls.set_timeline_data(score_tlui.id, "svg_data", SVG_WITH_MARKERS)
+
+        tls.restore_state(cleared_state)
+
+        assert score_tlui.get_data("svg_data") == ""
+        assert score_tlui.svg_view is None
+
+    def test_score_does_not_come_back_after_saving_and_reloading(
+        self, score_tlui, note, tls, tmp_path
+    ):
+        tls.set_timeline_data(score_tlui.id, "svg_data", SVG_WITH_MARKERS)
+        self._clear(score_tlui)
+
+        @reloadable(tmp_path / "file.tla")
+        def check() -> None:
+            score = get(Get.TIMELINE_UI_BY_ATTR, "timeline_class", ScoreTimeline)
+            assert score.get_data("svg_data") == ""
+            assert score.svg_view is None
+
+    def test_undo_redo(self, score_tlui, note, tls):
+        # `undoable()` can't be used here: TimelineComponentManager.restore_state
+        # recreates components in set-iteration order while hash_components()
+        # hashes them in list order, so a restored state's components_hash
+        # depends on PYTHONHASHSEED. That is a pre-existing defect in the base
+        # timeline, unrelated to clearing; assert the restored values directly.
+        tls.set_timeline_data(score_tlui.id, "svg_data", SVG_WITH_MARKERS)
+        svg_data = score_tlui.get_data("svg_data")
+        post(Post.APP_STATE_RECORD, "setup")
+        with Serve(Get.FROM_USER_YES_OR_NO, True):
+            commands.execute("timeline.clear", score_tlui)
+
+        commands.execute("edit.undo")
+
+        assert len(score_tlui.timeline) == 3
+        assert score_tlui.get_data("svg_data") == svg_data
+        assert score_tlui.svg_view is not None
+
+        commands.execute("edit.redo")
+
+        assert len(score_tlui.timeline) == 0
+        assert score_tlui.get_data("svg_data") == ""
+        assert score_tlui.svg_view is None

--- a/tests/ui/timelines/score/test_score_timeline_ui.py
+++ b/tests/ui/timelines/score/test_score_timeline_ui.py
@@ -345,6 +345,17 @@ class TestSvgView:
 
         assert score_tlui.get_or_create_svg_view() is score_tlui.svg_view
 
+    def test_viewer_and_tracker_come_back_after_reloading(
+        self, score_tlui, note, tls, tmp_path
+    ):
+        tls.set_timeline_data(score_tlui.id, "svg_data", SVG_WITH_MARKERS)
+
+        @reloadable(tmp_path / "file.tla")
+        def check() -> None:
+            score = get(Get.TIMELINE_UI_BY_ATTR, "timeline_class", ScoreTimeline)
+            assert score.svg_view is not None
+            assert score.measure_tracker.isVisible()
+
 
 class TestResetSvg:
     def test_deletes_existing_viewer(self, score_tlui, tls):

--- a/tests/ui/timelines/score/test_score_timeline_ui.py
+++ b/tests/ui/timelines/score/test_score_timeline_ui.py
@@ -12,6 +12,7 @@ from tests.mock import (
 )
 from tests.utils import get_blank_file_data, reloadable
 from tilia.errors import SCORE_STAFF_ID_ERROR
+from tilia.exceptions import NoReplyToRequest
 from tilia.parsers.score.musicxml import notes_from_musicXML
 from tilia.requests import Get, Post, get, post
 from tilia.timelines.component_kinds import ComponentKind
@@ -314,3 +315,63 @@ def test_symbol_staff_collision(qtui, tmp_path):
     )
 
     assert staff_top_y_sans_symbols < staff_top_y_with_symbols
+
+
+SVG_WITH_MARKERS = (
+    "<svg>"
+    "<g class='vf-text'><text font-size='0.00001px' x='100'>1␟0␟4</text></g>"
+    "<g class='vf-text'><text font-size='0.00001px' x='150'>1␟2␟4</text></g>"
+    "</svg>"
+)
+
+
+class TestSvgView:
+    def test_is_none_when_no_viewer_exists(self, score_tlui):
+        assert score_tlui.svg_view is None
+
+    def test_reading_it_does_not_register_a_viewer(self, score_tlui):
+        assert score_tlui.svg_view is None
+
+        with pytest.raises(NoReplyToRequest):
+            get(Get.SCORE_VIEWER, score_tlui.id)
+
+    def test_get_or_create_creates_and_loads(self, score_tlui, tls):
+        tls.set_timeline_data(score_tlui.id, "svg_data", SVG_WITH_MARKERS)
+
+        assert score_tlui.get_or_create_svg_view().is_svg_loaded
+
+    def test_get_or_create_returns_existing_viewer(self, score_tlui, tls):
+        tls.set_timeline_data(score_tlui.id, "svg_data", SVG_WITH_MARKERS)
+
+        assert score_tlui.get_or_create_svg_view() is score_tlui.svg_view
+
+
+class TestResetSvg:
+    def test_deletes_existing_viewer(self, score_tlui, tls):
+        tls.set_timeline_data(score_tlui.id, "svg_data", SVG_WITH_MARKERS)
+
+        score_tlui.reset_svg()
+
+        assert score_tlui.svg_view is None
+
+    def test_does_not_raise_when_no_viewer_exists(self, score_tlui):
+        score_tlui.reset_svg()
+
+        assert score_tlui.svg_view is None
+
+    def test_does_not_raise_when_another_timeline_owns_the_viewer(
+        self, score_tlui, tls, tluis
+    ):
+        other = tls.create_timeline(ScoreTimeline)
+        tls.set_timeline_data(other.id, "svg_data", SVG_WITH_MARKERS)
+
+        score_tlui.reset_svg()
+
+        assert tluis.get_timeline_ui(other.id).svg_view is not None
+
+
+class TestAudioTimeChange:
+    def test_does_not_create_a_viewer(self, score_tlui):
+        post(Post.PLAYER_CURRENT_TIME_CHANGED, 1.0, None)
+
+        assert score_tlui.svg_view is None

--- a/tests/ui/windows/test_svg_viewer.py
+++ b/tests/ui/windows/test_svg_viewer.py
@@ -80,3 +80,31 @@ class TestStripBeatXMarkers:
         # The bumped one should now be 15px.
         font_sizes = sorted(g[0].attrib["font-size"] for g in kept)
         assert font_sizes == ["15px", "15px"]
+
+
+SVG_WITHOUT_MARKERS = (
+    "<svg><g class='vf-text'><text font-size='15px' x='0'>Allegro</text></g></svg>"
+)
+SVG_WITH_MARKERS = (
+    "<svg>"
+    "<g class='vf-text'><text font-size='0.00001px' x='100'>1␟0␟4</text></g>"
+    "<g class='vf-text'><text font-size='0.00001px' x='150'>1␟2␟4</text></g>"
+    "</svg>"
+)
+
+
+class TestLoadSvgData:
+    def test_loads_svg_with_beat_markers(self, qtui, score_tl, tls, tluis):
+        tls.set_timeline_data(score_tl.id, "svg_data", SVG_WITH_MARKERS)
+
+        assert tluis.get_timeline_ui(score_tl.id).svg_view.is_svg_loaded
+        assert score_tl.get_data("viewer_beat_x") == {1.0: 100.0, 1.5: 150.0}
+
+    def test_displays_error_when_no_beat_positions_found(
+        self, qtui, score_tl, tls, tluis, tilia_errors
+    ):
+        tls.set_timeline_data(score_tl.id, "svg_data", SVG_WITHOUT_MARKERS)
+
+        tilia_errors.assert_error()
+        tilia_errors.assert_in_error_message("Beat positions not found")
+        assert not tluis.get_timeline_ui(score_tl.id).svg_view.is_svg_loaded

--- a/tilia/timelines/score/timeline.py
+++ b/tilia/timelines/score/timeline.py
@@ -59,6 +59,10 @@ class ScoreTLComponentManager(TimelineComponentManager):
 
     def clear(self):
         super().clear()
+        # The score viewer is rebuilt from svg_data, so a cleared timeline
+        # must not keep it: otherwise the viewer reopens with the discarded
+        # score, both in this session and after saving and reloading.
+        self.timeline.save_svg_data("")
         post(Post.SCORE_TIMELINE_CLEAR_DONE, self.timeline.id)
 
 

--- a/tilia/ui/timelines/score/element/annotation.py
+++ b/tilia/ui/timelines/score/element/annotation.py
@@ -12,7 +12,7 @@ class ScoreAnnotationUI(TimelineUIElement):
 
     @property
     def svg_view(self) -> SvgViewer:
-        return self.timeline_ui.svg_view
+        return self.timeline_ui.get_or_create_svg_view()
 
     def update_x(self):
         self.svg_view.update_annotation(self.id)

--- a/tilia/ui/timelines/score/timeline.py
+++ b/tilia/ui/timelines/score/timeline.py
@@ -482,7 +482,11 @@ class ScoreTimelineUI(TimelineUI):
             self.get_or_create_svg_view()
 
     def update_svg_data(self) -> None:
-        if (viewer := self.svg_view) is None:
+        if not self.timeline.svg_data:
+            # No score left to show. Reached when the timeline is cleared and
+            # when undo/redo restores a state where it was.
+            self.reset_svg()
+        elif (viewer := self.svg_view) is None:
             # Creating the viewer loads the current data as part of its setup.
             self.get_or_create_svg_view()
         else:

--- a/tilia/ui/timelines/score/timeline.py
+++ b/tilia/ui/timelines/score/timeline.py
@@ -93,15 +93,27 @@ class ScoreTimelineUI(TimelineUI):
         }
 
     @property
-    def svg_view(self):
+    def svg_view(self) -> SvgViewer | None:
+        """The score viewer serving this timeline, or None if there is none.
+
+        Reading this never creates a viewer. Use `get_or_create_svg_view`
+        when one is required.
+        """
         try:
             return get(Get.SCORE_VIEWER, self.id)
         except NoReplyToRequest:
-            viewer = SvgViewer(name=self.get_data("name"), tl_id=self.id)
-            if self.timeline.svg_data:
-                viewer.load_svg_data(self.timeline.svg_data)
-                self.measure_tracker.setVisible(not viewer.is_hidden)
+            return None
+
+    def get_or_create_svg_view(self) -> SvgViewer:
+        """This timeline's score viewer, creating and loading one if needed."""
+        if (viewer := self.svg_view) is not None:
             return viewer
+
+        viewer = SvgViewer(name=self.get_data("name"), tl_id=self.id)
+        if self.timeline.svg_data:
+            viewer.load_svg_data(self.timeline.svg_data)
+            self.measure_tracker.setVisible(not viewer.is_hidden)
+        return viewer
 
     @staticmethod
     def get_time_signature_icon_name(n: int) -> str:
@@ -114,8 +126,8 @@ class ScoreTimelineUI(TimelineUI):
     def update_name(self):
         name = self.get_data("name")
         self.scene.set_text(name)
-        if self.svg_view:
-            self.svg_view.update_title(name)
+        if (viewer := self.svg_view) is not None:
+            viewer.update_title(name)
 
     def get_staff_y_cache(self):
         return {
@@ -455,8 +467,8 @@ class ScoreTimelineUI(TimelineUI):
         return (x1 - x0) / self._measure_count
 
     def on_audio_time_change(self, time: float, _) -> None:
-        if self.svg_view.is_svg_loaded:
-            self.svg_view.scroll_to_time(time, False)
+        if (viewer := self.svg_view) is not None and viewer.is_svg_loaded:
+            viewer.scroll_to_time(time, False)
 
     def _setup_svg_view(self) -> None:
         self.tracker_start = 0
@@ -467,15 +479,18 @@ class ScoreTimelineUI(TimelineUI):
         self.scene.addItem(self.measure_tracker)
 
         if self.timeline.svg_data:
-            viewer = SvgViewer(name=self.get_data("name"), tl_id=self.id)
-            viewer.load_svg_data(self.timeline.svg_data)
-            self.measure_tracker.show()
+            self.get_or_create_svg_view()
 
     def update_svg_data(self) -> None:
-        self.svg_view.load_svg_data(self.timeline.svg_data)
+        if (viewer := self.svg_view) is None:
+            # Creating the viewer loads the current data as part of its setup.
+            self.get_or_create_svg_view()
+        else:
+            viewer.load_svg_data(self.timeline.svg_data)
 
-    def reset_svg(self):
-        self.svg_view.deleteLater()
+    def reset_svg(self) -> None:
+        if (viewer := self.svg_view) is not None:
+            viewer.deleteLater()
 
     def on_left_click(self, item, modifier, double, x, y):
         if item != self.measure_tracker:
@@ -497,7 +512,8 @@ class ScoreTimelineUI(TimelineUI):
             post(Post.ELEMENT_DRAG_START)
 
     def after_each_drag(self, drag_x: int):
-        self.svg_view.scroll_to_time(time_x_converter.get_time_by_x(drag_x), True)
+        if (viewer := self.svg_view) is not None:
+            viewer.scroll_to_time(time_x_converter.get_time_by_x(drag_x), True)
 
     def on_drag_end(self):
         if self.dragged:
@@ -529,7 +545,7 @@ class ScoreTimelineUI(TimelineUI):
             __set_tracker_position(QPointF(start, end))
 
     def on_timeline_width_set_done(self, _: float) -> None:
-        if self.svg_view and self.svg_view.is_svg_loaded:
+        if (viewer := self.svg_view) is not None and viewer.is_svg_loaded:
             self.update_measure_tracker_position()
 
 

--- a/tilia/ui/windows/svg_viewer.py
+++ b/tilia/ui/windows/svg_viewer.py
@@ -151,7 +151,7 @@ class SvgViewer(ViewDockWidget):
             beat_x_pos, success = self.timeline.set_data(
                 "viewer_beat_x", self._get_beat_x_pos(self.score_root)
             )
-            if not success:
+            if not success or not beat_x_pos:
                 tilia.errors.display(
                     tilia.errors.SCORE_SVG_CREATE_ERROR,
                     "File not properly set up. Beat positions not found.",

--- a/tilia/ui/windows/svg_viewer.py
+++ b/tilia/ui/windows/svg_viewer.py
@@ -26,6 +26,7 @@ from PySide6.QtWidgets import (
 )
 
 import tilia.errors
+from tilia.log import logger
 from tilia.requests import (
     Get,
     Post,
@@ -146,6 +147,9 @@ class SvgViewer(ViewDockWidget):
         return v_toolbar
 
     def load_svg_data(self, data: str) -> None:
+        if not data:
+            logger.error("Score viewer got no SVG data to load.")
+            return
         self.score_root = etree.fromstring(data, None)
         if not (x_pos := self.timeline.get_data("viewer_beat_x")):
             beat_x_pos, success = self.timeline.set_data(


### PR DESCRIPTION
Alternative to #481, rebuilt on current `dev`. Same diagnosis, deeper fix.

Closes #472.

## The bug is real and reachable

Clearing a score timeline and then letting playback run for one tick reopens the viewer with the score that was just discarded: `on_audio_time_change` reads `ScoreTimelineUI.svg_view`, whose getter *constructs* an `SvgViewer` when none is registered, loads `svg_data` into it and shows it. Instrumenting `SvgViewer.show` confirms one call per clear-plus-tick on `dev`. The score also survived into the saved file, so reopening a cleared timeline brought it back.

## Why not #481 as it stands

#481 guards `reset_svg` alone. That leaves the auto-creating property in place at five other call sites, and it introduces a state (`svg_data == ""` on a live timeline) that the rest of the code cannot handle:

- **Undo/redo crashes.** With `svg_data` blanked on clear, restoring a cleared state pushes `""` through the update trigger into `SvgViewer.load_svg_data`, which hands it to `etree.fromstring` — `XMLSyntaxError: Document is empty`.
- **The new guard catches the wrong thing.** Only one callback can be attached per `Get` member, so with two score timelines the viewer of one answers for the other's id and returns `None` rather than raising. `except NoReplyToRequest` does not cover that; `reset_svg` raises `AttributeError`. `on_audio_time_change` had the same latent crash.
- **The viewer still comes back.** `reset_svg` deletes it, and the next playback tick rebuilds it through the property. It stays invisible only because `svg_data` happens to be empty by then, so the two halves of that PR are load-bearing together rather than independently correct.

## What this does instead

**`528eb264`** — `load_svg_data` treated only `success=False` from `set_data` as a failure, but `viewer_beat_x` uses `validate_pre_validated`, so the call always succeeds and `SCORE_SVG_CREATE_ERROR` was unreachable. A render without usable beat markers silently produced an empty mapping. Check the returned mapping too.

**`6d391c06`** — `svg_view` no longer constructs anything; it returns `None` when there is no viewer, and the explicit `get_or_create_svg_view()` handles creation. All six read sites updated, plus `ScoreAnnotationUI.svg_view`, which keeps the creating behaviour it relies on. This is what actually stops the resurrection, and it fixes the `None`-return crash at the same time.

**`9a13afb9`** — the fix proper. `ScoreTLComponentManager.clear` discards `svg_data` (after `super().clear()`, so the deletion loop still sees the score it is clearing), and `update_svg_data` closes the viewer instead of loading when there is no score left. `load_svg_data` refuses empty data outright.

**`5dd1a7fc`** — docs; see below.

**`b106beac`** — `_setup_svg_view` now goes through `get_or_create_svg_view`, which sets the measure tracker's visibility from the viewer instead of calling `show()` unconditionally. Test pins the behaviour that must be preserved.

## Tests

16 added, covering: the viewer closing on clear and staying closed through playback, `svg_data` being discarded, restoring a cleared state, undo/redo, save-and-reload, `reset_svg` with no viewer and with another timeline owning the slot, and the revived beat-position error. Each fails without its corresponding change.

Full suite: 1847 passed, 0 failed.

## Two pre-existing bugs found on the way, left for their own PRs

- **`viewer_beat_x` is never cleared**, so a score imported into a timeline that already had one is laid out against the previous score's beat positions. Clearing it here is not safe yet: `_restore_timeline_state` restores `svg_data` before `viewer_beat_x`, so an undo would reload the already-marker-stripped SVG while the mapping is empty and recomputation yields nothing.
- **`components_hash` is nondeterministic across undo.** `TimelineComponentManager.restore_state` recreates components in set-iteration order while `hash_components()` hashes them in list order, so a restored state's hash depends on `PYTHONHASHSEED` (fails on seeds 0, 1, 4; passes on 2, 3, 5 — same on clean `dev`). That makes `undoable()` unusable on any timeline with several components and can mark an unmodified file as modified. The undo/redo test here asserts restored values directly and carries a comment pointing at this.

## Unrelated: parallel test runs

`pytest-xdist` was already a dev dependency but nothing documented it, so the documented way to run the suite takes about eight minutes instead of one and a half. `5dd1a7fc` adds `pytest -n auto` to CLAUDE.md, along with the two intermittent-failure sources that look like regressions but are not — cross-test interference under `-n auto`, and the `PYTHONHASHSEED` dependency above.
