### PR TITLE
fix: missing timeline toolbar on reopening a file

### DIFF
--- a/tests/ui/test_qtui.py
+++ b/tests/ui/test_qtui.py
@@ -7,12 +7,20 @@ from PySide6.QtCore import QEvent, QtMsgType, QUrl
 from tests.conftest import parametrize_tlui
 from tests.constants import EXAMPLE_MEDIA_PATH
 from tests.mock import PatchPost, Serve
-from tests.utils import get_actions_in_menu, get_main_window_menu
+from tests.utils import (
+    get_actions_in_menu,
+    get_main_window_menu,
+    get_tmp_file_with_dummy_timeline,
+)
 from tilia.boot import handle_qt_log_message
 from tilia.requests import Get, Post, post
+from tilia.settings import settings
 from tilia.timelines.timeline_kinds import TimelineKind
+from tilia.ui import commands
 from tilia.ui.commands import get_qaction
 from tilia.ui.qtui import FileDropEventFilter
+from tilia.ui.timelines.base.timeline import TimelineUI
+from tilia.ui.timelines.hierarchy import HierarchyTimelineUI
 from tilia.ui.timelines.marker import MarkerTimelineUI
 from tilia.ui.windows import WindowKind
 
@@ -115,6 +123,11 @@ def is_toolbar_visible(qtui, toolbar_class):
     return not toolbar[0].isHidden() if toolbar else False
 
 
+def open_file(path):
+    with Serve(Get.FROM_USER_SHOULD_SAVE_CHANGES, (True, False)):
+        commands.execute("file.open", path)
+
+
 class TestTimelineToolbars:
     @parametrize_tlui
     def test_is_visible_when_timeline_is_instantiated(self, qtui, tlui, request):
@@ -165,6 +178,39 @@ class TestTimelineToolbars:
         tls.set_timeline_data(marker_tl.id, "is_visible", True)
 
         assert is_toolbar_visible(qtui, MarkerTimelineUI.TOOLBAR_CLASS)
+
+    def test_is_visible_when_window_state_stored_for_file_hides_it(
+        self, qtui, tilia, tmp_path
+    ):
+        # Opening a file restores the window state stored under its path, which
+        # includes toolbar visibility. That state can be stale or, before toolbars
+        # had unique object names, belong to another timeline kind. The timelines
+        # in the file decide which toolbars are shown.
+        tmp_file = get_tmp_file_with_dummy_timeline(tmp_path)
+        open_file(tmp_file)
+
+        get_toolbars_of_class(qtui, HierarchyTimelineUI.TOOLBAR_CLASS)[0].hide()
+        settings.update_recent_files(
+            tmp_file, qtui.get_window_geometry(), qtui.get_window_state()
+        )
+
+        open_file(tmp_file)
+
+        assert is_toolbar_visible(qtui, HierarchyTimelineUI.TOOLBAR_CLASS)
+
+    def test_object_name_is_unique_across_toolbar_classes(self, qtui):
+        # QMainWindow.restoreState matches saved entries to live toolbars by object
+        # name. Duplicate names make it restore one kind's state onto another.
+        toolbar_classes = {
+            timeline_ui_class.TOOLBAR_CLASS
+            for timeline_ui_class in TimelineUI.subclasses()
+            if timeline_ui_class.TOOLBAR_CLASS
+        }
+        object_names = {
+            toolbar_class().objectName() for toolbar_class in toolbar_classes
+        }
+
+        assert len(object_names) == len(toolbar_classes)
 
 
 class TestDragAndDrop:

--- a/tilia/ui/qtui.py
+++ b/tilia/ui/qtui.py
@@ -431,6 +431,11 @@ class QtUI:
             self.main_window.restoreGeometry(geometry)
             self.main_window.restoreState(state)
 
+        # restoreState() also restores toolbar visibility, which may be stale or,
+        # for states saved before toolbars had unique object names, belong to a
+        # different timeline kind. The loaded timelines are the source of truth.
+        self.timeline_uis.update_toolbar_visibility()
+
         self._set_window_title_from_metadata_title()
 
     def _setup_widgets(self):

--- a/tilia/ui/timelines/collection/collection.py
+++ b/tilia/ui/timelines/collection/collection.py
@@ -699,6 +699,10 @@ class TimelineUIs:
             toolbar = tl_class.TOOLBAR_CLASS()
             self.main_window.addToolBar(toolbar)
             self.kind_to_toolbar[tl_kind] = toolbar
+            # addToolBar() only shows the toolbar on the next event loop iteration.
+            # Show it now, so that saving the window state right after opening a file
+            # does not record the toolbar as hidden.
+            toolbar.show()
 
     def _get_timeline_ui_by_scene(self, scene):
         return next((tlui for tlui in self if tlui.scene == scene), None)

