### PR TITLE
ci: use pytest-timeout's thread method instead of signal

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -81,12 +81,12 @@ jobs:
     - name: Test with pytest
       if: ${{ !(matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11') }}
       run: |
-        pytest -v -n auto --reruns=2 --timeout=10
+        pytest -v -n auto --reruns=2 --timeout=10 --timeout-method=thread
 
     - name: Test with pytest (coverage)
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
       run: |
-        pytest -v -n auto --reruns=2 --timeout=10 --cov-report= --cov=tilia
+        pytest -v -n auto --reruns=2 --timeout=10 --timeout-method=thread --cov-report= --cov=tilia
 
     - name: Generate Coverage Report
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'


### PR DESCRIPTION
pytest-timeout defaults to the "signal" method on POSIX, which arms SIGALRM and relies on the interpreter noticing it between bytecode instructions. If the main thread is blocked inside a native call that never returns control to Python -- a genuine OS-level deadlock, not a slow test -- the signal stays pending forever and the handler never runs. `--timeout=10` was already configured; it just structurally can't interrupt that class of hang.

The "thread" method runs a separate watcher thread that kills the whole process via `os._exit()` once the timeout elapses, regardless of what the main thread is doing -- it doesn't need the hung thread's cooperation. Under pytest-xdist (`-n auto`), that's one worker process; xdist detects the crash, reports the killed test as a failure, and reschedules the rest of that worker's queue onto a replacement worker, so the run doesn't hang.

**Trade-off:** no clean teardown/reporting for whatever was running at the moment of the kill (`os._exit()` skips it), and pytest-timeout's own docs note the crash can show up as a generic error rather than a labeled timeout in some report formats. Worth it to turn a silent 30-minute stall into a ~10-second, clearly-attributed failure with a stack trace of every thread at the point of the hang -- which is exactly the diagnostic info we're missing for the mystery hangs currently showing up on #578.