### PR TITLE
fix: make timeline components hash deterministic

### DIFF
--- a/tests/timelines/score/test_score_timeline.py
+++ b/tests/timelines/score/test_score_timeline.py
@@ -129,3 +129,45 @@ def test_crop_staff(score_tl, tilia_state):
     score_tl.crop(50)
 
     assert s in score_tl
+
+
+# Staff orders by ``index`` and Clef by ``time``, so a staff at index 0 and a
+# clef at time 0 both have an ordinal of ``(0,)`` and neither sorts before the
+# other. Clef ignores ``staff_index`` altogether, so the clefs of a multi-staff
+# score all tie too. Components that tie keep the order they were created in,
+# which after an undo is whatever order restore_state happened to use.
+MIXED_KINDS = [
+    (ComponentKind.STAFF, (0, 5), {}),
+    (ComponentKind.CLEF, (0, 0), {"shorthand": Clef.Shorthand.TREBLE}),
+    (ComponentKind.NOTE, (0, 1, 0, 0, 3, 0), {}),
+]
+
+EQUAL_ORDINALS = [
+    (ComponentKind.STAFF, (0, 5), {}),
+    (ComponentKind.STAFF, (1, 5), {}),
+    (ComponentKind.CLEF, (0, 0), {"shorthand": Clef.Shorthand.TREBLE}),
+    (ComponentKind.CLEF, (1, 0), {"shorthand": Clef.Shorthand.BASS}),
+]
+
+
+def components_hash_for(timeline, components):
+    timeline.clear()
+    for kind, args, kwargs in components:
+        timeline.create_component(kind, *args, **kwargs)
+    return timeline.component_manager.hash_components()
+
+
+class TestHashComponents:
+    def test_does_not_depend_on_creation_order_of_components_of_different_kinds(
+        self, score_tl
+    ):
+        assert components_hash_for(score_tl, MIXED_KINDS) == components_hash_for(
+            score_tl, list(reversed(MIXED_KINDS))
+        )
+
+    def test_does_not_depend_on_creation_order_of_components_with_equal_ordinals(
+        self, score_tl
+    ):
+        assert components_hash_for(score_tl, EQUAL_ORDINALS) == components_hash_for(
+            score_tl, list(reversed(EQUAL_ORDINALS))
+        )

--- a/tests/timelines/test_timeline_component_manager.py
+++ b/tests/timelines/test_timeline_component_manager.py
@@ -1,6 +1,8 @@
 import itertools
 import random
 
+from tilia.timelines.hash_timelines import hash_function
+
 
 class TestComponentOrder:
     def test_components_stay_sorted_after_setting_ordering_attr(
@@ -14,3 +16,23 @@ class TestComponentOrder:
 
         for c1, c2 in itertools.pairwise(marker_tl):
             assert c1 < c2 or c1.time == c2.time
+
+
+class TestHashComponents:
+    """Pins the digest's string shape. Changing it invalidates the
+    ``components_hash`` of every timeline, so it should not drift silently.
+    Order-independence is covered in tests/timelines/score, as score is the
+    only kind whose components can share an ordinal.
+    """
+
+    def test_is_component_hashes_joined_by_pipes(self, marker_tl):
+        marker_tl.create_marker(0)
+        marker_tl.create_marker(1)
+        first, second = marker_tl[0], marker_tl[1]
+
+        assert marker_tl.component_manager.hash_components() == hash_function(
+            f"{first.hash}|{second.hash}|"
+        )
+
+    def test_is_hash_of_empty_string_when_there_are_no_components(self, marker_tl):
+        assert marker_tl.component_manager.hash_components() == hash_function("")

--- a/tests/ui/timelines/score/test_score_timeline_ui.py
+++ b/tests/ui/timelines/score/test_score_timeline_ui.py
@@ -10,7 +10,7 @@ from tests.mock import (
     patch_yes_no_or_cancel_mb,
     patch_yes_or_no_dialog,
 )
-from tests.utils import get_blank_file_data, reloadable
+from tests.utils import get_blank_file_data, reloadable, undoable
 from tilia.errors import SCORE_STAFF_ID_ERROR
 from tilia.parsers.score.musicxml import notes_from_musicXML
 from tilia.requests import Get, Post, get, post
@@ -80,6 +80,25 @@ def test_create_key_signature(score_tlui, fifths):
     )
     score_tlui.create_component(ComponentKind.KEY_SIGNATURE, 0, 0, fifths)
     assert score_tlui[0]
+
+
+class TestClear:
+    def test_clear(self, score_tlui, note):
+        with patch_yes_or_no_dialog(True):
+            commands.execute("timeline.clear", score_tlui)
+
+        assert score_tlui.is_empty
+
+    def test_undo_redo(self, score_tlui, note):
+        # Score components have no user-facing creation command, so the fixture
+        # builds them directly and nothing records the resulting state. Record
+        # it here, or undo would restore the empty timeline the tlui fixture
+        # recorded instead. The staff and the clef have equal ordinals, so undo
+        # may recreate them in either order; the timeline hash must not notice.
+        post(Post.APP_STATE_RECORD, "components created by fixture")
+
+        with undoable(), patch_yes_or_no_dialog(True):
+            commands.execute("timeline.clear", score_tlui)
 
 
 def _check_attrs(tmp_path, items_per_attr):

