### PR TITLE
perf: make beat timelines usable at 14k beats

### DIFF
--- a/scripts/bench_beat_insert.py
+++ b/scripts/bench_beat_insert.py
@@ -41,6 +41,12 @@ def main():
         default="middle",
         help="insert point: middle (worst case) or end (live-tap workload)",
     )
+    parser.add_argument(
+        "--batch",
+        action="store_true",
+        help="pause measure recalculation before tapping; resume at end. "
+        "Reports per-tap timings and the final catch-up cost.",
+    )
     parser.add_argument("--quiet", action="store_true")
     args = parser.parse_args()
 
@@ -104,6 +110,10 @@ def run_bench(args):
         print(f"# fill_with_beats took {fill_elapsed*1000:.1f} ms")
         print(f"# seeked to t={seek_time:.4f} (spacing={spacing:.4f})")
 
+    if args.batch:
+        commands.execute("timeline.beat.toggle_recalculate_measures")
+        q_app.processEvents()
+
     timings = []
     profiler = cProfile.Profile() if args.profile else None
     prev_count = len(beat_tl.components)
@@ -129,12 +139,21 @@ def run_bench(args):
         commands.execute("media.seek", seek_time)
         q_app.processEvents()
 
+    catch_up_elapsed = None
+    if args.batch:
+        t0 = time.perf_counter()
+        commands.execute("timeline.beat.toggle_recalculate_measures")
+        q_app.processEvents()
+        catch_up_elapsed = time.perf_counter() - t0
+
     print()
     for i, t in enumerate(timings):
         print(f"run {i + 1}: {t * 1000:8.2f} ms")
     print(f"min   : {min(timings) * 1000:8.2f} ms")
     print(f"median: {sorted(timings)[len(timings) // 2] * 1000:8.2f} ms")
     print(f"max   : {max(timings) * 1000:8.2f} ms")
+    if catch_up_elapsed is not None:
+        print(f"catch-up resume: {catch_up_elapsed * 1000:.2f} ms")
 
     if profiler:
         s = io.StringIO()

--- a/scripts/bench_beat_insert.py
+++ b/scripts/bench_beat_insert.py
@@ -35,6 +35,12 @@ def main():
     parser.add_argument("--profile", action="store_true", help="enable cProfile")
     parser.add_argument("--profile-top", type=int, default=30)
     parser.add_argument("--runs", type=int, default=3)
+    parser.add_argument(
+        "--position",
+        choices=["middle", "end"],
+        default="middle",
+        help="insert point: middle (worst case) or end (live-tap workload)",
+    )
     parser.add_argument("--quiet", action="store_true")
     args = parser.parse_args()
 
@@ -83,7 +89,10 @@ def run_bench(args):
     fill_elapsed = time.perf_counter() - fill_start
 
     spacing = 100.0 / args.n
-    seek_time = (args.n // 2) * spacing + spacing / 2
+    if args.position == "end":
+        seek_time = (args.n - 1) * spacing + spacing / 2
+    else:
+        seek_time = (args.n // 2) * spacing + spacing / 2
     commands.execute("media.seek", seek_time)
     q_app.processEvents()
 

--- a/scripts/bench_beat_insert.py
+++ b/scripts/bench_beat_insert.py
@@ -1,0 +1,139 @@
+"""
+Bench: middle-insert into an N-beat timeline.
+
+Usage examples:
+    python scripts/bench_beat_insert.py --n 1000 --platform offscreen
+    python scripts/bench_beat_insert.py --n 5000 --platform windows
+    python scripts/bench_beat_insert.py --n 1000 --profile
+    python scripts/bench_beat_insert.py --n 1000 --platform minimal --runs 5
+
+Notes:
+- --platform must be applied before any Qt import; we set QT_QPA_PLATFORM at
+  the top of main() before any tilia/PySide6 module is imported.
+- --profile wraps each timed insert in cProfile and prints the top-N cumulative
+  callers. Numbers are inflated by the profiler; use a non-profile run for
+  wall-clock comparisons.
+- --runs > 1 runs multiple inserts; each subsequent insert nudges the seek
+  position by 0.001s so unique-time validation still passes.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--n", type=int, default=1000, help="number of beats to fill")
+    parser.add_argument(
+        "--platform",
+        choices=["offscreen", "minimal", "windows"],
+        default="offscreen",
+        help="QT_QPA_PLATFORM to test under",
+    )
+    parser.add_argument("--profile", action="store_true", help="enable cProfile")
+    parser.add_argument("--profile-top", type=int, default=30)
+    parser.add_argument("--runs", type=int, default=3)
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args()
+
+    os.environ["QT_QPA_PLATFORM"] = args.platform
+    os.environ.setdefault("ENVIRONMENT", "test")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root))
+
+    run_bench(args)
+
+
+def run_bench(args):
+    import cProfile
+    import io
+    import pstats
+    import time
+
+    from PySide6.QtCore import Qt
+    from PySide6.QtWidgets import QApplication
+    from tilia.timelines.timeline_kinds import TimelineKind as TlKind
+
+    from tilia.boot import setup_logic
+    from tilia.timelines.beat.timeline import BeatTimeline
+    from tilia.ui import commands
+    from tilia.ui.qtui import QtUI, TiliaMainWindow
+
+    q_app = QApplication(sys.argv)
+
+    tilia = setup_logic(autosaver=False)
+    tilia.set_file_media_duration(100)
+    tilia.reset_undo_manager()
+
+    mw = TiliaMainWindow()
+    if args.platform == "windows":
+        mw.setAttribute(Qt.WidgetAttribute.WA_DontShowOnScreen)
+    QtUI(q_app, mw)
+
+    beat_tl: BeatTimeline = tilia.timelines.create_timeline(
+        TlKind.BEAT_TIMELINE, [], beat_pattern=[4]
+    )
+
+    fill_start = time.perf_counter()
+    beat_tl.fill_with_beats(BeatTimeline.FillMethod.BY_AMOUNT, args.n)
+    q_app.processEvents()
+    fill_elapsed = time.perf_counter() - fill_start
+
+    spacing = 100.0 / args.n
+    seek_time = (args.n // 2) * spacing + spacing / 2
+    commands.execute("media.seek", seek_time)
+    q_app.processEvents()
+
+    if not args.quiet:
+        print(
+            f"# platform={args.platform} N={args.n} runs={args.runs} "
+            f"profile={args.profile}"
+        )
+        print(f"# fill_with_beats took {fill_elapsed*1000:.1f} ms")
+        print(f"# seeked to t={seek_time:.4f} (spacing={spacing:.4f})")
+
+    timings = []
+    profiler = cProfile.Profile() if args.profile else None
+    prev_count = len(beat_tl.components)
+    for i in range(args.runs):
+        if profiler:
+            profiler.enable()
+        t0 = time.perf_counter()
+        commands.execute("timeline.beat.add")
+        q_app.processEvents()
+        elapsed = time.perf_counter() - t0
+        if profiler:
+            profiler.disable()
+        new_count = len(beat_tl.components)
+        if new_count != prev_count + 1:
+            raise RuntimeError(
+                f"run {i + 1}: insert failed silently "
+                f"(component count {prev_count} -> {new_count} at seek={seek_time:.6f})"
+            )
+        prev_count = new_count
+        timings.append(elapsed)
+
+        seek_time += spacing / 10
+        commands.execute("media.seek", seek_time)
+        q_app.processEvents()
+
+    print()
+    for i, t in enumerate(timings):
+        print(f"run {i + 1}: {t * 1000:8.2f} ms")
+    print(f"min   : {min(timings) * 1000:8.2f} ms")
+    print(f"median: {sorted(timings)[len(timings) // 2] * 1000:8.2f} ms")
+    print(f"max   : {max(timings) * 1000:8.2f} ms")
+
+    if profiler:
+        s = io.StringIO()
+        stats = pstats.Stats(profiler, stream=s).strip_dirs().sort_stats("cumulative")
+        stats.print_stats(args.profile_top)
+        print()
+        print(s.getvalue())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_beat_zoom.py
+++ b/scripts/bench_beat_zoom.py
@@ -1,0 +1,112 @@
+"""
+Bench: zoom in on an N-beat timeline.
+
+Usage examples:
+    python scripts/bench_beat_zoom.py --n 1000 --platform offscreen
+    python scripts/bench_beat_zoom.py --n 14000 --platform offscreen --profile
+    python scripts/bench_beat_zoom.py --n 14000 --platform windows --runs 5
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--n", type=int, default=1000, help="number of beats to fill")
+    parser.add_argument(
+        "--platform",
+        choices=["offscreen", "minimal", "windows"],
+        default="offscreen",
+    )
+    parser.add_argument("--profile", action="store_true")
+    parser.add_argument("--profile-top", type=int, default=40)
+    parser.add_argument("--runs", type=int, default=3)
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args()
+
+    os.environ["QT_QPA_PLATFORM"] = args.platform
+    os.environ.setdefault("ENVIRONMENT", "test")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root))
+
+    run_bench(args)
+
+
+def run_bench(args):
+    import cProfile
+    import io
+    import pstats
+    import time
+
+    from PySide6.QtCore import Qt
+    from PySide6.QtWidgets import QApplication
+    from tilia.timelines.timeline_kinds import TimelineKind as TlKind
+
+    from tilia.boot import setup_logic
+    from tilia.timelines.beat.timeline import BeatTimeline
+    from tilia.ui import commands
+    from tilia.ui.qtui import QtUI, TiliaMainWindow
+
+    q_app = QApplication(sys.argv)
+
+    tilia = setup_logic(autosaver=False)
+    tilia.set_file_media_duration(100)
+    tilia.reset_undo_manager()
+
+    mw = TiliaMainWindow()
+    if args.platform == "windows":
+        mw.setAttribute(Qt.WidgetAttribute.WA_DontShowOnScreen)
+    QtUI(q_app, mw)
+
+    beat_tl: BeatTimeline = tilia.timelines.create_timeline(
+        TlKind.BEAT_TIMELINE, [], beat_pattern=[4]
+    )
+
+    fill_start = time.perf_counter()
+    beat_tl.fill_with_beats(BeatTimeline.FillMethod.BY_AMOUNT, args.n)
+    q_app.processEvents()
+    fill_elapsed = time.perf_counter() - fill_start
+
+    if not args.quiet:
+        print(
+            f"# platform={args.platform} N={args.n} runs={args.runs} "
+            f"profile={args.profile}"
+        )
+        print(f"# fill_with_beats took {fill_elapsed*1000:.1f} ms")
+
+    timings = []
+    profiler = cProfile.Profile() if args.profile else None
+    for i in range(args.runs):
+        direction = "in" if i % 2 == 0 else "out"
+        if profiler:
+            profiler.enable()
+        t0 = time.perf_counter()
+        commands.execute(f"view.zoom.{direction}")
+        q_app.processEvents()
+        elapsed = time.perf_counter() - t0
+        if profiler:
+            profiler.disable()
+        timings.append((direction, elapsed))
+
+    print()
+    for i, (direction, t) in enumerate(timings):
+        print(f"run {i + 1} ({direction}): {t * 1000:8.2f} ms")
+    raw = [t for _, t in timings]
+    print(f"min   : {min(raw) * 1000:8.2f} ms")
+    print(f"median: {sorted(raw)[len(raw) // 2] * 1000:8.2f} ms")
+    print(f"max   : {max(raw) * 1000:8.2f} ms")
+
+    if profiler:
+        s = io.StringIO()
+        stats = pstats.Stats(profiler, stream=s).strip_dirs().sort_stats("cumulative")
+        stats.print_stats(args.profile_top)
+        print()
+        print(s.getvalue())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/parsers/csv/test_beats_from_csv.py
+++ b/tests/parsers/csv/test_beats_from_csv.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from unittest.mock import mock_open, patch
 