--- a/tilia/ui/timelines/toolbar.py
+++ b/tilia/ui/timelines/toolbar.py
@@ -9,9 +9,10 @@ class TimelineToolbar(QToolBar):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.setObjectName("timeline_toolbar")
+        # The object name must be unique per toolbar class. QMainWindow.restoreState
+        # matches saved toolbar entries to live toolbars by object name, so sharing a
+        # single name across kinds makes it restore one kind's state onto another.
+        self.setObjectName(self.__class__.__name__)
         self.setContextMenuPolicy(Qt.ContextMenuPolicy.PreventContextMenu)
-        self.visible = False
-        self._visible_timelines_count = 0
         for command in self.COMMANDS:
             self.addAction(commands.get_qaction(command))


### PR DESCRIPTION
Fixes the recurring "timeline toolbar is missing" bug. Same root cause as #407; in #595 it is why the beat toolbar is absent and pressing <kbd>B</kbd> does nothing.

## Root cause

Not a Qt or C++ level problem. Three things in our own code combine:

1. `QtUI.on_file_loaded` calls `QMainWindow.restoreState()` with a window state stored **per absolute file path** in `QSettings` (`private/recent_files/<path>/state`). That is what makes the bug look machine- and path-dependent: the same file reproduces on one machine and not on another, and moving it to a different directory "fixes" it.
2. Every timeline toolbar used the object name `timeline_toolbar`. `restoreState()` matches saved entries to live toolbars **by object name**, in child order, so it can apply one timeline kind's saved state to a toolbar of another kind. That is exactly the #407 report: the harmony toolbar stayed visible while the hierarchy toolbar did not appear.
3. `QMainWindow.addToolBar()` only shows a toolbar on the **next event loop iteration** (`QLayout::addChildWidget` queues `_q_showIfNotHidden`). `App.on_open` saves the window state synchronously right after loading, so a toolbar created during that load is still hidden at save time and gets recorded as hidden. Reopening the file then restores it as hidden.

Point 3 only bites when the toolbar is created while the main window is **already visible**, which is why opening a file from the command line looks fine and opening it from the running app does not. It also explains @m-k94's "somehow it loaded fine the first time opening it".

## Changes

- Each toolbar class now gets its own object name (`self.__class__.__name__`), so `restoreState()` can no longer cross-assign state between timeline kinds.
- A newly added toolbar is shown immediately, so the window state saved right after a load does not record it as hidden.
- After restoring the window state, toolbar visibility is re-derived from the loaded timelines. The timelines are the source of truth, and this also repairs the states already stored in users' settings, so nobody has to clear their recent-files entries.

Also drops two unused attributes (`visible`, `_visible_timelines_count`) from `TimelineToolbar`.

Two regression tests in `tests/ui/test_qtui.py`, both verified to fail on `0.6.5` without the change:
- a stored window state that hides the toolbar must not survive reopening the file;
- toolbar object names must be unique across toolbar classes.

## Repro bundle

**Important deviation from the usual bundle:** passing the file on the command line does **not** reproduce. `boot()` calls `app.on_open` before `ui.launch()`, so the toolbar is parented to a still-hidden window, which Qt does not treat as hidden, and the saved state records it as shown. The file has to be opened from the running app.

Build the fixture, from this branch's checkout (PowerShell on Windows; `$PWD` in Git Bash is an MSYS path the interpreter cannot open):

```
mkdir -p .repro && printf '%s\n' \
  'metadata set-media-length 60' \
  'timelines add beat --name "Measures" --beat-pattern 4' \
  'components beat --tl-name "Measures" --time 5' \
  'components beat --tl-name "Measures" --time 10' \
  'components beat --tl-name "Measures" --time 15' \
  'components beat --tl-name "Measures" --time 20' \
  "save \"$PWD/.repro/issue-595.tla\" --overwrite" \
  | uv run --python 3.12 tilia --user-interface cli
```

See the bug, on the base ref:

```
git worktree add --detach ../tilia-base 23232ff6
cd ../tilia-base
uv run --python 3.12 tilia
```

See the fix, from this branch's checkout:

```
uv run --python 3.12 tilia
```

Close with `git worktree remove ../tilia-base`. In both cases open the fixture through **File > Open**, using its absolute path, and do it **twice in a row**.

### Acceptance criteria

1. **Action:** start with a blank project, open `.repro/issue-595.tla` via File > Open, open the same file a second time, then press <kbd>B</kbd>.
2. **Bug:** after the second open the beat toolbar is gone and <kbd>B</kbd> adds no beat.
3. **Correct:** the beat toolbar stays visible after every open and <kbd>B</kbd> adds a beat at the current position.

### What this bundle does not verify

The scenario, the fix and the tests all come from one analysis, so the before/after pair shows that behaviour changed, not that this is the bug as reported. Not covered: the cross-kind swap from #407 (only the object-name unit test speaks to that), window states written by older TiLiA versions or on another machine, and the beat-timeline behaviour that #595 originally opened with, which is a separate matter.

Refs #595, #407.
