### PR TITLE
ci: pin Nuitka to 4.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,11 @@ Repository = "https://github.com/TimeLineAnnotator/desktop"
 build = [
     "build",
     "ImageIO; sys_platform == 'darwin'",
-    "Nuitka >= 4.0",
+    # Pinned: under Nuitka 4.2.1 the compiled executable dies at startup with
+    # "module 'music21.repeat' has no attribute 'RepeatMark'" -- music21.bar
+    # reads that attribute at module level while music21.repeat is still
+    # initialising, and 4.2.1 no longer orders the imports so that it resolves.
+    "Nuitka==4.1.3",
     "ordered-set==4.1.0",
     "pyyaml",
     "setuptools<82.0.0; python_version >= '3.12'", #  setuptools>82.0.0 no longer provides pkg_resources


### PR DESCRIPTION
Carries the pin from the v0.6.5 release branch over to `dev`, so the next release build does not walk into the same wall.

## What happened

The first `v0.6.5` build compiled cleanly on every platform and then failed the smoke test on Linux and both macOS runners — the executable dies at startup:

```
File ".../music21/bar.py", line 211, in <module music21.bar>
AttributeError: module 'music21.repeat' has no attribute 'RepeatMark'
```

`music21.bar` reads `repeat.RepeatMark` at module level while `music21.repeat` is still initialising. CPython's import ordering resolves that; Nuitka 4.2.1's does not.

## Why it is Nuitka and not us

The `build` dependency group had no upper bound, so CI moved from 4.1.3 to 4.2.1 on its own. Comparing the last green build with the failing one:

| | v0.6.4 (2026-07-28, green) | v0.6.5 (2026-09-05, red) |
| --- | --- | --- |
| music21 | 10.5.0 | 10.5.0 |
| PySide6 | 6.9.3 | 6.9.3 |
| **Nuitka** | **4.1.3** | **4.2.1** |

And the crashing import chain (`qtui` → `parsers.csv.harmony` → `music21`) is untouched between the two tags: v0.6.5 changes five files under `tilia/`, none of them in `tilia/parsers/`.

## Scope

`[build-system] requires` is deliberately left alone — that Nuitka only ever exists in the isolated PEP 517 environment for `pip install -e .`, while `scripts/deploy.py` compiles with the one from the `build` group.

The rebuild on the release branch, with 4.1.3 pinned, is what confirms this;
at the time of writing it is still running. If it comes back red this PR
should wait, since the pin would then not be the whole story.