--- a/tilia/timelines/base/timeline.py
+++ b/tilia/timelines/base/timeline.py
@@ -509,8 +509,15 @@ class TimelineComponentManager(Generic[T, TC]):
             self.delete_component(component)
 
     def hash_components(self):
+        # The digest must not depend on the order of ``self._components``.
+        # ``ORDERING_ATTRS`` is not a total order across kinds — a Staff at
+        # index 0 and a Clef at time 0 both have an ordinal of ``(0,)`` — so
+        # ``bisect.insort_left`` leaves tied components in insertion order, and
+        # ``restore_state`` recreates them in an order that varies between
+        # processes. Ordering by ``(ordinal, hash)`` is total and reproducible,
+        # while still matching the ordinal order whenever ordinals are distinct.
         str_to_hash = ""
-        for component in self._components:
+        for component in sorted(self._components, key=lambda c: (c.ordinal, c.hash)):
             str_to_hash += component.hash + "|"
 
         return hash_function(str_to_hash)
@@ -543,12 +550,21 @@ class TimelineComponentManager(Generic[T, TC]):
                 hashes_to_delete.add(hash)
                 hashes_to_create.add(hash)
 
-        ids_to_delete = [cur_hash_to_id[id] for id in hashes_to_delete]
+        # Iterate the dicts rather than the hash sets: set iteration order over
+        # strings varies with PYTHONHASHSEED, which would make the resulting
+        # component order (and everything derived from it) process-dependent.
+        # ``cur_hash_to_id`` follows the current component order and
+        # ``prev_hash_to_data`` the order the previous state was serialized in.
+        ids_to_delete = [
+            id for hash, id in cur_hash_to_id.items() if hash in hashes_to_delete
+        ]
         self.timeline.delete_components(
             [self.timeline.get_component(id) for id in ids_to_delete]
         )
 
-        components_to_create = [prev_hash_to_data[hash] for hash in hashes_to_create]
+        components_to_create = [
+            data for hash, data in prev_hash_to_data.items() if hash in hashes_to_create
+        ]
         for component_data in components_to_create:
             component_data = component_data.copy()
             kind = ComponentKind[component_data.pop("kind")]


### PR DESCRIPTION
## Problem

`TimelineComponentManager.hash_components` concatenated component hashes in `_components` order, and `restore_state` recreated components by iterating a **set** of hash strings. Set iteration order over strings depends on `PYTHONHASHSEED`, so after an undo the components landed in `_components` in a process-dependent order and the digest changed even though the components were identical.

That order only matters because **`ORDERING_ATTRS` is not a total order across component kinds**. `Staff` orders by `index` and `Clef` by `time`, so a staff at index 0 and a clef at time 0 both have an ordinal of `(0,)` and neither sorts before the other. `Clef` ignores `staff_index` entirely, so the clefs of a multi-staff score all tie as well. `bisect.insort_left` leaves tied components in insertion order.

Worth flagging for reviewers: plain `sorted(self._components)` does **not** fix this. Timsort is stable, so tied components keep their input order and the digest still varies. A tiebreaker is required.

Impact: any `undoable()` test on a timeline with several components is flaky, and `components_hash` feeds the "is the file modified" comparison in `are_tilia_data_equal`.

## Fix

- `hash_components` iterates `sorted(self._components, key=lambda c: (c.ordinal, c.hash))` — total and reproducible, and identical to the ordinal order whenever ordinals are distinct.
- `restore_state` builds its delete/create lists by iterating the hash-keyed dicts rather than the sets, so the resulting component order is reproducible too.

## Effect on hashes already saved in `.tla` files

- Timelines whose components have distinct ordinals (every kind other than score) hash **byte-identically** — verified against marker, beat, hierarchy and pdf timelines.
- Score timelines can hash differently — verified on a 27-component multistaff MusicXML score.
- This is harmless: the stored `components_hash` is discarded on load, since `App._do_open` overwrites `file.timelines` with freshly computed state. Planting a pre-fix hash in a `.tla` and reopening it leaves `is_file_modified` at `False`.

The digest's string shape (`h1|h2|...|hn|`, empty string when there are no components) is unchanged, and is now pinned by a test so it cannot drift silently.

## Tests

| Test | Pre-fix | Post-fix |
| --- | --- | --- |
| `test_score_timeline.py::TestHashComponents` (2 tests) | fails on **all** seeds 0–5 | passes on all |
| `test_score_timeline_ui.py::TestClear::test_undo_redo` | fails on seeds 0, 1, 4 | passes on all |
| `test_timeline_component_manager.py::TestHashComponents` (2 tests) | passes (shape guard) | passes |

The two `test_score_timeline.py` tests are the real regression guards: they are deterministic, so a single-seed CI run cannot pass them by luck. `test_undo_redo` reproduces the user-visible symptom, which is inherently seed-dependent.

Full suite: 1834 passed. The two `tests/test_app.py` failures under `pytest -n auto` are pre-existing xdist flakiness — `dev` fails a different pair the same way, and all 90 pass serially.