+import pytest
+
 from tests.parsers.csv.common import assert_in_errors
 from tilia.parsers.csv.beat import beats_from_csv
 from tilia.timelines.base.metric_position import MetricPosition
@@ -112,3 +114,13 @@ def test_with_invalid_is_first_in_measure(beat_tl):
     _import_with_patch(beat_tl, data)
 
     assert beat_tl.beats_in_measure == [5, 3]
+
+
+@pytest.mark.timeout(5)
+def test_import_many_beats_from_csv(beat_tl, tilia_state):
+    tilia_state.set_duration(1000, scale_timelines="no")
+    data = "time\n" + "\n".join(str(i) for i in range(1000))
+
+    _import_with_patch(beat_tl, data)
+
+    assert len(beat_tl) == 1000

--- a/tests/timelines/beat/test_beat_timeline_perf.py
+++ b/tests/timelines/beat/test_beat_timeline_perf.py
@@ -1,0 +1,27 @@
+import time
+
+import pytest
+
+from tilia.timelines.beat.timeline import BeatTimeline
+from tilia.ui import commands
+
+
+class TestBeatTimelinePerf:
+    @pytest.mark.timeout(30)
+    def test_middle_insert_into_1000_beats_completes_quickly(
+        self, beat_tlui, tilia_state
+    ):
+        tilia_state.duration = 100.0
+        beat_tlui.timeline.fill_with_beats(BeatTimeline.FillMethod.BY_AMOUNT, 1000)
+
+        commands.execute("media.seek", 50.0 + 0.05)
+
+        start = time.perf_counter()
+        commands.execute("timeline.beat.add")
+        elapsed = time.perf_counter() - start
+
+        assert len(beat_tlui) == 1001
+        assert elapsed < 2.0, (
+            f"Single-beat insert into 1000-beat timeline took {elapsed:.2f}s; "
+            "expected < 2.0s. Possible O(N^2) regression in beat-insert path."
+        )

--- a/tests/ui/timelines/beat/test_beat_timeline_ui.py
+++ b/tests/ui/timelines/beat/test_beat_timeline_ui.py
@@ -3,12 +3,15 @@ from unittest.mock import MagicMock
 import pytest
 
 from tests.mock import Serve, patch_yes_or_no_dialog
-from tests.utils import undoable
+from tests.utils import get_command_action, undoable
 from tilia.requests import Get, Post, post
 from tilia.settings import settings
 from tilia.timelines.beat.timeline import BeatTimeline
 from tilia.ui import commands
+from tilia.ui.timelines.beat.context_menu import BeatTimelineUIContextMenu
 from tilia.ui.windows import WindowKind
+
+TOGGLE_RECALC = "timeline.beat.toggle_recalculate_measures"
 
 
 def get_displayed_measure_number(beat_ui):
@@ -630,3 +633,49 @@ class TestUndoRedo:
             "1",
             "2",
         ]
