### PR TITLE
refactor: beat measure-recomputation suppression, and the staleness it was hiding

### DIFF
--- a/tests/timelines/beat/test_beat_timeline.py
+++ b/tests/timelines/beat/test_beat_timeline.py
@@ -1,5 +1,8 @@
+from unittest.mock import patch
+
 import pytest
 
+from tests.utils import undoable
 from tilia.ui import commands
 
 
@@ -436,3 +439,81 @@ class TestBeatTimeline:
 
         assert len(tilia.timelines[0]) == 11
         assert tilia.timelines[0][-1].get_data("time") == 10
+
+    @staticmethod
+    def _add_beats(times):
+        for time in times:
+            commands.execute("media.seek", time)
+            commands.execute("timeline.beat.add")
+
+    def test_insert_beats_after_deleting_all_beats(self, beat_tlui):
+        self._add_beats(range(8))
+
+        beat_tlui.select_all_elements()
+        commands.execute("timeline.component.delete")
+
+        # An emptied timeline must not keep a measure structure describing
+        # beats that no longer exist.
+        assert beat_tlui.timeline.beats_in_measure == []
+        assert beat_tlui.timeline.measure_numbers == []
+
+        self._add_beats(range(8))
+
+        assert beat_tlui.timeline.beats_in_measure == [4, 4]
+        assert [
+            i for i, b in enumerate(beat_tlui) if b.get_data("is_first_in_measure")
+        ] == [0, 4]
+
+    def test_insert_beats_after_deleting_some_beats(self, beat_tlui):
+        self._add_beats(range(8))
+
+        for element in list(beat_tlui)[4:]:
+            beat_tlui.select_element(element)
+        commands.execute("timeline.component.delete")
+
+        assert beat_tlui.timeline.beats_in_measure == [4]
+
+        self._add_beats(range(8, 12))
+
+        assert beat_tlui.timeline.beats_in_measure == [4, 4]
+        assert [
+            i for i, b in enumerate(beat_tlui) if b.get_data("is_first_in_measure")
+        ] == [0, 4]
+
+    def test_undo_redo_delete_all_beats(self, beat_tlui):
+        self._add_beats(range(8))
+
+        beat_tlui.select_all_elements()
+        with undoable():
+            commands.execute("timeline.component.delete")
+
+    def test_delete_keeps_an_outer_suppression_in_place(self, beat_tlui):
+        # BeatTLComponentManager.restore_state suppresses recomputation across a
+        # whole delete-then-create pass, and reaches delete_components in the
+        # middle of it. Restoring a hardcoded True here would re-enable the
+        # recomputation for every beat the restore re-creates afterwards.
+        self._add_beats(range(8))
+        timeline = beat_tlui.timeline
+        component_manager = timeline.component_manager
+
+        with component_manager.suppressing_is_first_in_measure():
+            timeline.delete_components(list(timeline.components)[4:])
+
+            assert component_manager.compute_is_first_in_measure is False
+
+        assert component_manager.compute_is_first_in_measure is True
+
+    def test_delete_restores_the_flag_when_a_deletion_raises(self, beat_tlui):
+        # Leaving the flag off would silently stop every beat created later in
+        # the session from getting any measure data.
+        self._add_beats(range(8))
+        timeline = beat_tlui.timeline
+        component_manager = timeline.component_manager
+
+        with patch.object(
+            component_manager, "delete_component", side_effect=ValueError
+        ):
+            with pytest.raises(ValueError):
+                timeline.delete_components(list(timeline.components))
+
+        assert component_manager.compute_is_first_in_measure is True

--- a/tests/timelines/beat/test_beat_timeline.py
+++ b/tests/timelines/beat/test_beat_timeline.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
+from tests.mock import patch_yes_or_no_dialog
 from tests.utils import undoable
 from tilia.ui import commands
 
@@ -517,3 +518,32 @@ class TestBeatTimeline:
                 timeline.delete_components(list(timeline.components))
 
         assert component_manager.compute_is_first_in_measure is True
