### PR TITLE
fix: make YouTube player errors readable by users

### DIFF
--- a/tests/player/test_youtube_player.py
+++ b/tests/player/test_youtube_player.py
@@ -1,0 +1,36 @@
+import pytest
+
+from tilia.media.player.youtube import YouTubePlayer
+
+
+class TestIsWellFormedId:
+    @pytest.mark.parametrize(
+        "video_id",
+        ["dQw4w9WgXcQ", "zzzzzzzzzzz", "aaaaaaaaaaa", "_-_-_-_-_-_", "00000000000"],
+    )
+    def test_accepts_eleven_valid_characters(self, video_id):
+        assert YouTubePlayer.is_well_formed_id(video_id)
+
+    @pytest.mark.parametrize(
+        "video_id",
+        [
+            "abc",  # too short
+            "dQw4w9WgXcQQ",  # too long
+            "dQw4w9WgXc!",  # invalid character
+            "shorts",  # what get_id_from_url returns for a /shorts/ URL
+            "live",  # ... and for a /live/ URL
+            "",
+            None,
+        ],
+    )
+    def test_rejects_anything_else(self, video_id):
+        assert not YouTubePlayer.is_well_formed_id(video_id)
+
+    def test_ids_extracted_from_ordinary_urls_are_well_formed(self):
+        for url in [
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            "https://youtu.be/dQw4w9WgXcQ",
+            "https://www.youtube.com/embed/dQw4w9WgXcQ",
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42s",
+        ]:
+            assert YouTubePlayer.is_well_formed_id(YouTubePlayer.get_id_from_url(url))

--- a/tilia/media/player/youtube.html
+++ b/tilia/media/player/youtube.html
@@ -98,35 +98,41 @@
         }
       }
 
+      // Messages are what the user reads, so they say what to do about the
+      // failure rather than quoting the IFrame API reference. YouTube reports
+      // code 2 for ids it merely doesn't recognise, not only for malformed
+      // ones, so 2 and 100 have to stay compatible with each other.
       function onError(event) {
         switch (event.data) {
           case 2:
             backend.on_error(
-              "The request contains an invalid parameter value. For example, this error occurs if you specify a video ID that does not have 11 characters, or if the video ID contains invalid characters, such as exclamation points or asterisks.",
+              "YouTube did not accept this video ID. Check that the address is a link to an existing video.",
             );
             break;
 
           case 5:
             backend.on_error(
-              "The requested content cannot be played in an HTML5 player or another error related to the HTML5 player has occurred.",
+              "This video could not be played in the embedded player.",
             );
             break;
 
           case 100:
             backend.on_error(
-              "The video requested was not found. This error occurs when a video has been removed (for any reason) or has been marked as private.",
+              "Video not found. It may have been removed, made private, or never existed.",
             );
             break;
 
           case 101:
           case 150:
             backend.on_error(
-              "The owner of the requested video does not allow it to be played in embedded players.",
+              "This video cannot be played here: its owner does not allow it to be embedded in other sites. Try opening it on YouTube instead.",
             );
             break;
 
           default:
-            backend.on_error("Error code: ${event.data}.");
+            backend.on_error(
+              `YouTube reported an unexpected error (code ${event.data}).`,
+            );
         }
       }
 

--- a/tilia/media/player/youtube.py
+++ b/tilia/media/player/youtube.py
@@ -93,9 +93,23 @@ class YouTubePlayer(Player):
     MEDIA_TYPE = "youtube"
     PATH_TO_HTML = Path(__file__).parent / "youtube.html"
 
+    # Every YouTube video id has been eleven characters of [A-Za-z0-9_-] for
+    # as long as the service has existed, but YouTube has never promised to
+    # keep it that way. So this is used to *choose an error message*, never to
+    # refuse a load: if the format ever widens, the message gets vaguer and
+    # nothing else changes. See is_well_formed_id.
+    VIDEO_ID_PATTERN = re.compile(r"[\w-]{11}")
+
+    MALFORMED_ID_MESSAGE = (
+        "This does not look like the address of a YouTube video. Check the "
+        "URL: the video id is the eleven-character code after 'watch?v=' or "
+        "'youtu.be/'."
+    )
+
     def __init__(self):
         super().__init__()
         self.video_id = None
+        self.video_id_is_well_formed = True
         self._setup_web_engine()
         self._setup_web_channel()
 
@@ -192,9 +206,23 @@ class YouTubePlayer(Player):
         )
 
     def display_error(self, message: str):
+        # YouTube reports code 2 both for ids it can't parse and for ids it
+        # simply doesn't have, so its message can't tell the two apart. When
+        # we already know the id can't be one, say so instead.
+        if not self.video_id_is_well_formed:
+            message = self.MALFORMED_ID_MESSAGE
         tilia.errors.display(
             tilia.errors.YOUTUBE_PLAYER_ERROR, message + f"\nVideo ID: {self.video_id}"
         )