+
+
+class TestToggleRecalculateMeasures:
+    @pytest.fixture(autouse=True)
+    def reset_action(self):
+        # The QAction is a process-wide singleton, so its check state would
+        # leak between tests. Reset it around each test.
+        action = commands.get_qaction(TOGGLE_RECALC)
+        action.setChecked(False)
+        yield
+        action.setChecked(False)
+
+    def test_action_is_checkable_and_starts_unchecked(self, beat_tlui):
+        action = commands.get_qaction(TOGGLE_RECALC)
+        assert action.isCheckable()
+        assert not action.isChecked()
+        assert beat_tlui.timeline.component_manager.compute_is_first_in_measure
+
+    def test_pause_sets_cm_flag_false_and_checks_action(self, beat_tlui):
+        commands.execute(TOGGLE_RECALC)
+
+        cm = beat_tlui.timeline.component_manager
+        assert cm.compute_is_first_in_measure is False
+        assert commands.get_qaction(TOGGLE_RECALC).isChecked()
+
+    def test_resume_runs_catch_up_recalc(self, beat_tlui):
+        beat_tlui.timeline.beat_pattern = [2]
+        commands.execute(TOGGLE_RECALC)
+
+        commands.execute("media.seek", 1.0)
+        commands.execute("timeline.beat.add")
+        commands.execute("media.seek", 2.0)
+        commands.execute("timeline.beat.add")
+
+        assert len(beat_tlui.timeline.components) == 2
+        assert sum(beat_tlui.timeline.beats_in_measure) == 0
+
+        commands.execute(TOGGLE_RECALC)
+
+        assert sum(beat_tlui.timeline.beats_in_measure) == 2
+        assert beat_tlui.timeline.component_manager.compute_is_first_in_measure
+        assert not commands.get_qaction(TOGGLE_RECALC).isChecked()
+
+    def test_context_menu_includes_toggle(self, beat_tlui):
+        menu = BeatTimelineUIContextMenu(beat_tlui, 0, 0)
+        assert get_command_action(menu, TOGGLE_RECALC) is not None

--- a/tests/ui/timelines/beat/test_beat_timeline_ui.py
+++ b/tests/ui/timelines/beat/test_beat_timeline_ui.py
@@ -679,3 +679,17 @@ class TestToggleRecalculateMeasures:
     def test_context_menu_includes_toggle(self, beat_tlui):
         menu = BeatTimelineUIContextMenu(beat_tlui, 0, 0)
         assert get_command_action(menu, TOGGLE_RECALC) is not None
+
+    def test_context_menu_trigger_does_not_error(self, beat_tlui):
+        # TimelineUIContextMenu.add_action rewires the action's triggered
+        # signal to pass the clicked timeline_ui as an extra positional arg
+        # to commands.execute. Make sure the toggle callback tolerates it
+        # (regression guard against the "takes 1 positional argument but 2
+        # were given" TypeError).
+        menu = BeatTimelineUIContextMenu(beat_tlui, 0, 0)
+        action = get_command_action(menu, TOGGLE_RECALC)
+        assert action is not None
+        action.trigger()
+
+        cm = beat_tlui.timeline.component_manager
+        assert cm.compute_is_first_in_measure is False

