### PR TITLE
fix: beats added after a deletion lose measure structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ venv
 __pycache__
 tilia/dev
 
+# Generated repro fixtures
+.repro
+
 # IDEs
 .vscode
 .idea

--- a/tests/timelines/beat/test_beat_timeline.py
+++ b/tests/timelines/beat/test_beat_timeline.py
@@ -436,3 +436,50 @@ class TestBeatTimeline:
 
         assert len(tilia.timelines[0]) == 11
         assert tilia.timelines[0][-1].get_data("time") == 10
+
+    def test_insert_beats_after_deleting_all_beats(self, beat_tl):
+        for i in range(8):
+            beat_tl.create_beat(i)
+
+        beat_tl.delete_components(list(beat_tl.components))
+
+        assert beat_tl.beats_in_measure == []
+        assert beat_tl.measure_numbers == []
+
+        for i in range(8):
+            beat_tl.create_beat(i)
+
+        assert beat_tl.beats_in_measure == [4, 4]
+        assert [b.is_first_in_measure for b in beat_tl] == [
+            True,
+            False,
+            False,
+            False,
+            True,
+            False,
+            False,
+            False,
+        ]
+
+    def test_insert_beats_after_deleting_some_beats(self, beat_tl):
+        for i in range(8):
+            beat_tl.create_beat(i)
+
+        beat_tl.delete_components(list(beat_tl.components)[4:])
+
+        assert beat_tl.beats_in_measure == [4]
+
+        for i in range(8, 12):
+            beat_tl.create_beat(i)
+
+        assert beat_tl.beats_in_measure == [4, 4]
+        assert [b.is_first_in_measure for b in beat_tl] == [
+            True,
+            False,
+            False,
+            False,
+            True,
+            False,
+            False,
+            False,
+        ]

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -644,13 +644,12 @@ class BeatTimeline(Timeline):
         self.component_manager.compute_is_first_in_measure = False
         for component in list(reversed(components)):
             self.component_manager.delete_component(component)
-        self.component_manager.update_is_first_in_measure = True
+        self.component_manager.compute_is_first_in_measure = True
 
+        self.recalculate_measures()
         if not self.is_empty:
             self.component_manager.update_is_first_in_measure_of_subsequent_beats(0)
-            post(Post.BEAT_TIMELINE_MEASURE_NUMBER_CHANGE_DONE, self.id, 0)
-
-            # Higher index is possible.
+        post(Post.BEAT_TIMELINE_MEASURE_NUMBER_CHANGE_DONE, self.id, 0)
 
     class FillMethod(Enum):
         BY_AMOUNT = 0


### PR DESCRIPTION
Fixes the beat timeline losing its measure structure for every beat added after a deletion.

## The bug

`BeatTimeline.delete_components` disables the component manager's `compute_is_first_in_measure` flag for the duration of the deletion, then re-enables a misspelled attribute:

```python
self.component_manager.compute_is_first_in_measure = False
for component in list(reversed(components)):
    self.component_manager.delete_component(component)
self.component_manager.update_is_first_in_measure = True   # <- wrong attribute
```

The real flag stays `False` for the rest of the timeline's life. Every beat created afterwards takes the early-out in `BeatTLComponentManager.create_component`, so it skips `recalculate_measures()`, skips `beat.is_first_in_measure = ...`, and skips the `BEAT_TIMELINE_MEASURE_NUMBER_CHANGE_DONE` post — leaving the `Beat.__init__` default `is_first_in_measure = False`. Result: short dashes everywhere, no measure numbers.

Deleting *all* beats made it worse. The recompute was guarded by `if not self.is_empty:`, so an emptied timeline kept a stale `beats_in_measure` / `measure_numbers` describing beats that no longer existed.

Not limited to deleting everything — any multi-beat deletion leaves the flag stuck, so beats added after a partial delete are equally broken.

## The fix

Correct the attribute name, and move `recalculate_measures()` and the measure-number-change post out of the emptiness guard so an emptied timeline drops its stale measure data and the UI clears its labels.

Two regression tests in `tests/timelines/beat/test_beat_timeline.py` cover delete-all and delete-some followed by reinsertion. Full suite green: 1349 passed, 9 skipped, 2 xfailed, 2 xpassed.

## Repro bundle

Bundle format per #580. Nothing repro-specific is committed — the fixture is generated into `.repro/`, which this PR adds to `.gitignore`.

One-time setup, and note that re-running a checkout after you have made local edits can throw them away:

```bash
gh pr checkout 597
```

**Build the fixture**, from this branch's checkout at the repo root:

```bash
mkdir -p .repro && printf '%s\n' \
  'metadata set-media-length 60' \
  'timelines add beat --name "Measures" --beat-pattern 4' \
  'components beat --tl-name "Measures" --time 1' \
  'components beat --tl-name "Measures" --time 2' \
  'components beat --tl-name "Measures" --time 3' \
  'components beat --tl-name "Measures" --time 4' \
  'components beat --tl-name "Measures" --time 5' \
  'components beat --tl-name "Measures" --time 6' \
  'components beat --tl-name "Measures" --time 7' \
  'components beat --tl-name "Measures" --time 8' \
  'components beat --tl-name "Measures" --time 9' \
  'components beat --tl-name "Measures" --time 10' \
  'components beat --tl-name "Measures" --time 11' \
  'components beat --tl-name "Measures" --time 12' \
  "save \"$PWD/.repro/beat-delete-reinsert.tla\" --overwrite" \
  | uv run --python 3.12 tilia --user-interface cli
```

That leaves you on a "Measures" beat timeline with beat pattern 4 and twelve beats — three full measures. It is media-free (`media_path` empty, `media length` set), so it opens with no prompt and no error.

**See the bug**, on the base ref:

```bash
FIXTURE="$PWD/.repro/beat-delete-reinsert.tla"
git worktree add --detach ../tilia-base 0.6.5
cd ../tilia-base
uv run --python 3.12 tilia "$FIXTURE"
```

**See the fix**, back in this branch's checkout:

```bash
uv run --python 3.12 tilia "$PWD/.repro/beat-delete-reinsert.tla"
```

Close with `git worktree remove ../tilia-base`. Same fixture file both times; only the app code differs.

On Windows, run these in PowerShell — Git Bash expands `$PWD` to an MSYS path (`/c/Users/...`) that the interpreter cannot open.

### Acceptance criteria

- **Do:** select all beats on "Measures" and delete them, then add beats back.
- **Was:** every new beat drew as a short dash, no measure numbers appeared, and no beat was marked as starting a measure.
- **Should be:** every 4th beat draws as a long dash and starts a new measure, with measure numbers 1, 2, 3, … as before the deletion.

### What this bundle does not verify

The fix, the regression tests and the scenario all come from one author. The before/after pair shows that the scenario's behavior changed; it cannot show that the scenario is the bug as reported. The scenario and the criteria above are taken from the issue text rather than from the fix, but they exercise one path only: delete-all followed by clicking beats back in. Not covered — deleting a subset, `Fill with beats` as the reinsertion route, undo/redo across the deletion, and beat patterns other than 4. The regression tests cover delete-all and delete-some at the model level.