+
+    @classmethod
+    def is_well_formed_id(cls, video_id: str | None) -> bool:
+        """Whether video_id has the shape YouTube ids have always had.
+
+        A False result only sharpens the error message shown after a failed
+        load; it never prevents one. See VIDEO_ID_PATTERN.
+        """
+        return bool(video_id) and bool(cls.VIDEO_ID_PATTERN.fullmatch(video_id))
 
     @staticmethod
     def get_id_from_url(url):
@@ -209,6 +237,7 @@ class YouTubePlayer(Player):
 
     def _engine_load_media(self, media_path: str) -> bool:
         self.video_id = self.get_id_from_url(media_path)
+        self.video_id_is_well_formed = self.is_well_formed_id(self.video_id)
 
         def load_video():
             self.view.page().runJavaScript(f'loadVideo("{self.video_id}")')
@@ -247,6 +276,7 @@ class YouTubePlayer(Player):
             self.view.page().runJavaScript("stop()")
         self.view.hide()
         self.video_id = None
+        self.video_id_is_well_formed = True
         self.shared_object.player_toolbar_enabled = False
 
     def _engine_get_media_duration(self, requested_video_id=None):


### PR DESCRIPTION
## Why

Every branch of `onError` in the YouTube player quoted the IFrame API reference verbatim. The most common failure — a URL whose video id YouTube doesn't recognise — comes back as error code **2**, whose documented text reads:

> The request contains an invalid parameter value. For example, this error occurs if you specify a video ID that does not have 11 characters, or if the video ID contains invalid characters, such as exclamation points or asterisks.

Paste `https://www.youtube.com/watch?v=zzzzzzzzzzz` and that is what you get: a lecture about character counts, for an id that is exactly eleven valid characters. The message contradicts the input.

Found while building a repro bundle for #450. Pre-existing on `dev`, unrelated to that PR's feature work, so it is branched off `dev` and can land independently.

## What changes

**Messages say what happened and what to try.** Code 2 and code 100 are worded so either can appear for an unknown id without misleading the reader, since YouTube uses 2 for ids it merely doesn't recognise as well as for malformed ones.

**The default branch is fixed.** It used a plain string, so it printed the literal `${event.data}` instead of the error code.

**The malformed case gets named.** `YouTubePlayer.is_well_formed_id` checks the id against `[\w-]{11}` and, when it can't be a video id at all, `display_error` says so instead of relaying YouTube's answer — so a typo and a deleted video no longer produce the same message.

## The id check never blocks a load

Deliberate, and the reason is worth stating because the obvious implementation is worse.

Eleven characters of `[A-Za-z0-9_-]` has held since YouTube launched, but Google documents the id as an opaque string and has never promised a length. So `VIDEO_ID_PATTERN` is used **only to choose an error message**. If the format ever widens, the specific message stops appearing and everything falls back to today's behaviour — no valid URL is ever refused, and no release is needed to unbreak it.

That is not hypothetical caution. The same class of assumption is already broken next door, on the URL side:

```
https://www.youtube.com/shorts/dQw4w9WgXcQ  ->  'shorts'
https://www.youtube.com/live/dQw4w9WgXcQ    ->  'live'
https://www.youtube.com/watch?v=dQw4w9WgXcQ ->  'dQw4w9WgXcQ'
```

`YOUTUBE_URL_REGEX` matches Shorts and Live URLs and then extracts the path segment as the video id, so those links fail today. **This PR does not fix that** — it only means such a URL now produces a message about the address rather than one about asterisks. Flagging it for a separate change.

## Tests

`tests/player/test_youtube_player.py` pins the id-shape assumption, including the `shorts` / `live` values the regex currently mis-extracts, so a change in either place shows up as a test failure rather than silently.

Full suite on this branch: 2 failed / 1850 passed. Both failures are `tests/test_app.py::TestOpen` cases that also fail on `dev` under `-n auto` and pass serially — the known parallel-run flakiness, not this change.

## Repro bundle

The fixture is any `.tla` whose `media_path` is a YouTube URL with a bad id — generate one by saving a file with a valid YouTube URL through the CLI, then swapping `media_path` (don't hand-author the JSON, it drifts from the real serialization format).

```bash
uv run --python 3.12 tilia "$PWD/repro/yt-missing-video.tla"
```

**Acceptance criteria — unrecognised id** (`watch?v=zzzzzzzzzzz`, eleven valid characters):
- Do: launch with the fixture as the first file of the session.
- Was: "…a video ID that does not have 11 characters, or … invalid characters, such as exclamation points or asterisks."
- Now: "YouTube did not accept this video ID. Check that the address is a link to an existing video."

**Acceptance criteria — malformed id** (`watch?v=abc`):
- Do: same.
- Was: identical text to the case above — the two were indistinguishable.
- Now: "This does not look like the address of a YouTube video. Check the URL: the video id is the eleven-character code after 'watch?v=' or 'youtu.be/'."

`HEAD~1` is the message rewrite alone, without the id check, if you want to see the two effects separately.

## Note for #450

#450 touches the same `default:` line in `onError` (it fixes the template literal too), so whichever lands second will hit a one-hunk conflict there. Trivial to resolve.