--- a/tilia/parsers/csv/beat.py
+++ b/tilia/parsers/csv/beat.py
@@ -125,7 +125,7 @@ def beats_from_csv(
             timeline.set_data("measures_to_force_display", measures_to_force_display)
 
     component_manager = timeline.component_manager
-    with component_manager.is_first_in_measure_computation_paused():
+    with component_manager.suppressing_is_first_in_measure():
         with TiliaCSVReader(path, file_kwargs, reader_kwargs) as reader:
             next(reader)
             for row in reader:

--- a/tilia/parsers/csv/beat.py
+++ b/tilia/parsers/csv/beat.py
@@ -124,21 +124,22 @@ def beats_from_csv(
             timeline.set_data("measure_numbers", measure_numbers)
             timeline.set_data("measures_to_force_display", measures_to_force_display)
 
-    with TiliaCSVReader(path, file_kwargs, reader_kwargs) as reader:
-        next(reader)
-        for row in reader:
-            if not row:
-                continue
+    component_manager = timeline.component_manager
+    with component_manager.is_first_in_measure_computation_paused():
+        with TiliaCSVReader(path, file_kwargs, reader_kwargs) as reader:
+            next(reader)
+            for row in reader:
+                if not row:
+                    continue
 
-            constructor_kwargs = {}
-            index = params_to_indices["time"]
-            constructor_kwargs["time"] = float(row[index])
+                constructor_kwargs = {"time": float(row[params_to_indices["time"]])}
 
-            component, fail_reason = timeline.create_component(
-                ComponentKind.BEAT, **constructor_kwargs
-            )
-            if not component:
-                errors.append(fail_reason)
+                component, fail_reason = timeline.create_component(
+                    ComponentKind.BEAT, **constructor_kwargs
+                )
+                if not component:
+                    errors.append(fail_reason)
 
-            timeline.recalculate_measures()
-        return True, errors
+    timeline.recalculate_measures()
+    component_manager.update_is_first_in_measure_of_subsequent_beats(0)
+    return True, errors

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -12,6 +12,7 @@ import tilia.errors
 from tilia.requests import Get, LongOperation, Post, get, long_operation, post
 from tilia.settings import settings
 from tilia.timelines.base.component.pointlike import crop_pointlike
+from tilia.timelines.base.metric_position import MetricPosition
 from tilia.timelines.base.timeline import (
     TC,
     Timeline,
@@ -537,26 +538,75 @@ class BeatTimeline(Timeline):
         self.update_metric_fraction_dicts()
 
     def update_metric_fraction_dicts(self):
-        self.metric_fraction_to_beat_dict = {}
-        self.metric_fraction_to_time = {}
-        self.time_to_metric_fraction = {}
-        for beat in self.components:
+        # Two-pointer pass over components: walk btsm in parallel with
+        # beat-index enumeration so we never need a bisect per beat. We also
+        # populate `_cached_metric_position` inline — `recalculate_measures`
+        # cleared the caches just before this call, so every beat would be a
+        # cache miss otherwise, and the values we compute here are exactly
+        # what `metric_position` would lazily produce.
+        metric_fraction_to_beat_dict: dict[float, list[Beat]] = {}
+        metric_fraction_to_time: dict[float, list[float]] = {}
+        time_to_metric_fraction: dict[float, float] = {}
+
+        components = self.components
+        if not components:
+            self.metric_fraction_to_beat_dict = metric_fraction_to_beat_dict
+            self.metric_fraction_to_time = metric_fraction_to_time
+            self.time_to_metric_fraction = time_to_metric_fraction
+            return
+
+        btsm = self.beats_that_start_measures
+        measure_numbers = self.measure_numbers
+        beats_in_measure = self.beats_in_measure
+        btsm_count = len(btsm)
+
+        measure_index = 0
+        next_measure_start = btsm[1] if btsm_count > 1 else math.inf
+
+        for beat_index, beat in enumerate(components):
+            while beat_index >= next_measure_start:
+                measure_index += 1
+                next_measure_start = (
+                    btsm[measure_index + 1]
+                    if measure_index + 1 < btsm_count
+                    else math.inf
+                )
+
+            beat_in_measure = beat_index - btsm[measure_index] + 1
+            beat_count_in_measure = beats_in_measure[measure_index]
+            measure_number = measure_numbers[measure_index]
+
+            beat._cached_metric_position = MetricPosition(
+                measure_number, beat_in_measure, beat_count_in_measure
+            )
+
             metric_fraction = round(
-                (mp := beat.metric_position).measure
-                + (mp.beat - 1) / mp.measure_beat_count,
+                measure_number + (beat_in_measure - 1) / beat_count_in_measure,
                 3,
             )
-            if mp := self.metric_fraction_to_beat_dict.get(metric_fraction):
-                mp.append(beat)
-                self.metric_fraction_to_time[metric_fraction].append(beat.time)
-                self.time_to_metric_fraction[beat.time] = metric_fraction
+            if metric_fraction in metric_fraction_to_beat_dict:
+                metric_fraction_to_beat_dict[metric_fraction].append(beat)
+                metric_fraction_to_time[metric_fraction].append(beat.time)
             else:
-                self.metric_fraction_to_beat_dict[metric_fraction] = [beat]
-                self.metric_fraction_to_time[metric_fraction] = [beat.time]
-                self.time_to_metric_fraction[beat.time] = metric_fraction
-        self.__sort_metric_to_beat()
-        self.__sort_metric_to_time()
-        self.__sort_time_to_metric()
+                metric_fraction_to_beat_dict[metric_fraction] = [beat]
+                metric_fraction_to_time[metric_fraction] = [beat.time]
+            time_to_metric_fraction[beat.time] = metric_fraction
+
+        # measure_numbers can be arbitrary (e.g. pickup measures number their
+        # entries non-monotonically), so the dicts may not be in sorted-key
+        # order even though we iterated beats in beat-index order. Reorder
+        # before publishing so downstream consumers (which rely on sorted-key
+        # iteration via list(...keys()) / bisect) see consistent state.
+        self.metric_fraction_to_beat_dict = {
+            k: metric_fraction_to_beat_dict[k]
+            for k in sorted(metric_fraction_to_beat_dict)
+        }
+        self.metric_fraction_to_time = {
+            k: metric_fraction_to_time[k] for k in sorted(metric_fraction_to_time)
+        }
+        self.time_to_metric_fraction = {
+            k: time_to_metric_fraction[k] for k in sorted(time_to_metric_fraction)
+        }
 
     def __sort_metric_to_beat(self) -> None:
         self.metric_fraction_to_beat_dict = {

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -76,9 +76,12 @@ class BeatTLComponentManager(TimelineComponentManager):
 
         if success:
             if self.compute_is_first_in_measure:
-                self.timeline.recalculate_measures()
-                beat.is_first_in_measure = self.timeline.is_first_in_measure(beat)
+                # get_beat_index works before recalculate_measures (just a
+                # bisect on times), so we can compute the insertion index
+                # first and use it to scope the recalc to beats[K:].
                 new_beat_index = self.timeline.get_beat_index(beat)
+                self.timeline.recalculate_measures(start_index=new_beat_index)
+                beat.is_first_in_measure = self.timeline.is_first_in_measure(beat)
                 self.update_is_first_in_measure_of_subsequent_beats(new_beat_index + 1)
                 post(
                     Post.BEAT_TIMELINE_MEASURE_NUMBER_CHANGE_DONE,
@@ -390,11 +393,20 @@ class BeatTimeline(Timeline):
     def is_first_in_measure(self, beat):
         return self.get_beat_index(beat) in self.beats_that_start_measures_set
 
-    def clear_cached_metric_positions(self):
-        for beat in self:
-            beat.clear_cached_metric_position()
+    def clear_cached_metric_positions(self, start_index: int = 0):
+        # When start_index > 0, only invalidate caches for beats[start_index:].
+        # Upstream beats keep their cached positions because they're unaffected
+        # by a downstream structural change (e.g. a middle insert at K only
+        # shifts beats[K:] in their measures; beats[:K] keep their old measure
+        # / beat-in-measure / beat-count).
+        if start_index <= 0:
+            for beat in self:
+                beat.clear_cached_metric_position()
+        else:
+            for beat in self.components[start_index:]:
+                beat.clear_cached_metric_position()
 
-    def recalculate_measures(self):
+    def recalculate_measures(self, start_index: int = 0):
         beat_delta = (len(self)) - sum(self.beats_in_measure)
         if beat_delta > 0:
             self.extend_beats_in_measure(beat_delta)
@@ -403,8 +415,8 @@ class BeatTimeline(Timeline):
             self.reduce_beats_in_measure(-beat_delta)
             self.reduce_measure_numbers()
 
-        self.clear_cached_metric_positions()
-        self.update_beats_that_start_measures()
+        self.clear_cached_metric_positions(start_index)
+        self.update_beats_that_start_measures(start_index)
 
     @staticmethod
     def get_extension_from_beat_pattern(
@@ -529,30 +541,34 @@ class BeatTimeline(Timeline):
             ):
                 self.measures_to_force_display.pop(-1)
 
-    def update_beats_that_start_measures(self):
+    def update_beats_that_start_measures(self, start_index: int = 0):
         # noinspection PyAttributeOutsideInit
         self.beats_that_start_measures = [0] + list(
             itertools.accumulate(self.beats_in_measure[:-1])
         )
         self.beats_that_start_measures_set = set(self.beats_that_start_measures)
-        self.update_metric_fraction_dicts()
+        self.update_metric_fraction_dicts(start_index)
 
-    def update_metric_fraction_dicts(self):
+    def update_metric_fraction_dicts(self, start_index: int = 0):
         # Two-pointer pass over components: walk btsm in parallel with
-        # beat-index enumeration so we never need a bisect per beat. We also
-        # populate `_cached_metric_position` inline — `recalculate_measures`
-        # cleared the caches just before this call, so every beat would be a
-        # cache miss otherwise, and the values we compute here are exactly
-        # what `metric_position` would lazily produce.
-        metric_fraction_to_beat_dict: dict[float, list[Beat]] = {}
-        metric_fraction_to_time: dict[float, list[float]] = {}
-        time_to_metric_fraction: dict[float, float] = {}
-
+        # beat-index enumeration so we never need a bisect per beat. Populate
+        # `_cached_metric_position` inline — when start_index == 0 the caches
+        # have just been cleared by `recalculate_measures`, and when
+        # start_index > 0 only beats[start_index:] were invalidated, so the
+        # values we compute here are exactly what `metric_position` would
+        # lazily produce.
+        #
+        # When start_index > 0, we incrementally update the three dicts:
+        # upstream beats (0..start_index-1) keep their entries untouched
+        # because their metric_position is unchanged. Only entries for
+        # beats[start_index:] are removed and re-added with their new
+        # positions. This is the load-bearing optimization for end-insert
+        # (where start_index == len(components) - 1, so almost no work).
         components = self.components
         if not components:
-            self.metric_fraction_to_beat_dict = metric_fraction_to_beat_dict
-            self.metric_fraction_to_time = metric_fraction_to_time
-            self.time_to_metric_fraction = time_to_metric_fraction
+            self.metric_fraction_to_beat_dict = {}
+            self.metric_fraction_to_time = {}
+            self.time_to_metric_fraction = {}
             return
 
         btsm = self.beats_that_start_measures
@@ -560,10 +576,51 @@ class BeatTimeline(Timeline):
         beats_in_measure = self.beats_in_measure
         btsm_count = len(btsm)
 
-        measure_index = 0
-        next_measure_start = btsm[1] if btsm_count > 1 else math.inf
+        if start_index <= 0 or not self.metric_fraction_to_beat_dict:
+            # Full rebuild.
+            metric_fraction_to_beat_dict: dict[float, list[Beat]] = {}
+            metric_fraction_to_time: dict[float, list[float]] = {}
+            time_to_metric_fraction: dict[float, float] = {}
+            loop_start = 0
+            measure_index = 0
+        else:
+            # Incremental: keep upstream entries; remove stale entries for
+            # beats[start_index:] (their old metric_fractions are looked up
+            # via time_to_metric_fraction, then we filter beat-id-matched
+            # entries out of the list-valued dicts).
+            metric_fraction_to_beat_dict = self.metric_fraction_to_beat_dict
+            metric_fraction_to_time = self.metric_fraction_to_time
+            time_to_metric_fraction = self.time_to_metric_fraction
 
-        for beat_index, beat in enumerate(components):
+            stale_beats = components[start_index:]
+            stale_beat_ids = {id(b) for b in stale_beats}
+            stale_fractions: set[float] = set()
+            for beat in stale_beats:
+                old_fraction = time_to_metric_fraction.pop(beat.time, None)
+                if old_fraction is not None:
+                    stale_fractions.add(old_fraction)
+
+            for fraction in stale_fractions:
+                beat_list = metric_fraction_to_beat_dict[fraction]
+                kept = [b for b in beat_list if id(b) not in stale_beat_ids]
+                if kept:
+                    metric_fraction_to_beat_dict[fraction] = kept
+                    metric_fraction_to_time[fraction] = [b.time for b in kept]
+                else:
+                    del metric_fraction_to_beat_dict[fraction]
+                    del metric_fraction_to_time[fraction]
+
+            loop_start = start_index
+            measure_index = bisect(btsm, start_index) - 1
+            if measure_index < 0:
+                measure_index = 0
+
+        next_measure_start = (
+            btsm[measure_index + 1] if measure_index + 1 < btsm_count else math.inf
+        )
+
+        for beat_index in range(loop_start, len(components)):
+            beat = components[beat_index]
             while beat_index >= next_measure_start:
                 measure_index += 1
                 next_measure_start = (
@@ -592,11 +649,11 @@ class BeatTimeline(Timeline):
                 metric_fraction_to_time[metric_fraction] = [beat.time]
             time_to_metric_fraction[beat.time] = metric_fraction
 
-        # measure_numbers can be arbitrary (e.g. pickup measures number their
-        # entries non-monotonically), so the dicts may not be in sorted-key
-        # order even though we iterated beats in beat-index order. Reorder
-        # before publishing so downstream consumers (which rely on sorted-key
-        # iteration via list(...keys()) / bisect) see consistent state.
+        # measure_numbers can be non-monotonic (pickup measures number their
+        # entries arbitrarily, e.g. [1, 3, 0, 2, 4, 5]), so dict insertion
+        # order does not necessarily match sorted-key order. Reorder before
+        # publishing so downstream consumers (which iterate keys via
+        # list(...keys()) / bisect) see sorted state.
         self.metric_fraction_to_beat_dict = {
             k: metric_fraction_to_beat_dict[k]
             for k in sorted(metric_fraction_to_beat_dict)

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -69,7 +69,7 @@ class BeatTLComponentManager(TimelineComponentManager):
             if self.compute_is_first_in_measure:
                 self.timeline.recalculate_measures()
                 beat.is_first_in_measure = self.timeline.is_first_in_measure(beat)
-                beat_index = self.get_components().index(beat) + 1
+                beat_index = self.timeline.get_beat_index(beat) + 1
                 self.update_is_first_in_measure_of_subsequent_beats(beat_index)
                 measure_index = self.timeline.get_measure_index(beat_index)[0]
                 post(
@@ -90,7 +90,7 @@ class BeatTLComponentManager(TimelineComponentManager):
         return Beat.validate_creation(time, self.beat_times)
 
     def delete_component(self, component: TC) -> None:
-        component_idx = self.get_components().index(component)
+        component_idx = self.timeline.get_beat_index(component)
         super().delete_component(component)
         if self.compute_is_first_in_measure:
             self.update_is_first_in_measure_of_subsequent_beats(component_idx - 1)
@@ -380,7 +380,7 @@ class BeatTimeline(Timeline):
         ) + metric_fraction[idx - 1]
 
     def is_first_in_measure(self, beat):
-        return self.components.index(beat) in self.beats_that_start_measures_set
+        return self.get_beat_index(beat) in self.beats_that_start_measures_set
 
     def clear_cached_metric_positions(self):
         for beat in self:

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import itertools
 import math
 from bisect import bisect, bisect_left
+from collections.abc import Iterator
 from contextlib import contextmanager
 from enum import Enum
 from math import isclose
@@ -32,13 +33,23 @@ class BeatTLComponentManager(TimelineComponentManager):
         self.compute_metric_fraction_dict = True
 
     @contextmanager
-    def is_first_in_measure_computation_paused(self):
-        previous = self.compute_is_first_in_measure
+    def suppressing_is_first_in_measure(self) -> Iterator[bool]:
+        """
+        Suppress per-beat measure recomputation for the duration of the block.
+
+        Yields the value the flag had on entry, so a caller can tell whether it
+        owns the recomputation or an outer block will do it once at the end.
+        Restoring that value rather than a literal True is what keeps nested
+        blocks correct; the try/finally keeps a raising body from leaving the
+        flag off for the rest of the timeline's life, which would silently stop
+        every beat created afterwards from getting any measure data.
+        """
+        was_computing = self.compute_is_first_in_measure
         self.compute_is_first_in_measure = False
         try:
-            yield
+            yield was_computing
         finally:
-            self.compute_is_first_in_measure = previous
+            self.compute_is_first_in_measure = was_computing
 
     @property
     def beat_times(self):
@@ -160,11 +171,11 @@ class BeatTLComponentManager(TimelineComponentManager):
         self.timeline.update_metric_fraction_dicts()
 
     def crop(self, length: float) -> None:
-        with self.is_first_in_measure_computation_paused():
+        with self.suppressing_is_first_in_measure():
             crop_pointlike(self, length)
 
     def clear(self):
-        with self.is_first_in_measure_computation_paused():
+        with self.suppressing_is_first_in_measure():
             for component in self._components.copy():
                 self.delete_component(component)
 
@@ -174,7 +185,7 @@ class BeatTLComponentManager(TimelineComponentManager):
         measure_numbers = self.timeline.measure_numbers.copy()
         measures_to_force_display = self.timeline.measures_to_force_display.copy()
 
-        with self.is_first_in_measure_computation_paused():
+        with self.suppressing_is_first_in_measure():
             # This call will change the attributes above.
             super().deserialize_components(serialized_components)
 
@@ -190,7 +201,7 @@ class BeatTLComponentManager(TimelineComponentManager):
 
     def restore_state(self, prev_state: dict):
         self.timeline.clear_cached_metric_positions()
-        with self.is_first_in_measure_computation_paused():
+        with self.suppressing_is_first_in_measure():
             super().restore_state(prev_state)
         self.timeline.recalculate_measures()
         self.update_is_first_in_measure_of_subsequent_beats(0)
@@ -758,7 +769,7 @@ class BeatTimeline(Timeline):
 
         self.clear_cached_metric_positions()
 
-        with self.component_manager.is_first_in_measure_computation_paused():
+        with self.component_manager.suppressing_is_first_in_measure():
             for component in list(reversed(components)):
                 self.component_manager.delete_component(component)
 
@@ -776,7 +787,7 @@ class BeatTimeline(Timeline):
     def fill_with_beats(self, method: BeatTimeline.FillMethod, value: int | float):
         duration = get(Get.MEDIA_DURATION)
 
-        with self.component_manager.is_first_in_measure_computation_paused():
+        with self.component_manager.suppressing_is_first_in_measure():
             if method == BeatTimeline.FillMethod.BY_AMOUNT:
                 total = int(value)
                 for i in range(total):

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -77,13 +77,12 @@ class BeatTLComponentManager(TimelineComponentManager):
             if self.compute_is_first_in_measure:
                 self.timeline.recalculate_measures()
                 beat.is_first_in_measure = self.timeline.is_first_in_measure(beat)
-                beat_index = self.timeline.get_beat_index(beat) + 1
-                self.update_is_first_in_measure_of_subsequent_beats(beat_index)
-                measure_index = self.timeline.get_measure_index(beat_index)[0]
+                new_beat_index = self.timeline.get_beat_index(beat)
+                self.update_is_first_in_measure_of_subsequent_beats(new_beat_index + 1)
                 post(
                     Post.BEAT_TIMELINE_MEASURE_NUMBER_CHANGE_DONE,
                     self.timeline.id,
-                    measure_index - 1,
+                    new_beat_index,
                 )
 
         return success, beat, reason

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -570,18 +570,15 @@ class BeatTimeline(Timeline):
         }
 
     def get_measure_index(self, beat_index: int) -> tuple[int, int]:
-        prev_n = 0
-        for measure_index, n in enumerate(self.beats_that_start_measures):
-            if beat_index < n:
-                return measure_index - 1, beat_index - prev_n
-            elif beat_index == n:
-                return measure_index, 0
-            prev_n = n
-
-        if beat_index > n:
-            return measure_index, 1
-        else:
+        btsm = self.beats_that_start_measures
+        if not btsm:
             raise ValueError(f'No beat with index "{beat_index}" at {self}.')
+        idx = bisect(btsm, beat_index) - 1
+        if idx < 0:
+            raise ValueError(f'No beat with index "{beat_index}" at {self}.')
+        if beat_index > btsm[-1]:
+            return len(btsm) - 1, 1
+        return idx, beat_index - btsm[idx]
 
     def get_beat_index(self, beat: Beat) -> int:
         return bisect_left(

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -44,6 +44,14 @@ class BeatTLComponentManager(TimelineComponentManager):
         return {b.time for b in self._components}
 
     def update_is_first_in_measure_of_subsequent_beats(self, start_index):
+        # metric_position depends on get_beat_index / get_measure_index /
+        # measure_numbers / beats_in_measure, none of which involve the
+        # is_first_in_measure flag. Mutating that flag therefore can't make
+        # metric_fraction_dicts stale, so no rebuild is needed here. Every
+        # caller of this method either rebuilt the dicts via
+        # recalculate_measures before invoking it (create_component,
+        # restore_state, CSV parser) or rebuilds them after, separately
+        # (delete_component's UI follow-up).
         self.compute_metric_fraction_dict = False
         beats_that_start_measure = set(self.timeline.beats_that_start_measures)
         for i, beat in enumerate(self.timeline[start_index:]):
@@ -56,7 +64,6 @@ class BeatTLComponentManager(TimelineComponentManager):
                 )
 
         self.compute_metric_fraction_dict = True
-        self.timeline.update_metric_fraction_dicts()
 
     def create_component(
         self, kind: ComponentKind, timeline, id, *args, **kwargs

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -44,26 +44,27 @@ class BeatTLComponentManager(TimelineComponentManager):
         return {b.time for b in self._components}
 
     def update_is_first_in_measure_of_subsequent_beats(self, start_index):
-        # metric_position depends on get_beat_index / get_measure_index /
-        # measure_numbers / beats_in_measure, none of which involve the
-        # is_first_in_measure flag. Mutating that flag therefore can't make
-        # metric_fraction_dicts stale, so no rebuild is needed here. Every
-        # caller of this method either rebuilt the dicts via
-        # recalculate_measures before invoking it (create_component,
-        # restore_state, CSV parser) or rebuilds them after, separately
-        # (delete_component's UI follow-up).
-        self.compute_metric_fraction_dict = False
-        beats_that_start_measure = set(self.timeline.beats_that_start_measures)
+        # Set is_first_in_measure directly instead of routing through
+        # set_component_data: at N=5000 a middle-insert flips ~N/2 beats,
+        # and each set_component_data fires Post.TIMELINE_COMPONENT_SET_DATA_DONE,
+        # which the UI translates into a per-beat
+        # `update_is_first_in_measure` cascade. Callers of this method
+        # already follow up with Post.BEAT_TIMELINE_MEASURE_NUMBER_CHANGE_DONE,
+        # which drives a single bulk UI pass — so the per-set posts were
+        # pure duplicate work.
+        #
+        # Direct assignment is safe because:
+        # - `is_first_in_measure` isn't in `Beat.SERIALIZABLE`, so the
+        #   component hash doesn't depend on it.
+        # - `metric_position` doesn't read it, so the metric_fraction
+        #   dicts can't go stale.
+        # - The undo/redo snapshot doesn't capture it either; it's
+        #   recomputed via this same method on restore.
+        beats_that_start_measure = self.timeline.beats_that_start_measures_set
         for i, beat in enumerate(self.timeline[start_index:]):
             is_first_in_measure = start_index + i in beats_that_start_measure
             if is_first_in_measure != beat.is_first_in_measure:
-                self.timeline.set_component_data(
-                    beat.id,
-                    "is_first_in_measure",
-                    is_first_in_measure,
-                )
-
-        self.compute_metric_fraction_dict = True
+                beat.is_first_in_measure = is_first_in_measure
 
     def create_component(
         self, kind: ComponentKind, timeline, id, *args, **kwargs

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import itertools
 import math
-from bisect import bisect
+from bisect import bisect, bisect_left
 from contextlib import contextmanager
 from enum import Enum
 from math import isclose
@@ -584,7 +584,9 @@ class BeatTimeline(Timeline):
             raise ValueError(f'No beat with index "{beat_index}" at {self}.')
 
     def get_beat_index(self, beat: Beat) -> int:
-        return self.components.index(beat)
+        return bisect_left(
+            self.component_manager._components, beat.time, key=lambda b: b.time
+        )
 
     def propagate_measure_number_change(self, start_index: int):
         for j in range(len(self.measure_numbers[start_index + 1 :])):

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import itertools
 import math
 from bisect import bisect
+from contextlib import contextmanager
 from enum import Enum
 from math import isclose
 from typing import Any, cast
@@ -28,6 +29,15 @@ class BeatTLComponentManager(TimelineComponentManager):
         self.timeline = cast(BeatTimeline, self.timeline)
         self.compute_is_first_in_measure = True
         self.compute_metric_fraction_dict = True
+
+    @contextmanager
+    def is_first_in_measure_computation_paused(self):
+        previous = self.compute_is_first_in_measure
+        self.compute_is_first_in_measure = False
+        try:
+            yield
+        finally:
+            self.compute_is_first_in_measure = previous
 
     @property
     def beat_times(self):
@@ -139,15 +149,13 @@ class BeatTLComponentManager(TimelineComponentManager):
         self.timeline.update_metric_fraction_dicts()
 
     def crop(self, length: float) -> None:
-        self.compute_is_first_in_measure = False
-        crop_pointlike(self, length)
-        self.compute_is_first_in_measure = True
+        with self.is_first_in_measure_computation_paused():
+            crop_pointlike(self, length)
 
     def clear(self):
-        self.compute_is_first_in_measure = False
-        for component in self._components.copy():
-            self.delete_component(component)
-        self.compute_is_first_in_measure = True
+        with self.is_first_in_measure_computation_paused():
+            for component in self._components.copy():
+                self.delete_component(component)
 
     def deserialize_components(self, serialized_components: dict[int, dict[str]]):
         # Storing these attributes so we can restore them below.
@@ -155,26 +163,24 @@ class BeatTLComponentManager(TimelineComponentManager):
         measure_numbers = self.timeline.measure_numbers.copy()
         measures_to_force_display = self.timeline.measures_to_force_display.copy()
 
-        self.compute_is_first_in_measure = False
+        with self.is_first_in_measure_computation_paused():
+            # This call will change the attributes above.
+            super().deserialize_components(serialized_components)
 
-        # This call will change the attributes above.
-        super().deserialize_components(serialized_components)
-
-        # But we restore them here.
-        self.timeline.set_data("measure_numbers", measure_numbers)
-        self.timeline.set_data("beats_in_measure", beats_in_measure)
-        self.timeline.set_data("measures_to_force_display", measures_to_force_display)
-
-        self.compute_is_first_in_measure = True
+            # But we restore them here.
+            self.timeline.set_data("measure_numbers", measure_numbers)
+            self.timeline.set_data("beats_in_measure", beats_in_measure)
+            self.timeline.set_data(
+                "measures_to_force_display", measures_to_force_display
+            )
 
         self.timeline.recalculate_measures()
         post(Post.BEAT_TIMELINE_COMPONENTS_DESERIALIZED, self.timeline.id)
 
     def restore_state(self, prev_state: dict):
         self.timeline.clear_cached_metric_positions()
-        self.compute_is_first_in_measure = False
-        super().restore_state(prev_state)
-        self.compute_is_first_in_measure = True
+        with self.is_first_in_measure_computation_paused():
+            super().restore_state(prev_state)
         self.timeline.recalculate_measures()
         self.update_is_first_in_measure_of_subsequent_beats(0)
         post(Post.BEAT_TIMELINE_MEASURE_NUMBER_CHANGE_DONE, self.timeline.id, 0)
@@ -639,10 +645,9 @@ class BeatTimeline(Timeline):
 
         self.clear_cached_metric_positions()
 
-        self.component_manager.compute_is_first_in_measure = False
-        for component in list(reversed(components)):
-            self.component_manager.delete_component(component)
-        self.component_manager.update_is_first_in_measure = True
+        with self.component_manager.is_first_in_measure_computation_paused():
+            for component in list(reversed(components)):
+                self.component_manager.delete_component(component)
 
         if not self.is_empty:
             self.component_manager.update_is_first_in_measure_of_subsequent_beats(0)
@@ -657,21 +662,19 @@ class BeatTimeline(Timeline):
     @long_operation("Creating beats...")
     def fill_with_beats(self, method: BeatTimeline.FillMethod, value: int | float):
         duration = get(Get.MEDIA_DURATION)
-        self.component_manager.compute_is_first_in_measure = False
-        # only compute at end
 
-        if method == BeatTimeline.FillMethod.BY_AMOUNT:
-            total = int(value)
-            for i in range(total):
-                self.create_component(ComponentKind.BEAT, i * duration / value)
-                post(Post.LONG_OPERATION, LongOperation.PROGRESS, i + 1, total)
-        elif method == BeatTimeline.FillMethod.BY_INTERVAL:
-            total = math.floor(duration / value)
-            for i in range(total):
-                self.create_component(ComponentKind.BEAT, i * value)
-                post(Post.LONG_OPERATION, LongOperation.PROGRESS, i + 1, total)
+        with self.component_manager.is_first_in_measure_computation_paused():
+            if method == BeatTimeline.FillMethod.BY_AMOUNT:
+                total = int(value)
+                for i in range(total):
+                    self.create_component(ComponentKind.BEAT, i * duration / value)
+                    post(Post.LONG_OPERATION, LongOperation.PROGRESS, i + 1, total)
+            elif method == BeatTimeline.FillMethod.BY_INTERVAL:
+                total = math.floor(duration / value)
+                for i in range(total):
+                    self.create_component(ComponentKind.BEAT, i * value)
+                    post(Post.LONG_OPERATION, LongOperation.PROGRESS, i + 1, total)
 
-        self.component_manager.compute_is_first_in_measure = True
         self.recalculate_measures()
         self.component_manager.update_is_first_in_measure_of_subsequent_beats(0)
 

--- a/tilia/ui/commands.py
+++ b/tilia/ui/commands.py
@@ -61,6 +61,7 @@ def register(
     shortcut: str = "",
     icon: str = "",
     parent: QMainWindow | QWidget | None = None,
+    checkable: bool = False,
 ):
     """
     Register a command with name to a callback.
@@ -68,6 +69,9 @@ def register(
 
     Also creates a QAction with the given text, shortcut and icon.
      The action can be retrieved with commands.get_qaction(name) and used in the Qt interface.
+
+    When checkable=True, the action behaves as a toggle. The callback can read
+    the new checked state via commands.get_qaction(name).isChecked().
     """
     action = CommandQAction(name, parent)
 
@@ -94,6 +98,9 @@ def register(
         elif icon in QIcon.ThemeIcon._member_names_:
             action.setIcon(QIcon.fromTheme(getattr(QIcon.ThemeIcon, icon)))
     action.setIconVisibleInMenu(False)
+
+    if checkable:
+        action.setCheckable(True)
 
     if callback:
         # Qt sometimes activates signals with additional parameters,

--- a/tilia/ui/timelines/beat/context_menu.py
+++ b/tilia/ui/timelines/beat/context_menu.py
@@ -24,4 +24,8 @@ class BeatContextMenu(TimelineUIElementContextMenu):
 
 class BeatTimelineUIContextMenu(TimelineUIContextMenu):
     name = "Beat timeline"
-    items = [(MenuItemKind, "timeline.set_name")]
+    items = [
+        (MenuItemKind.COMMAND, "timeline.set_name"),
+        (MenuItemKind.SEPARATOR, None),
+        (MenuItemKind.COMMAND, "timeline.beat.toggle_recalculate_measures"),
+    ]

--- a/tilia/ui/timelines/beat/element.py
+++ b/tilia/ui/timelines/beat/element.py
@@ -120,8 +120,18 @@ class BeatUI(TimelineUIElement):
         self.update_position()
 
     def update_position(self):
-        self.body.set_position(self.x, self.height)
-        self.label.set_position(self.x, self.height)
+        # Cache x/height locally: each is computed twice without this (once
+        # for body, once for label) and the calls aren't free (get_x_by_time
+        # plus get_data on every property read). For zooms on long beat
+        # timelines this loop is the dominant cost.
+        x = self.x
+        h = self.height
+        self.body.set_position(x, h)
+        # Skip invisible labels (most beats with beat_pattern>=2 have empty
+        # text and are hidden). Zoom doesn't change visibility, so a hidden
+        # label can stay put until update_label runs and re-positions it.
+        if self.label.isVisible():
+            self.label.set_position(x, h)
 
     def update_is_first_in_measure(self) -> None:
         self.body.set_position(self.x, self.height)

--- a/tilia/ui/timelines/beat/timeline.py
+++ b/tilia/ui/timelines/beat/timeline.py
@@ -215,8 +215,12 @@ class BeatTimelineUI(TimelineUI):
         return self.timeline.should_display_measure_number(measure_index)
 
     def on_measure_number_change_done(self, start_index: int):
+        # update_is_first_in_measure() covers both the body height (which
+        # depends on is_first_in_measure) and the label. Bulk callers no
+        # longer fire Post.TIMELINE_COMPONENT_SET_DATA_DONE per flipped
+        # beat, so this pass is the only path that refreshes those bodies.
         for beat_ui in self[start_index:]:
-            beat_ui.update_label()
+            beat_ui.update_is_first_in_measure()
 
     def get_copy_data_from_selected_elements(self):
         return self.get_copy_data_from_beat_uis(self.selected_elements)

--- a/tilia/ui/timelines/beat/timeline.py
+++ b/tilia/ui/timelines/beat/timeline.py
@@ -211,7 +211,7 @@ class BeatTimelineUI(TimelineUI):
 
     def should_display_measure_number(self, beat_ui):
         beat = self.timeline.get_component(beat_ui.id)
-        beat_index = self.timeline.components.index(beat)
+        beat_index = self.timeline.get_beat_index(beat)
         measure_index, _ = self.timeline.get_measure_index(beat_index)
         return self.timeline.should_display_measure_number(measure_index)
 

--- a/tilia/ui/timelines/beat/timeline.py
+++ b/tilia/ui/timelines/beat/timeline.py
@@ -104,6 +104,7 @@ class BeatTimelineUI(TimelineUI):
             TimelineSelector.FIRST,
             text="Pause measure recalculation",
             shortcut="Ctrl+Shift+B",
+            icon="MediaPlaybackPause",
             checkable=True,
         )
 
@@ -171,7 +172,12 @@ class BeatTimelineUI(TimelineUI):
         component, _ = self.timeline.create_component(ComponentKind.BEAT, time)
         return False if component is None else True
 
-    def on_toggle_recalculate_measures(self):
+    def on_toggle_recalculate_measures(self, *_):
+        # *_ swallows the extra positional arg that
+        # TimelineUIContextMenu.add_action injects (the clicked timeline_ui).
+        # We already have `self` (picked by the FIRST selector) and don't need
+        # the menu-passed copy.
+        #
         # When the user is tapping many beats into a long timeline, the
         # per-beat recalc is the dominant cost. Pausing it skips the whole
         # `recalculate_measures` block inside `create_component` (gated on

--- a/tilia/ui/timelines/beat/timeline.py
+++ b/tilia/ui/timelines/beat/timeline.py
@@ -159,7 +159,6 @@ class BeatTimelineUI(TimelineUI):
 
         self.timeline_ui: BeatTimelineUI
         component, _ = self.timeline.create_component(ComponentKind.BEAT, time)
-        self.timeline.recalculate_measures()
         return False if component is None else True
 
     @staticmethod

--- a/tilia/ui/timelines/beat/timeline.py
+++ b/tilia/ui/timelines/beat/timeline.py
@@ -1,6 +1,6 @@
 import copy
 
-from tilia.requests import Get, Post, get, listen
+from tilia.requests import Get, Post, get, listen, post
 from tilia.timelines.beat.timeline import BeatTimeline
 from tilia.timelines.component_kinds import ComponentKind
 from tilia.ui import commands
@@ -97,6 +97,16 @@ class BeatTimelineUI(TimelineUI):
             text="Set amount in measure",
         )
 
+        cls.register_timeline_command(
+            collection,
+            "toggle_recalculate_measures",
+            cls.on_toggle_recalculate_measures,
+            TimelineSelector.FIRST,
+            text="Pause measure recalculation",
+            shortcut="Ctrl+Shift+B",
+            checkable=True,
+        )
+
     def _get_measure_indices(self, elements: list[BeatUI]):
         measure_indices = set()
         for e in elements:
@@ -160,6 +170,35 @@ class BeatTimelineUI(TimelineUI):
         self.timeline_ui: BeatTimelineUI
         component, _ = self.timeline.create_component(ComponentKind.BEAT, time)
         return False if component is None else True
+
+    def on_toggle_recalculate_measures(self):
+        # When the user is tapping many beats into a long timeline, the
+        # per-beat recalc is the dominant cost. Pausing it skips the whole
+        # `recalculate_measures` block inside `create_component` (gated on
+        # `compute_is_first_in_measure`), so each beat-add drops to ~O(log N).
+        # On resume we run a single catch-up recalc + UI refresh.
+        #
+        # The cm flag is the source of truth — when invoked via menu click Qt
+        # has already toggled the action's check state, but when invoked via
+        # `commands.execute()` (tests, shortcut wiring, etc.) the action's
+        # state is unchanged. Compute the new value from the cm flag and
+        # sync the action's check state to match either way.
+        cm = self.timeline.component_manager
+        resume = not cm.compute_is_first_in_measure
+        cm.compute_is_first_in_measure = resume
+
+        action = commands.get_qaction("timeline.beat.toggle_recalculate_measures")
+        action.setChecked(not resume)
+
+        if resume:
+            self.timeline.recalculate_measures()
+            cm.update_is_first_in_measure_of_subsequent_beats(0)
+            post(
+                Post.BEAT_TIMELINE_MEASURE_NUMBER_CHANGE_DONE,
+                self.timeline.id,
+                0,
+            )
+        return False
 
     @staticmethod
     @command_callback

--- a/tilia/ui/timelines/beat/toolbar.py
+++ b/tilia/ui/timelines/beat/toolbar.py
@@ -9,4 +9,5 @@ class BeatTimelineToolbar(TimelineToolbar):
         "timeline.beat.distribute",
         "timeline.beat.set_measure_number",
         "timeline.beat.reset_measure_number",
+        "timeline.beat.toggle_recalculate_measures",
     ]


### PR DESCRIPTION
**Draft.** Opening this early to get a read on scope and on the one design question at the bottom before I polish it.

Beat timelines get slow well before they get large. A ~14k-beat timeline (a full movement tapped by hand) makes tapping, zooming and CSV import unusable. This branch works through the hot paths.

## What's slow, and why

Nearly all of it traces back to two things: `Beat.metric_position` resolved itself with `components.index(beat)`, which copies the component list and scans it, and `recalculate_measures()` rebuilt three metric-fraction dicts from scratch on every single beat insert. Both are O(n) per beat, so every bulk path was O(n²).

## Measurements

All offscreen, median of 5 runs, via the two bench scripts added here.

| Workload | Before | After |
| --- | --- | --- |
| CSV import, 13932 beats | did not finish | ~25 s |
| End-insert (live tap), N=13000 | ~250 ms/beat | 55 ms/beat |
| End-insert, N=10000 | — | 31 ms/beat |
| Zoom step, N=14000 | 112.7 ms | 66.5 ms (-41%) |
| Middle-insert per tap, N=13000, batch mode on | ~250-300 ms | 39 ms |

Middle-insert without batch mode is unchanged at N=5000 (~60 ms) — the UI bulk pass dominates there, not the recalculation.

## How it's organised

Each commit is standalone with its own rationale and numbers. Roughly:

- **Indexing** — bisect-based `get_beat_index` / `get_measure_index`, and routing `.index` lookups through them.
- **Recalculation** — two-pointer rebuild of `update_metric_fraction_dicts` that populates the position cache inline, then an incremental path scoped to the inserted index so an end-insert only walks the tail.
- **Post cascades** — dropping a per-beat `Post` storm and two redundant rebuilds.
- **UI** — caching `x`/`height` in `update_position` and skipping `set_position` for labels that are hidden anyway (with `beat_pattern >= 2` most labels are hidden, and `set_position` costs a Qt `setPos` + `boundingRect()` each).
- **Batch mode** — see below.

## Two things worth reviewing separately

**1. The batch-mode toggle is a feature, not a perf fix.** `timeline.beat.toggle_recalculate_measures` (Ctrl+Shift+B, context menu + toolbar) lets the user suspend measure recalculation while tapping a passage and pay one catch-up on resume. It's here because it's the only thing that makes middle-insert bearable on long timelines, but it adds UI surface and a new `commands.register(checkable=True)` capability. Happy to split it into its own PR if you'd rather review it on its own.

At N=13000 the per-tap cost in batch mode is 39 ms, and that floor is the undo-snapshot serialization, not recalculation. Going below ~10 ms means deferring per-tap `APP_STATE_RECORD` and bundling the batch into a single undoable — deliberately out of scope here.

**2. The context manager overlaps with v0.6.5.** This branch grew a context manager for suspending `compute_is_first_in_measure`; v0.6.5 shipped the same idea as `suppressing_is_first_in_measure()`. The last commit drops this branch's name and takes the released one verbatim, so merging 0.6.5 forward into `dev` should be a no-op for that hunk rather than a conflict. Worth a sanity check that I took the right direction.

## Not included

`refactor/beat-suppression-contextmanager` has two related fixes that aren't here — `crop()`/`clear()` leaving a stale measure structure behind, and a duplicate recalculation on every deletion. They're bug fixes rather than perf work and sit on a v0.6.4 base, so they belong in their own PR.

## Testing

Full suite green on this base (1849 passed, 10 skipped). Adds a perf regression guard for middle-insert and a 5-second-timeout guard on a 1000-beat CSV import — the latter fails outright on `dev`.

`scripts/bench_beat_insert.py` and `scripts/bench_beat_zoom.py` are dev harnesses, not tests; they take `--position end|middle`, `--batch` and `--runs`.