+
+    def test_shrinking_media_drops_measures_for_cropped_beats(
+        self, beat_tlui, tilia_state
+    ):
+        tilia_state.duration = 100
+        self._add_beats(range(12))
+
+        assert beat_tlui.timeline.beats_in_measure == [4, 4, 4]
+
+        tilia_state.set_duration(7.5, scale_timelines="no")
+
+        # The measure structure has to shrink with the beats. Leaving a third
+        # measure behind makes measure_count over-report, makes
+        # get_time_by_measure interpolate against a partition that no longer
+        # exists, and makes "Distribute beats" on the last measure raise.
+        assert len(beat_tlui) == 8
+        assert beat_tlui.timeline.beats_in_measure == [4, 4]
+
+    def test_clearing_the_timeline_drops_the_measure_structure(self, beat_tlui):
+        self._add_beats(range(12))
+
+        assert beat_tlui.timeline.beats_in_measure == [4, 4, 4]
+
+        with patch_yes_or_no_dialog(True):
+            commands.execute("timeline.clear", beat_tlui)
+
+        assert len(beat_tlui) == 0
+        assert beat_tlui.timeline.beats_in_measure == []
+        assert beat_tlui.timeline.measure_numbers == []

--- a/tests/timelines/pdf/test_pdf_timeline.py
+++ b/tests/timelines/pdf/test_pdf_timeline.py
@@ -15,14 +15,14 @@ class TestPageTotal:
 
 
 class TestPageNumber:
-    def test_marker_page_number_default_is_next_page(self, pdf_tl):
+    def test_marker_page_number_default_is_next_page(self, pdf_tlui, pdf_tl):
         pdf_tl.page_total = 2
         commands.execute("timeline.pdf.add")
         commands.execute("media.seek", 10)
         commands.execute("timeline.pdf.add")
         assert pdf_tl[1].get_data("page_number") == 2
 
-    def test_first_marker_page_number_is_one(self, pdf_tl):
+    def test_first_marker_page_number_is_one(self, pdf_tlui, pdf_tl):
         pdf_tl.page_total = 1
         commands.execute("timeline.pdf.add")
         assert pdf_tl[0].get_data("page_number") == 1

--- a/tests/ui/timelines/harmony/test_harmony_timeline_ui.py
+++ b/tests/ui/timelines/harmony/test_harmony_timeline_ui.py
@@ -131,6 +131,75 @@ class TestRomanNumeralDisplay:
 
         assert harmony_tlui[0].label.startswith(expected_start)
 
+    @pytest.mark.parametrize(
+        "step,quality,inversion,expected",
+        [
+            (0, "major", 1, "I6"),
+            (0, "major", 2, "I64"),
+            (1, "minor-seventh", 1, "ii65"),
+            (4, "dominant-seventh", 1, "V65"),
+            (4, "dominant-seventh", 2, "V43"),
+            (4, "dominant-seventh", 3, "V42"),
+            # Four figures: more than the "%" stack's three slots, so the whole
+            # group falls back to the inline form.
+            (0, "half-diminished-13th", 4, "io\\bb7542"),
+            # Three figures, but a double accidental needs two characters and
+            # overflows its single slot — same fallback.
+            (0, "diminished-seventh", 1, "iobbb653"),
+        ],
+    )
+    def test_roman_label_has_no_blank_accidental_placeholder(
+        self, step, quality, inversion, expected, harmony_tlui
+    ):
+        # "s" marks an accidental slot left blank. MusAnalysis consumes it only
+        # inside the "%" stack, and only there in its exact shape: three slots
+        # of one character each, paired with three numbers. Anywhere else it is
+        # drawn as a literal letter next to the numeral.
+        add_harmony(step=step, quality=quality, inversion=inversion)
+
+        assert harmony_tlui.harmonies()[0].label == expected
+
+    @pytest.mark.parametrize(
+        "step,accidental,quality,inversion",
+        [
+            (6, 0, "major", 1),  # figures (6, None), (3, "#")
+            (0, 0, "augmented", 1),  # figures (6, None), (3, "#")
+            (1, -1, "major", 2),  # figures (6, None), (4, "-")
+            (0, 0, "dominant-seventh", 1),  # figures (6, None), (5, "-")
+            (0, 0, "half-diminished-13th", 4),  # four figures
+            (0, 0, "diminished-seventh", 1),  # double accidental
+        ],
+    )
+    def test_roman_label_has_no_literal_s_when_figures_carry_accidentals(
+        self, step, accidental, quality, inversion, harmony_tlui
+    ):
+        # A partially accidented figure group is the case the placeholder rule
+        # is easiest to get wrong: dropping the blank slot only for fully
+        # diatonic groups would leave the letter in every one of these.
+        # Asserting on the absence of "s" rather than on the exact string keeps
+        # this test independent of how the accidentals end up positioned.
+        add_harmony(
+            step=step, accidental=accidental, quality=quality, inversion=inversion
+        )
+
+        assert "s" not in harmony_tlui.harmonies()[0].label
+
+    def test_roman_label_keeps_blank_accidental_placeholder_in_stacked_figures(
+        self, harmony_tlui
+    ):
+        add_harmony(step=4, quality="dominant-ninth", inversion=3)
+
+        assert harmony_tlui.harmonies()[0].label == "V%sss432"
+
+    def test_roman_label_keeps_stack_when_only_some_figures_are_accidented(
+        self, harmony_tlui
+    ):
+        # Three figures, one accidental, all single-character: still the exact
+        # shape the "%" stack takes, so the two blank slots must be kept.
+        add_harmony(step=6, quality="dominant-seventh", inversion=1)
+
+        assert harmony_tlui.harmonies()[0].label == "VII%ss#653"
+
     def test_roman_label_for_ninth_chord_high_inversion(self, harmony_tlui):
         # inversion=4 places the 9th in the bass; label is dynamically computed
         add_harmony(

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -178,13 +178,19 @@ class BeatTLComponentManager(TimelineComponentManager):
         self.timeline.update_metric_fraction_dicts()
 
     def crop(self, length: float) -> None:
-        with self.suppressing_is_first_in_measure():
+        with self.suppressing_is_first_in_measure() as was_computing:
             crop_pointlike(self, length)
 
+        if was_computing:
+            self.timeline.refresh_measures()
+
     def clear(self):
-        with self.suppressing_is_first_in_measure():
+        with self.suppressing_is_first_in_measure() as was_computing:
             for component in self._components.copy():
                 self.delete_component(component)
+
+        if was_computing:
+            self.timeline.refresh_measures()
 
     def deserialize_components(self, serialized_components: dict[int, dict[str]]):
         # Storing these attributes so we can restore them below.
@@ -210,9 +216,7 @@ class BeatTLComponentManager(TimelineComponentManager):
         self.timeline.clear_cached_metric_positions()
         with self.suppressing_is_first_in_measure():
             super().restore_state(prev_state)
-        self.timeline.recalculate_measures()
-        self.update_is_first_in_measure_of_subsequent_beats(0)
-        post(Post.BEAT_TIMELINE_MEASURE_NUMBER_CHANGE_DONE, self.timeline.id, 0)
+        self.timeline.refresh_measures()
 
 
 class BeatTimeline(Timeline):
@@ -670,6 +674,20 @@ class BeatTimeline(Timeline):
     def distribute_beats(self, measure_index: int) -> None:
         self.component_manager.distribute_beats(measure_index)
 
+    def refresh_measures(self) -> None:
+        """
+        Rebuild the measure structure and have the UI relabel every beat.
+
+        Run this after any bulk operation that added or removed beats with
+        per-beat recomputation suppressed. It is safe on an emptied timeline,
+        and required there: otherwise beats_in_measure and measure_numbers go
+        on describing beats that no longer exist, and the labels stay on
+        screen.
+        """
+        self.recalculate_measures()
+        self.component_manager.update_is_first_in_measure_of_subsequent_beats(0)
+        post(Post.BEAT_TIMELINE_MEASURE_NUMBER_CHANGE_DONE, self.id, 0)
+
     def delete_components(self, components: list[TC]) -> None:
         self._validate_delete_components(components)
 
@@ -687,12 +705,7 @@ class BeatTimeline(Timeline):
             # every beat it re-creates afterwards sweep the whole timeline.
             return
 
-        # Unconditional, including when the timeline is now empty: otherwise it
-        # keeps a beats_in_measure / measure_numbers describing beats that no
-        # longer exist, and the UI keeps their labels.
-        self.recalculate_measures()
-        component_manager.update_is_first_in_measure_of_subsequent_beats(0)
-        post(Post.BEAT_TIMELINE_MEASURE_NUMBER_CHANGE_DONE, self.id, 0)
+        self.refresh_measures()
 
     class FillMethod(Enum):
         BY_AMOUNT = 0

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import itertools
 import math
 from bisect import bisect
+from collections.abc import Iterator
+from contextlib import contextmanager
 from enum import Enum
 from math import isclose
 from typing import Any, cast
@@ -29,6 +31,25 @@ class BeatTLComponentManager(TimelineComponentManager):
         self.timeline = cast(BeatTimeline, self.timeline)
         self.compute_is_first_in_measure = True
         self.compute_metric_fraction_dict = True
+
+    @contextmanager
+    def suppressing_is_first_in_measure(self) -> Iterator[bool]:
+        """
+        Suppress per-beat measure recomputation for the duration of the block.
+
+        Yields the value the flag had on entry, so a caller can tell whether it
+        owns the recomputation or an outer block will do it once at the end.
+        Restoring that value rather than a literal True is what keeps nested
+        blocks correct; the try/finally keeps a raising body from leaving the
+        flag off for the rest of the timeline's life, which would silently stop
+        every beat created afterwards from getting any measure data.
+        """
+        was_computing = self.compute_is_first_in_measure
+        self.compute_is_first_in_measure = False
+        try:
+            yield was_computing
+        finally:
+            self.compute_is_first_in_measure = was_computing
 
     @property
     def beat_times(self):
@@ -641,16 +662,24 @@ class BeatTimeline(Timeline):
 
         self.clear_cached_metric_positions()
 
-        self.component_manager.compute_is_first_in_measure = False
-        for component in list(reversed(components)):
-            self.component_manager.delete_component(component)
-        self.component_manager.update_is_first_in_measure = True
+        component_manager = self.component_manager
+        with component_manager.suppressing_is_first_in_measure() as was_computing:
+            for component in list(reversed(components)):
+                component_manager.delete_component(component)
 
-        if not self.is_empty:
-            self.component_manager.update_is_first_in_measure_of_subsequent_beats(0)
-            post(Post.BEAT_TIMELINE_MEASURE_NUMBER_CHANGE_DONE, self.id, 0)
+        if not was_computing:
+            # BeatTLComponentManager.restore_state, reached on every undo and
+            # redo, suppresses recomputation across a whole delete-then-create
+            # pass and recomputes once at the end. Recomputing here would make
+            # every beat it re-creates afterwards sweep the whole timeline.
+            return
 
-            # Higher index is possible.
+        # Unconditional, including when the timeline is now empty: otherwise it
+        # keeps a beats_in_measure / measure_numbers describing beats that no
+        # longer exist, and the UI keeps their labels.
+        self.recalculate_measures()
+        component_manager.update_is_first_in_measure_of_subsequent_beats(0)
+        post(Post.BEAT_TIMELINE_MEASURE_NUMBER_CHANGE_DONE, self.id, 0)
 
     class FillMethod(Enum):
         BY_AMOUNT = 0

--- a/tilia/timelines/beat/timeline.py
+++ b/tilia/timelines/beat/timeline.py
@@ -51,23 +51,40 @@ class BeatTLComponentManager(TimelineComponentManager):
         finally:
             self.compute_is_first_in_measure = was_computing
 
+    @contextmanager
+    def suppressing_metric_fraction_dict(self) -> Iterator[bool]:
+        """
+        Suppress per-beat rebuilds of the metric-fraction dicts for the block.
+
+        Same contract as suppressing_is_first_in_measure: restore what was
+        found, and restore it even when the body raises. Leaving this flag off
+        would stop set_component_data from ever rebuilding the dicts again, so
+        every later get_time_by_measure and by-measure import would silently
+        read stale time-to-measure data.
+        """
+        was_computing = self.compute_metric_fraction_dict
+        self.compute_metric_fraction_dict = False
+        try:
+            yield was_computing
+        finally:
+            self.compute_metric_fraction_dict = was_computing
+
     @property
     def beat_times(self):
         return {b.time for b in self._components}
 
     def update_is_first_in_measure_of_subsequent_beats(self, start_index):
-        self.compute_metric_fraction_dict = False
-        beats_that_start_measure = set(self.timeline.beats_that_start_measures)
-        for i, beat in enumerate(self.timeline[start_index:]):
-            is_first_in_measure = start_index + i in beats_that_start_measure
-            if is_first_in_measure != beat.is_first_in_measure:
-                self.timeline.set_component_data(
-                    beat.id,
-                    "is_first_in_measure",
-                    is_first_in_measure,
-                )
+        with self.suppressing_metric_fraction_dict():
+            beats_that_start_measure = set(self.timeline.beats_that_start_measures)
+            for i, beat in enumerate(self.timeline[start_index:]):
+                is_first_in_measure = start_index + i in beats_that_start_measure
+                if is_first_in_measure != beat.is_first_in_measure:
+                    self.timeline.set_component_data(
+                        beat.id,
+                        "is_first_in_measure",
+                        is_first_in_measure,
+                    )
 
-        self.compute_metric_fraction_dict = True
         self.timeline.update_metric_fraction_dicts()
 
     def create_component(
@@ -161,15 +178,13 @@ class BeatTLComponentManager(TimelineComponentManager):
         self.timeline.update_metric_fraction_dicts()
 
     def crop(self, length: float) -> None:
-        self.compute_is_first_in_measure = False
-        crop_pointlike(self, length)
-        self.compute_is_first_in_measure = True
+        with self.suppressing_is_first_in_measure():
+            crop_pointlike(self, length)
 
     def clear(self):
-        self.compute_is_first_in_measure = False
-        for component in self._components.copy():
-            self.delete_component(component)
-        self.compute_is_first_in_measure = True
+        with self.suppressing_is_first_in_measure():
+            for component in self._components.copy():
+                self.delete_component(component)
 
     def deserialize_components(self, serialized_components: dict[int, dict[str]]):
         # Storing these attributes so we can restore them below.
@@ -177,26 +192,24 @@ class BeatTLComponentManager(TimelineComponentManager):
         measure_numbers = self.timeline.measure_numbers.copy()
         measures_to_force_display = self.timeline.measures_to_force_display.copy()
 
-        self.compute_is_first_in_measure = False
+        with self.suppressing_is_first_in_measure():
+            # This call will change the attributes above.
+            super().deserialize_components(serialized_components)
 
-        # This call will change the attributes above.
-        super().deserialize_components(serialized_components)
-
-        # But we restore them here.
-        self.timeline.set_data("measure_numbers", measure_numbers)
-        self.timeline.set_data("beats_in_measure", beats_in_measure)
-        self.timeline.set_data("measures_to_force_display", measures_to_force_display)
-
-        self.compute_is_first_in_measure = True
+            # But we restore them here.
+            self.timeline.set_data("measure_numbers", measure_numbers)
+            self.timeline.set_data("beats_in_measure", beats_in_measure)
+            self.timeline.set_data(
+                "measures_to_force_display", measures_to_force_display
+            )
 
         self.timeline.recalculate_measures()
         post(Post.BEAT_TIMELINE_COMPONENTS_DESERIALIZED, self.timeline.id)
 
     def restore_state(self, prev_state: dict):
         self.timeline.clear_cached_metric_positions()
-        self.compute_is_first_in_measure = False
-        super().restore_state(prev_state)
-        self.compute_is_first_in_measure = True
+        with self.suppressing_is_first_in_measure():
+            super().restore_state(prev_state)
         self.timeline.recalculate_measures()
         self.update_is_first_in_measure_of_subsequent_beats(0)
         post(Post.BEAT_TIMELINE_MEASURE_NUMBER_CHANGE_DONE, self.timeline.id, 0)
@@ -687,17 +700,15 @@ class BeatTimeline(Timeline):
 
     def fill_with_beats(self, method: BeatTimeline.FillMethod, value: int | float):
         duration = get(Get.MEDIA_DURATION)
-        self.component_manager.compute_is_first_in_measure = False
         # only compute at end
+        with self.component_manager.suppressing_is_first_in_measure():
+            if method == BeatTimeline.FillMethod.BY_AMOUNT:
+                for i in range(value):
+                    self.create_component(ComponentKind.BEAT, i * duration / value)
+            elif method == BeatTimeline.FillMethod.BY_INTERVAL:
+                for i in range(math.floor(duration / value)):
+                    self.create_component(ComponentKind.BEAT, i * value)
 
-        if method == BeatTimeline.FillMethod.BY_AMOUNT:
-            for i in range(value):
-                self.create_component(ComponentKind.BEAT, i * duration / value)
-        elif method == BeatTimeline.FillMethod.BY_INTERVAL:
-            for i in range(math.floor(duration / value)):
-                self.create_component(ComponentKind.BEAT, i * value)
-
-        self.component_manager.compute_is_first_in_measure = True
         self.recalculate_measures()
         self.component_manager.update_is_first_in_measure_of_subsequent_beats(0)
 

--- a/tilia/ui/timelines/beat/timeline.py
+++ b/tilia/ui/timelines/beat/timeline.py
@@ -104,12 +104,6 @@ class BeatTimelineUI(TimelineUI):
 
         return sorted(list(measure_indices))
 
-    def on_delete_component(self, elements: list[BeatUI] | None = None) -> bool:
-        success = super().on_delete_component(elements)
-        if success:
-            self.timeline.recalculate_measures()
-        return success
-
     @with_elements
     def on_set_measure_number(self, elements: list[BeatUI] | None = None):
         accepted, number = get(

--- a/tilia/ui/timelines/harmony/utils.py
+++ b/tilia/ui/timelines/harmony/utils.py
@@ -134,10 +134,18 @@ def _fmt_mod(mod: str | None, none_str: str = "") -> str:
 
 
 def _figs_to_str(figures: list[tuple[int, str | None]]) -> str:
-    prefix = "%" if len(figures) > 2 else ""
-    accs = "".join(_fmt_mod(mod, "s") for _, mod in figures)
+    # The "%" stack is a fixed three-slot construct: MusAnalysis pairs each of
+    # three single-character accidental slots with one of three numbers, and
+    # consumes "s" as a slot left blank. Any other shape overflows it — a
+    # different figure count, or a double accidental needing two characters —
+    # and the placeholders are then drawn as literal letters next to the
+    # numeral. Those fall back to the inline form, which has no blank slot and
+    # so must contribute nothing for an unaccidented figure.
+    slots = [_fmt_mod(mod, "s") for _, mod in figures]
     nums = "".join(str(n) for n, _ in figures)
-    return prefix + accs + nums
+    if len(slots) == 3 and all(len(slot) == 1 for slot in slots):
+        return "%" + "".join(slots) + nums
+    return "".join(_fmt_mod(mod) for _, mod in figures) + nums
 
 
 def _figure_index_for_pitch(


### PR DESCRIPTION
Follow-up to the v0.6.5 hotfix. Three commits, each with its own rationale.

> **Stacking note.** This branch is based on the v0.6.5 release line, because its first commit builds on the context manager introduced there. `dev` has not received the release merge-back yet, so the diff below currently shows the three release commits as well. Merge `main` into `dev` first and this reduces to the three commits that follow.

## 1. `refactor`: route every suppression window through a context manager

`BeatTLComponentManager` carries two flags that callers switch off around a bulk operation and back on afterwards. Every one of those windows was a pair of bare attribute assignments restoring a literal `True`, with no `try`/`finally`.

That shape is what produced the bug this hotfix fixed: a misspelled restore (`update_is_first_in_measure`) silently created a new attribute and left the real flag off for the rest of the timeline's life. Nothing in CI could see it — the project runs black and ruff with `E,W,F,B,I`, none of which flag an assignment to an attribute that does not exist, and there is no type checker configured.

**This commit is behaviour-preserving, and that is measured rather than asserted.** Instrumenting every window over a full test run:

| window | entered with flag `True` | entered suppressed |
| --- | --- | --- |
| `clear` | 236 | 0 |
| `crop` | 1 | 0 |
| `deserialize_components` | 7 | 0 |
| `restore_state` | 16 | 0 |
| `fill_with_beats` | 4 | 0 |
| `update_is_first_in_measure_of_subsequent_beats` | 624 | 0 |
| `delete_components` | 15 | **17** |

Only `delete_components` ever nests, and that is the one the hotfix already addressed. For the other six, restoring the entry value instead of `True` cannot change what they do.

## 2. `fix`: `crop()` and `clear()` leave a stale measure structure behind

Both suppress the flag around a bulk deletion and then never recompute.

`crop()` runs whenever the loaded media gets shorter and the user declines scaling. Twelve beats at pattern 4 cropped to 7.5s leaves 8 beats but still reports `measure_count` 3 and `beats_that_start_measures` `[0, 4, 8]`. `get_time_by_measure(3)` then returns a time with no beat, which misplaces by-measure CSV and MusicXML imports, and **"Distribute beats" on the last visible measure raises `IndexError`** because the last-measure guard is fooled by the phantom third measure. Saving in that state serializes the phantom.

`clear()` is reached from import into an existing beat timeline, from the "delete existing beats?" confirmation in Fill with beats, and from `Timelines.clear_timelines`. After it the timeline has no beats but still reports three measures.

Both defects predate the hotfix. The commit also extracts `BeatTimeline.refresh_measures()` from the four sites that had hand-written variants of the same recalculate/re-derive/notify trio — that divergence is how `delete_components` came to be missing its recomputation in the first place. `fill_with_beats` and `deserialize_components` are left alone; their sequences genuinely differ.

## 3. `perf`: stop recalculating measures twice on every deletion

`BeatTimelineUI.on_delete_component` called `recalculate_measures()` after `super().on_delete_component`, which routes unconditionally through `BeatTimeline.delete_components` — and that now performs the recalculation itself. `recalculate_measures` starts by clearing every cached metric position, so the second pass throws away the caches the first just built and re-derives all of them, each via an O(n) `components.index()`. The override is dropped.

## Testing

Full suite green (1370 passed). Both fixes in commit 2 have a counter-check: reverting the `refresh_measures()` calls makes exactly the two new tests fail, and nothing else.